### PR TITLE
Replace all occurrences of a variable in a translation

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -252,7 +252,7 @@
             if (typeof value === 'object') {
                 str = applyReplacement(str, value, key);
             } else {
-                str = str.replace([o.interpolationPrefix, nestedKey ? nestedKey + '.' + key : key, o.interpolationSuffix].join(''), value);
+                str = str.replace(new RegExp([o.interpolationPrefix, nestedKey ? nestedKey + '.' + key : key, o.interpolationSuffix].join(''), 'g'), value);
             }
         });
         return str;


### PR DESCRIPTION
Currently it replaces only the first occurrence.
