### PR TITLE
added asyncReq option (default to true) to allow synchronous loading of resources if needed. 

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -78,7 +78,9 @@
         pluralNotFound: ['plural_not_found', Math.random()].join(''),
         contextNotFound: ['context_not_found', Math.random()].join(''),
 
-        setJqueryExt: true
+        setJqueryExt: true,
+        
+        asyncReq: true
     };
 
     // move dependent functions to a container so that
@@ -501,7 +503,8 @@
                         f.log('failed loading: ' + url);
                         cb('failed loading resource.json error: ' + error);
                     },
-                    dataType: "json"
+                    dataType: "json",
+                    async : o.asyncReq
                 });         
             }
         },
@@ -518,7 +521,8 @@
                     f.log('failed loading: ' + url);
                     done(error, {});
                 },
-                dataType: "json"
+                dataType: "json",
+                async : o.asyncReq
             });
         },
 
@@ -538,7 +542,8 @@
                 error : function(xhr, status, error) {
                     f.log('failed posting missing key \'' + key + '\' to: ' + url);
                 },
-                dataType: "json"
+                dataType: "json",
+                async : o.asyncReq
             });
         }
     };

--- a/test/test.js
+++ b/test/test.js
@@ -491,3 +491,26 @@ asyncTest("auto upload missing resources", function() {
         start();
     });
 });
+
+asyncTest("synchronous init", function() {
+    $.i18n.init({
+        lng: 'en-US',
+        lowerCaseLng: false,
+        ns: 'translation',
+        dynamicLoad: false,
+        useLocalStorage: false,
+        debug: true,
+        resStore: {
+            dev: { translation: { simpleTest_dev: 'ok_from_dev' } },
+            en: { translation: { simpleTest_en: 'ok_from_en' } },            
+            'en-US': { translation: { 'simpleTest_en-US': 'ok_from_en-US' } }
+        },
+        asyncReq: false
+    }, function(t) { //do nothing here
+    });
+    equals($.t('simpleTest_en-US'),'ok_from_en-US', 'from specific lng with namespace given');
+    equals($.t('simpleTest_en'),'ok_from_en', 'from unspecific lng with namespace given');
+    equals($.t('simpleTest_dev'),'ok_from_dev', 'from fallback lng with namespace given');
+
+    start();
+});


### PR DESCRIPTION
I use to put $.ajaxSetup({"async":
false}) and $.ajaxSetup({"async":true}) before and after the init (as
suggested in this post
http://stackoverflow.com/questions/9640630/javascript-i18n-internationalization-frameworks-libraries-for-clientside-use)

This workaround is not elegant at all and can cause slowness to other
ajax calls.

Added test case.
