### PR TITLE
Save i18n options to elem's data field in order to re-use them when dynamically changing language.

### DIFF
--- a/i18next-1.3.3.js
+++ b/i18next-1.3.3.js
@@ -232,18 +232,20 @@
 
         function localize(ele, options) {
             var key = ele.attr('data-i18n');
+            var optionsToUse = options || ele.data("i18n-options") || {}
             if (!key) return;
 
             if (key.indexOf(';') <= key.length-1) {
                 var keys = key.split(';');
 
                 $.each(keys, function(m, k) {
-                    parse(ele, k, options);
+                    parse(ele, k, optionsToUse);
                 });
 
             } else {
-                parse(ele, key, options);
+                parse(ele, key, optionsToUse);
             }
+            ele.data("i18n-options", optionsToUse)
         }
 
         // fn


### PR DESCRIPTION
Small patch that stores most recently used translation options to jQuery data so that they can be re-used later when dynamically translating element again.
