### PR TITLE
a tiny modification allowing to pass the namespace as an option

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -64,7 +64,7 @@ function _translate(key, options){
 
     if (!resStore) { return notfound; } // no resStore to translate from
 
-    var ns = o.ns.defaultNs;
+    var ns = options.ns || o.ns.defaultNs;
     if (key.indexOf(o.nsseparator) > -1) {
         var parts = key.split(o.nsseparator);
         ns = parts[0];


### PR DESCRIPTION
I find this mutch cleaner in case we want to display the key content if translation is missing

exemple: 
console.log(i18n.t('Hello world', { lng: "en-US", ns:'ns.mynamespace' }));

in case of missing translation we will get "Hello world" instead of "ns.mynamespace:Hello world"
