### PR TITLE
Fixed a bug in postMissing()

### DIFF
--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -141,7 +141,7 @@ var sync = {
             var item = urls[y];
             f.ajax({
                 url: item.url,
-                type: o.sendType,
+                sendType: o.sendType,
                 data: payload,
                 success: function(data, status, xhr) {
                     f.log('posted missing key \'' + key + '\' to: ' + item.url);


### PR DESCRIPTION
Fixed a typo in "postMissing" that caused it to default the requests to "GET" rather than "POST"
