### PR TITLE
allow for configurable selector attribute, defaulting to data-i18n

### DIFF
--- a/spec/jquery.spec.js
+++ b/spec/jquery.spec.js
@@ -63,7 +63,7 @@ describe('jQuery integration / specials', function() {
       };
       
       beforeEach(function(done) {
-        setFixtures('<div id="container"><button id="testBtn" data-i18n="simpleTest"></button></div>');
+        setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="simpleTest"></button></div>');
 
         i18n.init( $.extend(opts, { resStore: resStore }),
           function(t) {  done(); });
@@ -90,7 +90,7 @@ describe('jQuery integration / specials', function() {
       };
       
       beforeEach(function(done) {
-        setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+        setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
 
         i18n.init( $.extend(opts, { resStore: resStore }),
           function(t) {  done(); });
@@ -117,7 +117,7 @@ describe('jQuery integration / specials', function() {
       };
       
       beforeEach(function(done) {
-        setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+        setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
 
         i18n.init( $.extend(opts, { resStore: resStore }),
           function(t) {  done(); });
@@ -162,7 +162,7 @@ describe('jQuery integration / specials', function() {
       };
       
       beforeEach(function(done) {
-        setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+        setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
 
         i18n.init( $.extend(opts, { 
           resStore: resStore,

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -19,6 +19,7 @@ describe('i18next', function() {
       getAsync: true,
       returnObjectTrees: false,
       debug: true,
+      selectorAttr: 'data-i18n',
       postProcess: ''
     };
   });

--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -10,6 +10,7 @@ var o = {
     ns: 'translation',
     nsseparator: ':',
     keyseparator: '.',
+    selectorAttr: 'data-i18n',
     debug: false,
     
     resGetPath: 'locales/__lng__/__ns__.json',

--- a/src/i18next.jquery.js
+++ b/src/i18next.jquery.js
@@ -32,7 +32,7 @@ function addJqueryFunct() {
     }
 
     function localize(ele, options) {
-        var key = ele.attr('data-i18n');
+        var key = ele.attr(o.selectorAttr);
         if (!key) return;
 
         if (!options && o.useDataAttrOptions === true) {
@@ -61,7 +61,7 @@ function addJqueryFunct() {
             localize($(this), options);
 
             // localize childs
-            var elements =  $(this).find('[data-i18n]');
+            var elements =  $(this).find('[' + o.selectorAttr + ']');
             elements.each(function() { 
                 localize($(this), options);
             });

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ describe('i18next', function() {
       getAsync: true,
       returnObjectTrees: false,
       debug: true,
+      selectorAttr: 'data-i18n',
       postProcess: ''
     };
   });
@@ -1040,7 +1041,7 @@ describe('i18next', function() {
         };
         
         beforeEach(function(done) {
-          setFixtures('<div id="container"><button id="testBtn" data-i18n="simpleTest"></button></div>');
+          setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="simpleTest"></button></div>');
   
           i18n.init( $.extend(opts, { resStore: resStore }),
             function(t) {  done(); });
@@ -1067,7 +1068,7 @@ describe('i18next', function() {
         };
         
         beforeEach(function(done) {
-          setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+          setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
   
           i18n.init( $.extend(opts, { resStore: resStore }),
             function(t) {  done(); });
@@ -1094,7 +1095,7 @@ describe('i18next', function() {
         };
         
         beforeEach(function(done) {
-          setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+          setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
   
           i18n.init( $.extend(opts, { resStore: resStore }),
             function(t) {  done(); });
@@ -1139,7 +1140,7 @@ describe('i18next', function() {
         };
         
         beforeEach(function(done) {
-          setFixtures('<div id="container"><button id="testBtn" data-i18n="[title]simpleTest;simpleTest"></button></div>');
+          setFixtures('<div id="container"><button id="testBtn" ' + opts.selectorAttr + '="[title]simpleTest;simpleTest"></button></div>');
   
           i18n.init( $.extend(opts, { 
             resStore: resStore,
@@ -1162,5 +1163,6 @@ describe('i18next', function() {
     });
   
   });
+  
 
 });


### PR DESCRIPTION
Allow data attribute to be configured.  My use case is 'data-i18n-token' over the default 'data-i18n'.
