### PR TITLE
Fixes a bad call when no language is defined in browser

### DIFF
--- a/src/i18next.helpers.js
+++ b/src/i18next.helpers.js
@@ -379,7 +379,7 @@ var f = {
     },
     toLanguages: function(lng) {
         var languages = [];
-        if (lng.indexOf('-') > -1) {
+        if (typeof lng === 'string' && lng.indexOf('-') > -1) {
             var parts = lng.split('-');
 
             lng = o.lowerCaseLng ? 


### PR DESCRIPTION
When no language is configured in the browser, instead of a string, the argument of the function i'll be a boolean value, and calling indexOf on a boolean causes an error.
