### PR TITLE
Allow custom loader callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ In the folder you find one static sample.
 
 - [jsperanto](https://github.com/jpjoyal/jsperanto).
 
+# Building
+To build your own copy of i18next, check out the repository and:
+
+    cd i18next
+    npm install grunt grunt-contrib grunt-rigger
+    node_modules/grunt/bin/grunt
+    
+The grunt command will build i18next into the bin/ and release/ folders.
+
 # License
 
 Copyright (c) 2011 Jan Mühlemann
@@ -121,18 +130,9 @@ The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LMITED TO THE WARRANTIES OF MERCHANTABILITY,
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-# Building
-To build your own copy of i18next, check out the repository and:
-
-    cd i18next
-    npm install grunt grunt-contrib grunt-rigger
-    node_modules/grunt/bin/grunt
-    
-The grunt command will build i18next into the bin/ and release/ folders.

--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -72,9 +72,9 @@ var sync = {
             // load each file individual
             f.each(ns.namespaces, function(nsIndex, nsValue) {
                 f.each(lngs, function(lngIndex, lngValue) {
-					
-					// Call this once our translation has returned.
-					var loadComplete = function(err, data) {
+                    
+                    // Call this once our translation has returned.
+                    var loadComplete = function(err, data) {
                         if (err) {
                             errors = errors || [];
                             errors.push(err);
@@ -86,13 +86,13 @@ var sync = {
                         if (todo === 0) cb(errors, store);
                     };
                     
-					if(typeof options.customLoad == 'function'){
-						// Use the specified custom callback.
-						options.customLoad(lngValue, nsValue, options, loadComplete);
-					} else {
-						//~ // Use our inbuilt sync.
-						sync._fetchOne(lngValue, nsValue, options, loadComplete);
-					}
+                    if(typeof options.customLoad == 'function'){
+                        // Use the specified custom callback.
+                        options.customLoad(lngValue, nsValue, options, loadComplete);
+                    } else {
+                        //~ // Use our inbuilt sync.
+                        sync._fetchOne(lngValue, nsValue, options, loadComplete);
+                    }
                 });
             });
         } else {


### PR DESCRIPTION
I implemented a custom loader to override sync._fetchOne and allow a custom function to return translations. This is useful in cases where you can't use AJAX, and have to use some other method of returning data.

I also updated the readme to include some brief build instructions since it took a while for me to work it out since I didn't know what I was doing.

I'm not sure if this meets your expectations of the project or if you'd prefer to do this in a different way, but if there's anything you want me to do in order to accept this, please let me know and I'll get on it. :)

Cheers,
Ash.
