### PR TITLE
Support for Zepto library if jQuery not found

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -3,7 +3,7 @@
     //= i18next.shim.js
 
     var root = this
-      , $ = root.jQuery
+      , $ = root.jQuery || root.Zepto
       , i18n = {}
       , resStore = {}
       , currentLng


### PR DESCRIPTION
For mobile development we preffer Zeptojs instead of jQuery.

From zeptojs.com:
Zepto is a minimalist JavaScript library for modern browsers with a
largely jQuery-compatible API. If you use jQuery, you already know how
to use Zepto.
