### PR TITLE
Optional interpolation prefix/suffix not used in plural translation cases.

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -125,17 +125,13 @@ function _translate(key, options){
         
         translated = translate(pluralKey, optionWithoutCount);
         if (translated != o.pluralNotFound) {
-            var pluralOptions = { count :  options.count }; // apply replacement for count only
 
-            if (options.interpolationPrefix) {
-                pluralOptions.interpolationPrefix = options.interpolationPrefix;
-            }
+            return applyReplacement(translated, { // apply replacement for count only
+              count: options.count,
+              interpolationPrefix: options.interpolationPrefix,
+              interpolationSuffix: options.interpolationSuffix 
+            });
 
-            if (options.interpolationSuffix) {
-                pluralOptions.interpolationSuffix = options.interpolationSuffix;
-            }
-
-            return applyReplacement(translated, pluralOptions);
         } // else continue translation with original/singular key
     }
 


### PR DESCRIPTION
Optional interpolation prefix/suffix were being used in singular, but not plural translations.

``` json
{
  "app": {
    "child": "${count} child",
    "child_plural": "${count} children"
  }
}
```

``` javascript
i18n.t("app.child", {
  count : 1,
  interpolationPrefix : "${",
  interpolationSuffix : "}",
});
```

Outputs "1 child"

``` javascript
i18n.t("app.child", {
  count : 2,
  interpolationPrefix : "${",
  interpolationSuffix : "}",
});
```

Outputs "${count} children"
