### PR TITLE
failing test when asking a key in a language with a different plural form

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1601,7 +1601,33 @@ describe('i18next', function() {
           expect(i18n.t('key', {count: 100})).to.be('0,5,6');
         });
       });
-    
+      
+      describe('extended usage - ask for a key in a language with a different plural form', function() {
+        var resStore = {
+            en: { translation: {
+                key:'singular_en',
+                key_plural:'plural_en'
+              } 
+            },
+            zh: { translation: { 
+                key: 'singular_zh'
+              }
+            }
+        };
+        
+        beforeEach(function(done) {
+          i18n.init(i18n.functions.extend(opts, { lng: 'zh', resStore: resStore }),
+            function(t) { done(); });
+        });
+
+        it('it should provide translation for passed in language with 1 item', function() {
+          expect(i18n.t('key', { lng: 'en', count:1 })).to.be('singular_en');
+        });
+
+        it('it should provide translation for passed in language with 2 items', function() {
+          expect(i18n.t('key', { lng: 'en', count:2 })).to.be('plural_en');
+        });
+      });
     });
   
     describe('context usage', function() {


### PR DESCRIPTION
...m

Seems that is ignoring any plural form even if it comes from a language that has a plural system that is different
i18n.setLng("en"); //object
i18n.t("date.day",{count:2}) // Days
i18n.setLng("zh") //obeject
i18n.t("date.day",{count:2}) // 日
i18n.t("date.day",{count:2, lng:"en"}) // Day
i18n.setLng("ar") //object
i18n.t("date.day",{count:2, lng:"da"}) //Dag //wrong
i18n.t("date.day",{count:2, lng:"en"}) //Day
i18n.setLng("en") //object
i18n.t("date.day",{count:2, lng:"da"}) //Dage //correct
