### PR TITLE
setLng callbacks are now remembering their language.

### DIFF
--- a/spec/functions/functions.setlng.spec.js
+++ b/spec/functions/functions.setlng.spec.js
@@ -19,4 +19,20 @@ describe('setting language', function() {
 
   });
 
+  it('should be possible to call setLng multiple times to get specialized callbacks', function(done) {
+    i18n.setLng('de-DE', function(deDE) {
+        expect(deDE.lng).to.be('de-DE');
+
+        i18n.setLng('en-US', function(enUS) {
+            expect(deDE.lng).to.be('de-DE');
+            expect(enUS.lng).to.be('en-US');
+
+            expect(deDE('simpleTest')).to.be('ok_from_de-DE');
+            expect(enUS('simpleTest')).to.be('ok_from_en-US');
+
+            done();
+        });
+    });
+  })
+
 });

--- a/src/i18next.functions.js
+++ b/src/i18next.functions.js
@@ -97,7 +97,7 @@ function loadNamespaces(namespaces, cb) {
 }
 
 function setLng(lng, cb) {
-    return init({lng: lng}, cb);
+    return init({lng: lng, specializedTranslate: true}, cb);
 }
 
 function lng() {

--- a/src/i18next.init.js
+++ b/src/i18next.init.js
@@ -36,6 +36,16 @@ function init(options, cb) {
     currentLng = languages[0];
     f.log('currentLng set to: ' + currentLng);
 
+    var lngTranslate = translate;
+    if (options.specializedTranslate) {
+        lngTranslate = function(key, options) {
+            options = options || {};
+            options.lng = options.lng || lngTranslate.lng;
+            return translate(key, options);
+        };
+        lngTranslate.lng = currentLng;
+    }
+
     pluralExtensions.setCurrentLng(currentLng);
 
     // add JQuery extensions
@@ -50,8 +60,8 @@ function init(options, cb) {
     // return immidiatly if res are passed in
     if (o.resStore) {
         resStore = o.resStore;
-        if (cb) cb(translate);
-        if (deferred) deferred.resolve();
+        if (cb) cb(lngTranslate);
+        if (deferred) deferred.resolve(lngTranslate);
         if (deferred) return deferred.promise();
         return;
     }
@@ -72,8 +82,8 @@ function init(options, cb) {
     i18n.sync.load(lngsToLoad, o, function(err, store) {
         resStore = store;
 
-        if (cb) cb(translate);
-        if (deferred) deferred.resolve();
+        if (cb) cb(lngTranslate);
+        if (deferred) deferred.resolve(lngTranslate);
     });
 
     if (deferred) return deferred.promise();


### PR DESCRIPTION
This is point 2/ as discussed in https://github.com/jamuhl/i18next-node/issues/106. I know this was not the one you accepted as is but this patch looked easier for a first one.
