### PR TITLE
returnObjectTrees should not return empty object for number

### DIFF
--- a/spec/translate/translate.objectValue.spec.js
+++ b/spec/translate/translate.objectValue.spec.js
@@ -67,7 +67,7 @@ describe('accessing tree values', function() {
         'en-US': { 
           translation: {                      
             test: { res: 'added __replace__',
-                    id: '0',
+                    id: 0,
                     template: '4',
                     title: 'About...',
                     text: 'Site description',
@@ -87,7 +87,7 @@ describe('accessing tree values', function() {
       it('it should return objectTree', function() {
         expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
           res: 'added two',
-          id: '0',
+          id: 0,
           template: '4',
           title: 'About...',
           text: 'Site description',

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -269,7 +269,7 @@ function _find(key, options){
                     value = 'key \'' + ns + ':' + key + ' (' + l + ')\' ' +
                         'returned a object instead of string.';
                     f.log(value);
-                } else {
+                } else if (typeof value !== 'number') {
                     var copy = {}; // apply child translation on a copy
                     f.each(value, function(m) {
                         copy[m] = _translate(ns + o.nsseparator + key + o.keyseparator + m, options);

--- a/test/server/i18next.translate.spec.js
+++ b/test/server/i18next.translate.spec.js
@@ -274,7 +274,7 @@ describe('i18next.translate', function() {
           'en-US': { 
             translation: {                      
               test: { res: 'added __replace__',
-                      id: '0',
+                      id: 0,
                       template: '4',
                       title: 'About...',
                       text: 'Site description',
@@ -294,7 +294,7 @@ describe('i18next.translate', function() {
         it('it should return objectTree', function() {
           expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
             res: 'added two',
-            id: '0',
+            id: 0,
             template: '4',
             title: 'About...',
             text: 'Site description',

--- a/test/test.js
+++ b/test/test.js
@@ -1249,7 +1249,7 @@ describe('i18next', function() {
             'en-US': { 
               translation: {                      
                 test: { res: 'added __replace__',
-                        id: '0',
+                        id: 0,
                         template: '4',
                         title: 'About...',
                         text: 'Site description',
@@ -1269,7 +1269,7 @@ describe('i18next', function() {
           it('it should return objectTree', function() {
             expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
               res: 'added two',
-              id: '0',
+              id: 0,
               template: '4',
               title: 'About...',
               text: 'Site description',


### PR DESCRIPTION
Currently `_find()` will return an empty object when using `returnObjectTrees: true` and the current value is actually a number.
