### PR TITLE
Numeric Context

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -65,7 +65,7 @@ function applyReuse(translated, options) {
 }
 
 function hasContext(options) {
-    return (options.context && typeof options.context == 'string');
+    return (options.context && (typeof options.context == 'string' || typeof options.context == 'number'));
 }
 
 function needsPlural(options) {


### PR DESCRIPTION
This single line change allows context to be a number. I couldn't see any other complications with this. It would allow translations like below while still allowing for numeric plurals:

```
"Foo_1"        : "Foo number one",
"Foo_7"        : "Foo Seven",
"Foo_plural_1" : "a foo",
"Foo_plural_7" : "a bunch of foos"
```

My use case is translating venue descriptions based on a sport ID, like 4 => "Rink", 5 => "Field", 6 => "Court".
