### PR TITLE
Make returnObjectTrees not mangle arrays, functions, and regexps

### DIFF
--- a/spec/translate/translate.objectValue.spec.js
+++ b/spec/translate/translate.objectValue.spec.js
@@ -68,6 +68,8 @@ describe('accessing tree values', function() {
           translation: {                      
             test: { res: 'added __replace__',
                     id: 0,
+                    regex: /test/,
+                    func: function () {},
                     template: '4',
                     title: 'About...',
                     text: 'Site description',
@@ -88,6 +90,8 @@ describe('accessing tree values', function() {
         expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
           res: 'added two',
           id: 0,
+          regex: resStore['en-US'].translation.test.regex,
+          func: resStore['en-US'].translation.test.func,
           template: '4',
           title: 'About...',
           text: 'Site description',

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -269,10 +269,11 @@ function _find(key, options){
             x++;
         }
         if (value !== undefined) {
+            var valueType = Object.prototype.toString.apply(value);
             if (typeof value === 'string') {
                 value = applyReplacement(value, options);
                 value = applyReuse(value, options);
-            } else if (Object.prototype.toString.apply(value) === '[object Array]' && !o.returnObjectTrees && !options.returnObjectTrees) {
+            } else if (valueType === '[object Array]' && !o.returnObjectTrees && !options.returnObjectTrees) {
                 value = value.join('\n');
                 value = applyReplacement(value, options);
                 value = applyReuse(value, options);
@@ -283,8 +284,8 @@ function _find(key, options){
                     value = 'key \'' + ns + ':' + key + ' (' + l + ')\' ' +
                         'returned a object instead of string.';
                     f.log(value);
-                } else if (typeof value !== 'number') {
-                    var copy = {}; // apply child translation on a copy
+                } else if (valueType !== '[object Number]' && valueType !== '[object Function]' && valueType !== '[object RegExp]') {
+                    var copy = (valueType === '[object Array]') ? [] : {}; // apply child translation on a copy
                     f.each(value, function(m) {
                         copy[m] = _translate(ns + o.nsseparator + key + o.keyseparator + m, options);
                     });

--- a/test/server/i18next.translate.spec.js
+++ b/test/server/i18next.translate.spec.js
@@ -306,6 +306,8 @@ describe('i18next.translate', function() {
             translation: {                      
               test: { res: 'added __replace__',
                       id: 0,
+                      regex: /test/,
+                      func: function () {},
                       template: '4',
                       title: 'About...',
                       text: 'Site description',
@@ -326,6 +328,8 @@ describe('i18next.translate', function() {
           expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
             res: 'added two',
             id: 0,
+            regex: resStore['en-US'].translation.test.regex,
+            func: resStore['en-US'].translation.test.func,
             template: '4',
             title: 'About...',
             text: 'Site description',

--- a/test/test.js
+++ b/test/test.js
@@ -1281,6 +1281,8 @@ describe('i18next', function() {
               translation: {                      
                 test: { res: 'added __replace__',
                         id: 0,
+                        regex: /test/,
+                        func: function () {},
                         template: '4',
                         title: 'About...',
                         text: 'Site description',
@@ -1301,6 +1303,8 @@ describe('i18next', function() {
             expect(i18n.t('test', { returnObjectTrees: true, replace: 'two' })).to.eql({ 
               res: 'added two',
               id: 0,
+              regex: resStore['en-US'].translation.test.regex,
+              func: resStore['en-US'].translation.test.func,
               template: '4',
               title: 'About...',
               text: 'Site description',


### PR DESCRIPTION
The `returnObjectTrees` option mangles `Array`s, `function`s and `RegExp`s.
- Arrays are turned into array-like objects with numeric property names (but are not actually arrays)
- Functions are turned into empty objects (`{}`)
- RegExps are turned into empty objects (`{}`)

I've fixed it so that these types are correctly handled.

Before my fix:

```
{ 
  res: 'added __replace__',
  id: 0,
  regex: /x/,
  func: function () {},
  template: '4',
  title: 'About...',
  text: 'Site description',
  media: ['test'] 
}
```

Would get turned into (assuming "two" is passed in as the "replace" value):

```
{
  res: 'added two',
  id: 0,
  regex: {},
  func: {},
  template: '4',
  title: 'About...',
  text: 'Site description',
  media: { 0: 'test' } 
}
```

After my fix it gets turned into:

```
{ 
  res: 'added two',
  id: 0,
  regex: /x/,
  func: function () {},
  template: '4',
  title: 'About...',
  text: 'Site description',
  media: ['test'] 
}
```
