### PR TITLE
Initialized is not defined in the current amd builds.

### DIFF
--- a/src/amd.jquery.js
+++ b/src/amd.jquery.js
@@ -18,7 +18,8 @@
         , resStore = {}
         , currentLng
         , replacementCounter = 0
-        , languages = [];
+        , languages = []
+        , initialized = false;
 
     //= i18next.defaults.js
     //= i18next.helpers.js

--- a/src/amd.js
+++ b/src/amd.js
@@ -17,7 +17,8 @@
         , resStore = {}
         , currentLng
         , replacementCounter = 0
-        , languages = [];
+        , languages = []
+        , initialized = false;
 
     //= i18next.defaults.js
     //= i18next.helpers.js


### PR DESCRIPTION
It looks like this was added in 1.7.0, but the variable didn't get added to the amd versions.
