### PR TITLE
Possibility to hook i18n when returned value for a key is an object rathern than a string

### DIFF
--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -48,6 +48,7 @@ var o = {
     cookieName: 'i18next',
     cookieDomain: undefined,
 
+    objectKeyHandler: undefined,
     postProcess: undefined,
     parseMissingKey: undefined,
 

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -282,6 +282,9 @@ function _find(key, options){
                 if (!o.returnObjectTrees && !options.returnObjectTrees) {
                     value = 'key \'' + ns + ':' + key + ' (' + l + ')\' ' +
                         'returned an object instead of string.';
+                    if (o.objectKeyHandler && typeof o.objectKeyHandler == 'function')
+                        value = o.objectKeyHandler(ns,key,l);
+                    }
                     f.log(value);
                 } else if (typeof value !== 'number') {
                     var copy = {}; // apply child translation on a copy


### PR DESCRIPTION
Possibility to hook i18n when returned value for a key is an object rathern than a string.

(NB: not sure i'm not reinventing the wheel i.e "context" stuff)

Exemple:
- jsonfile

```
{
    "myKey":{
        "FOO":"myFoo",
        "BAR":"myBar"
}
```
- javascript

```
i18n.init({
    objectKeyHandler : function(ns,key,lg) {
        if (someWebAppCondition) {
            var n = ns+':'+key+'.'+'FOO';
        } else {
            var n = ns+':'+key+'.'+'BAR';
        }
        return i18n.t(n);
    },
    [.... other init options ....]
});
```
- html

```
<p data-i18n="myNameSpace:myKey"></p>
```
