### PR TITLE
fix if no options and no callback passed

### DIFF
--- a/src/i18next.functions.js
+++ b/src/i18next.functions.js
@@ -101,6 +101,9 @@ function setLng(lng, options, cb) {
         cb = options;
         options = {};
     }
+    if (!options)
+        options = {};
+
     options.lng = lng;
     return init(options, cb);
 }


### PR DESCRIPTION
I had this issue in production: 

```
TypeError: 'undefined' is not an object (evaluating 'options.lng = lng')
```
