### PR TITLE
Correct error handler. Did not work in Chrome

### DIFF
--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -133,13 +133,14 @@ var sync = {
                 done(null, data);
             },
             error : function(xhr, status, error) {
-                if (xhr.status == 200) {
+                if ((status && status == 200) || (xhr && xhr.status && xhr.status == 200)) {
                     // file loaded but invalid json, stop waste time !
                     f.log('There is a typo in: ' + url);
-                } else if (xhr.status == 404) {
+                } else if ((status && status == 404) || (xhr && xhr.status && xhr.status == 404)) {
                     f.log('Does not exist: ' + url);
                 } else {
-                    f.log(xhr.status + ' when loading ' + url);
+                    var theStatus = status ? status : ((xhr && xhr.status) ? xhr.status : null);
+                    f.log(theStatus + ' when loading ' + url);
                 }
                 
                 done(error, {});


### PR DESCRIPTION
In Chrome (and this might not only happen in Chrome ... I did not test this in other browsers), the ‘xhr’ parameter had the following value when I hit line 136: "Cannot GET /locales/en-US/translation.json?_=1396024455309”. The object type of this parameter was ‘string’ and it did not have a ‘status’ attribute defined on it. This caused the i18next script to fail and prevent the proper translation of keys.

I noticed that you recently changed this method, changing from using ‘error.status’ to ‘xhr.status’ in various places. I assume that in some circumstances, perhaps with some browsers or server software, the xhr parameter has a 'status' attribute populated. In my case it did not. However, in my case, the ‘status’ parameter DID have a value, 404, which I believe you expected the xhr parameter to carry in an attribute named 'status'. 

The proposed code change allows the code to run without error in both scenarios, deferring to the value of the status parameter in the case that both the status parameter has a value and an attribute named 'status' is defined and populated on the xhr parameter.
