### PR TITLE
ie8 not support trim.

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -301,7 +301,7 @@ function _find(key, options) {
                 }
             }
 
-            if (typeof value === 'string' && value.trim() === '' && o.fallbackOnEmpty === true)
+            if (typeof value === 'string' && value.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '') === '' && o.fallbackOnEmpty === true)
                 value = undefined;
 
             found = value;


### PR DESCRIPTION
If user use IE8 or below, user get the error message. 
''Object doesn't support property or method 'trim'"
I replaced trim to replace to support IE8. 
