### PR TITLE
Escape dollar signs ('$') in replacement strings.

### DIFF
--- a/spec/translate/translate.interpolation.spec.js
+++ b/spec/translate/translate.interpolation.spec.js
@@ -33,6 +33,10 @@ describe('default i18next way', function() {
     expect(i18n.t('interpolationTest5', {defaultValue: 'added __toAdd__', toAdd: 'something'})).to.be('added something');
   });
 
+  it("it should escape dollar signs in replacement values", function() {
+    expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&');
+  });
+
 });
 
 describe('default i18next way - different prefix/suffix', function() {
@@ -142,6 +146,10 @@ describe('default i18next way - with escaping interpolated arguments per default
     expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
   });
 
+  it("it should escape dollar signs in replacement values", function() {
+    expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
+  });
+
 });
 
 describe('default i18next way - with escaping interpolated arguments per default via options', function () {
@@ -175,6 +183,10 @@ describe('default i18next way - with escaping interpolated arguments per default
 
   it("it should support both escaping and not escaping HTML", function() {
     expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
+  });
+
+  it("it should escape dollar signs in replacement values", function() {
+    expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
   });
 
 });

--- a/src/i18next.helpers.js
+++ b/src/i18next.helpers.js
@@ -427,5 +427,12 @@ var f = {
     },
     regexEscape: function(str) {
         return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+    },
+    regexReplacementEscape: function(strOrFn) {
+        if (typeof strOrFn === 'string') {
+            return strOrFn.replace(/\$/g, "$$$$");
+        } else {
+            return strOrFn;
+        }
     }
 };

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -14,10 +14,10 @@ function applyReplacement(str, replacementHash, nestedKey, options) {
             str = applyReplacement(str, value, nextKey, options);
         } else {
             if (options.escapeInterpolation || o.escapeInterpolation) {
-                str = str.replace(new RegExp([prefix, nextKey, unEscapingSuffix].join(''), 'g'), value);
-                str = str.replace(new RegExp([prefix, nextKey, suffix].join(''), 'g'), f.escape(value));
+                str = str.replace(new RegExp([prefix, nextKey, unEscapingSuffix].join(''), 'g'), f.regexReplacementEscape(value));
+                str = str.replace(new RegExp([prefix, nextKey, suffix].join(''), 'g'), f.regexReplacementEscape(f.escape(value)));
             } else {
-                str = str.replace(new RegExp([prefix, nextKey, suffix].join(''), 'g'), value);
+                str = str.replace(new RegExp([prefix, nextKey, suffix].join(''), 'g'), f.regexReplacementEscape(value));
             }
             // str = options.escapeInterpolation;
         }
@@ -59,7 +59,7 @@ function applyReuse(translated, options) {
         }
 
         var translated_token = _translate(token_without_symbols, opts);
-        translated = translated.replace(token, translated_token);
+        translated = translated.replace(token, f.regexReplacementEscape(translated_token));
     }
     return translated;
 }

--- a/test/server/i18next.translate.spec.js
+++ b/test/server/i18next.translate.spec.js
@@ -502,6 +502,10 @@ describe('i18next.translate', function() {
         expect(i18n.t('interpolationTest5', {defaultValue: 'added __toAdd__', toAdd: 'something'})).to.be('added something');
       });
     
+      it("it should escape dollar signs in replacement values", function() {
+        expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&');
+      });
+    
     });
     
     describe('default i18next way - different prefix/suffix', function() {
@@ -611,6 +615,10 @@ describe('i18next.translate', function() {
         expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
       });
     
+      it("it should escape dollar signs in replacement values", function() {
+        expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
+      });
+    
     });
     
     describe('default i18next way - with escaping interpolated arguments per default via options', function () {
@@ -644,6 +652,10 @@ describe('i18next.translate', function() {
     
       it("it should support both escaping and not escaping HTML", function() {
         expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
+      });
+    
+      it("it should escape dollar signs in replacement values", function() {
+        expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
       });
     
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1588,6 +1588,10 @@ describe('i18next', function() {
           expect(i18n.t('interpolationTest5', {defaultValue: 'added __toAdd__', toAdd: 'something'})).to.be('added something');
         });
       
+        it("it should escape dollar signs in replacement values", function() {
+          expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&');
+        });
+      
       });
       
       describe('default i18next way - different prefix/suffix', function() {
@@ -1697,6 +1701,10 @@ describe('i18next', function() {
           expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
         });
       
+        it("it should escape dollar signs in replacement values", function() {
+          expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
+        });
+      
       });
       
       describe('default i18next way - with escaping interpolated arguments per default via options', function () {
@@ -1730,6 +1738,10 @@ describe('i18next', function() {
       
         it("it should support both escaping and not escaping HTML", function() {
           expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
+        });
+      
+        it("it should escape dollar signs in replacement values", function() {
+          expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
         });
       
       });


### PR DESCRIPTION
Fixes #242.

`String.prototype.replace` treats '$' as a special character,
so replacement values with substrings like '$&' will break.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter.
