### PR TITLE
Update i18next.js

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -991,7 +991,7 @@
     }
     
     function _getDefaultValue(key, options) {
-        return (options.defaultValue !== undefined) ? options.defaultValue : key;
+        return (options.defaultValue !== undefined && options.defaultValue !== '') ? options.defaultValue : key;
     }
     
     function _injectSprintfProcessor() {
@@ -1040,9 +1040,6 @@
             }
         }
         
-        if (o.debug)
-            return key;
-    
         var notFound = _getDefaultValue(key, options)
             , found = _find(key, options)
             , lngs = options.lng ? f.toLanguages(options.lng) : languages


### PR DESCRIPTION
Very small change to the "_translate" function to simply return the key in debug mode (lines 1043-4) - this allows the developer to have a quick visual test to see where strings have been extracted to JSON and where they have not, to ensure that all text is translated.   If the text shows up as the "key" then it has been extracted.   If not, it can be considered a bug.    If it's not desirable to have this tied to the "debug" property, then I propose a separate "languageDebug" property that performs the same function.    This is in high use in my company and would be greatly appreciated.
