### PR TITLE
feat(fallback): add fallbacklng capability in translate function

### DIFF
--- a/src/i18next.helpers.js
+++ b/src/i18next.helpers.js
@@ -404,7 +404,11 @@ var f = {
     log: function(str) {
         if (o.debug && typeof console !== "undefined") console.log(str);
     },
-    toLanguages: function(lng) {
+    toLanguages: function(lng, fallbackLng) {
+        if (fallbackLng === undefined)
+            fallbackLng = o.fallbackLng;
+        fallbackLng = fallbackLng || [];
+
         var languages = [];
         if (typeof lng === 'string' && lng.indexOf('-') > -1) {
             var parts = lng.split('-');

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -144,7 +144,7 @@ function _translate(potentialKeys, options) {
 
     var notFound = _getDefaultValue(key, options)
         , found = _find(key, options)
-        , lngs = options.lng ? f.toLanguages(options.lng) : languages
+        , lngs = options.lng ? f.toLanguages(options.lng, options.fallbackLng) : languages
         , ns = options.ns || o.ns.defaultNs
         , parts;
 
@@ -207,7 +207,7 @@ function _find(key, options) {
 
     // passed in lng
     if (options.lng) {
-        lngs = f.toLanguages(options.lng);
+        lngs = f.toLanguages(options.lng, options.fallbackLng);
 
         if (!resStore[lngs[0]]) {
             var oldAsync = o.getAsync;


### PR DESCRIPTION
When using the translate function, it is currently impossible use a different fallback language than the one declared in the init.

This patch adds a "fallbackLng" option to the existing options array that may be given to t() (like in the init, with the same behavior).
