### PR TITLE
Fix needsPlural returning true for singular values in some languages

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -68,8 +68,8 @@ function hasContext(options) {
     return (options.context && (typeof options.context == 'string' || typeof options.context == 'number'));
 }
 
-function needsPlural(options) {
-    return (options.count !== undefined && typeof options.count != 'string' && options.count !== 1);
+function needsPlural(options, lng) {
+    return (options.count !== undefined && typeof options.count != 'string' && pluralExtensions.get(lng, options.count) !== 1);
 }
 
 function exists(key, options) {
@@ -240,7 +240,7 @@ function _find(key, options) {
         } // else continue translation with original/nonContext key
     }
 
-    if (needsPlural(options)) {
+    if (needsPlural(options, lngs[0])) {
         optionWithoutCount = f.extend({}, options);
         delete optionWithoutCount.count;
         optionWithoutCount.defaultValue = o.pluralNotFound;


### PR DESCRIPTION
There is a huge bug in the handling of plurals:

In `needsPlural()`, `options.count !== 1` refers to the English plural rule, not the one corresponding to the current language!

The missing keys feature reported `my_key_plural_1: plural_not_found`, when `my_key_plural` was defined in French.
