### PR TITLE
Fix for file protocol returning status code 0 (see #141)

### DIFF
--- a/src/i18next.helpers.js
+++ b/src/i18next.helpers.js
@@ -347,7 +347,8 @@ function _ajax(options) {
     var methode = options.type ? options.type.toLowerCase() : 'get';
 
     http[methode](options.url, options, function (status, data) {
-        if (status === 200) {
+        // file: protocol always gives status code 0, so check for data
+        if (status === 200 || (status === 0 && data.text())) {
             options.success(data.json(), status, null);
         } else {
             options.error(data.text(), status, null);


### PR DESCRIPTION
This fixes the issue with file protocol returning status code 0 for XHR requests. Tested and works in a Phonegap app (which was the original issue reported).
