### PR TITLE
Return empty string if passed key is also an empty string

### DIFF
--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -125,7 +125,7 @@ function _translate(potentialKeys, options) {
         options = options || {};
     }
 
-    if (potentialKeys === undefined || potentialKeys === null) return '';
+    if (potentialKeys === undefined || potentialKeys === null || potentialKeys === '') return '';
 
     if (typeof potentialKeys == 'string') {
         potentialKeys = [potentialKeys];


### PR DESCRIPTION
HI!

I noticed that I was going to adjust a full name of key (for 3rd time) that returns an empty string. And I realized that this is contrproductive. So I looked into sources and got a lucky chance.

Just added 1 more subcondition into 'if' that does checking of incoming key
