### PR TITLE
reduce npm component size from 9MB to 2MB by not including old releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+release


### PR DESCRIPTION
This addition of .npmignore will reduce npm published component size from 9MB to 2MB by not including previous releases.  Each release to npm will now only be the current script
