### PR TITLE
Added getResourceBundle to API. #334

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -8,6 +8,8 @@ describe('Initialisation', function() {
 
     //= init/init.addResourceOrResourceBundle.spec.js
 
+    //= init/init.getResourceBundle.spec.js
+
     //= init/init.removeResourceBundle.spec.js
 
     //= init/init.loadBehaviour.spec.js

--- a/spec/init/init.getResourceBundle.spec.js
+++ b/spec/init/init.getResourceBundle.spec.js
@@ -1,0 +1,41 @@
+describe('getting resources after init', function() {
+
+  var resStore = {
+    dev: { translation: { 'test': 'ok_from_dev' } },
+    en: { translation: { 'test': 'ok_from_en' } },            
+    'en-US': { translation: { 'test': 'ok_from_en-US' } }
+  };
+
+  beforeEach(function(done) {
+    i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function() {
+        done();
+    });
+  });
+
+  it('it should return resources for existing bundle', function() {
+    var devTranslation = i18n.getResourceBundle('dev', 'translation');
+    var enTranslation = i18n.getResourceBundle('en', 'translation');
+    var enUSTranslation = i18n.getResourceBundle('en-US', 'translation');
+    expect(devTranslation.test).to.be('ok_from_dev');
+    expect(enTranslation.test).to.be('ok_from_en');
+    expect(enUSTranslation.test).to.be('ok_from_en-US');
+  });
+
+  it('it should return empty object for non-existing bundle', function() {
+    var nonExisting = i18n.getResourceBundle('en-GB', 'translation');
+    expect(Object.keys(nonExisting).length).to.be(0);
+  });
+
+  it('it should use default namespace when namespace argument is left out', function() {
+    var enTranslation = i18n.getResourceBundle('en');
+    expect(enTranslation.test).to.be('ok_from_en');
+  });
+
+  it('it should return a clone of the resources', function() {
+    var enTranslation = i18n.getResourceBundle('en');
+    enTranslation.test = 'ok_from_en_changed';
+    expect(enTranslation.test).to.be('ok_from_en_changed');
+    expect(resStore.en.translation.test).to.be('ok_from_en');
+  });
+
+});

--- a/src/i18next.api.js
+++ b/src/i18next.api.js
@@ -4,6 +4,7 @@ i18n.setLng = setLng;
 i18n.preload = preload;
 i18n.addResourceBundle = addResourceBundle;
 i18n.hasResourceBundle = hasResourceBundle;
+i18n.getResourceBundle = getResourceBundle;
 i18n.addResource = addResource;
 i18n.addResources = addResources;
 i18n.removeResourceBundle = removeResourceBundle;

--- a/src/i18next.functions.js
+++ b/src/i18next.functions.js
@@ -44,6 +44,15 @@ function hasResourceBundle(lng, ns) {
     return hasValues;
 }
 
+function getResourceBundle(lng, ns) {
+    if (typeof ns !== 'string') {
+        ns = o.ns.defaultNs;
+    }
+
+    resStore[lng] = resStore[lng] || {};
+    return f.extend({}, resStore[lng][ns]);
+}
+
 function removeResourceBundle(lng, ns) {
     if (typeof ns !== 'string') {
         ns = o.ns.defaultNs;


### PR DESCRIPTION
I've added a new API function 'getResourceBundle' which will return the resources of a specific bundle.

The function takes two arguments, a language and an optional namespace. When no namespace is provided, is will use the default namespace taken from the options. This is consistent with other functions like addResourceBundle and removeResourceBundle. It will return the bundle resources or an empty object when the bundle does not exist. It returns a clone of the bundle, to prevent the bundle from being changed.

I've added tests for it.