### PR TITLE
Add repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     , "zipstream": ">=0.2.1"
     , "underscore": ">=0.2.1"
   }
+  , "repository": "https://github.com/i18next/i18next/"
   , "scripts": {
     "test": "testacular start"
   }


### PR DESCRIPTION
This will suppress annoying warning messages on `npm install` when using the library.
