### PR TITLE
public visibility of applyReplacement function

### DIFF
--- a/src/i18next.api.js
+++ b/src/i18next.api.js
@@ -19,4 +19,5 @@ i18n.sync = sync;
 i18n.functions = f;
 i18n.lng = lng;
 i18n.addPostProcessor = addPostProcessor;
+i18n.applyReplacement = f.applyReplacement;
 i18n.options = o;


### PR DESCRIPTION
Hi,

customLoad option is a great feature.
In angularjs context, it's necessary to use $http in place of jQuery or xmlhttprequest for unit testing.
But it's not DRY to copy applyReplacement method that handle a lot of code to prepare resource url.

Give visibility to function is really useful in conjunction with customLoad and unit testing.

Regards