### PR TITLE
Fix CommonJS with jQuery export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   , "main": "i18next.js"
   , "browser": "i18next.js"
   , "engines": {
-        "node": "~v0.4.12"
+        "node": "^0.4.12"
     }
   , "dependencies": { }
   , "devDependencies": {

--- a/src/i18next.exports.jquery.js
+++ b/src/i18next.exports.jquery.js
@@ -1,7 +1,8 @@
-// Export the i18next object for **CommonJS**. 
+// Export the i18next object for **CommonJS**.
 // If we're not in CommonJS, add `i18n` to the
 // global object or to jquery.
 if (typeof module !== 'undefined' && module.exports) {
+    module.exports = i18n;
     if (!$) {
         try {
             $ = require('jquery');
@@ -9,13 +10,11 @@ if (typeof module !== 'undefined' && module.exports) {
             // just ignore
         }
     }
-    if ($) {
-        $.i18n = $.i18n || i18n;
-    }
+
 } else {
-    if ($) {
-        $.i18n = $.i18n || i18n;
-    }
-    
     root.i18n = root.i18n || i18n;
+}
+
+if ($) {
+    $.i18n = $.i18n || i18n;
 }


### PR DESCRIPTION
`module.exports = i18n;` was missing. `require('i18n-client/i18next.commonjs.withJQuery.js')` would return `{}`

The rest is just simplification.