### PR TITLE
.noConflict() functionality

### DIFF
--- a/spec/functions.spec.js
+++ b/spec/functions.spec.js
@@ -12,4 +12,6 @@ describe('basic functionality', function() {
 
   //= functions/functions.objectTreeKeyHandler.spec.js
 
+  //= functions/functions.noConflict.spec.js
+
 });

--- a/spec/functions/functions.noConflict.spec.js
+++ b/spec/functions/functions.noConflict.spec.js
@@ -1,0 +1,12 @@
+describe('Global variable conflict', function () {
+
+  it('it should rename global "window.i18n" to "window.i18next"' + 
+    ' and restore window.i18n conflicting reference', function () {
+
+    window.i18n.noConflict();
+
+    expect(window.i18n.isFakeConflictingLib).to.be(true);
+    expect(window.i18next).to.be.an(Object);
+    expect(window.i18next.t).to.be.a(Function);
+  });
+});

--- a/src/i18next.api.js
+++ b/src/i18next.api.js
@@ -22,3 +22,4 @@ i18n.lng = lng;
 i18n.addPostProcessor = addPostProcessor;
 i18n.applyReplacement = f.applyReplacement;
 i18n.options = o;
+i18n.noConflict = noConflict;

--- a/src/i18next.exports.js
+++ b/src/i18next.exports.js
@@ -8,5 +8,8 @@ if (typeof module !== 'undefined' && module.exports) {
         $.i18n = $.i18n || i18n;
     }
     
-    root.i18n = root.i18n || i18n;
+    if (root.i18n) {
+    	conflictReference = root.i18n;
+    }
+    root.i18n = i18n;
 }

--- a/src/i18next.functions.js
+++ b/src/i18next.functions.js
@@ -207,3 +207,14 @@ function reload(cb) {
     resStore = {};
     setLng(currentLng, cb);
 }
+
+function noConflict() {
+    
+    window.i18next = window.i18n;
+
+    if (conflictReference) {
+        window.i18n = conflictReference;
+    } else {
+        delete window.i18n;
+    }
+}

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -9,7 +9,8 @@
       , replacementCounter = 0
       , languages = []
       , initialized = false
-      , sync = {};
+      , sync = {}
+      , conflictReference = null;
 
 
 

--- a/test/libs/fake.conflict.lib.js
+++ b/test/libs/fake.conflict.lib.js
@@ -1,0 +1,3 @@
+window.i18n = {
+	isFakeConflictingLib: true
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1228,6 +1228,19 @@ describe('i18next', function() {
     
     });
   
+    describe('Global variable conflict', function () {
+    
+      it('it should rename global "window.i18n" to "window.i18next"' + 
+        ' and restore window.i18n conflicting reference', function () {
+    
+        window.i18n.noConflict();
+    
+        expect(window.i18n.isFakeConflictingLib).to.be(true);
+        expect(window.i18next).to.be.an(Object);
+        expect(window.i18next.t).to.be.a(Function);
+      });
+    });
+  
   });
   describe('translation functionality', function() {
   

--- a/testacular.conf.js
+++ b/testacular.conf.js
@@ -15,6 +15,7 @@ files = [
   'test/libs/sinon-1.3.4.js',
   'test/libs/expect.js',
   'test/libs/jsfixtures.js',
+  'test/libs/fake.conflict.lib.js',
   'bin/i18next-latest.js',
   'test/test.js'
   


### PR DESCRIPTION
Added ```.noConflict()``` function to the public API. This works much like ```jQuery.noConflict()```.

When called, this method renames ```window.i18n``` to ```window.i18next```.

**Note:**
Even when there is no conflicting global, this method *will* rename the ```window.i18n``` global. Use carefully.