### PR TITLE
Change test command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "async": ">= 0.1.18",
     "lodash": ">= 0.5.x",
     "zipstream": ">=0.2.1",
-    "underscore": ">=0.2.1"
+    "underscore": ">=0.2.1",
+    "phantomjs": "^1.9.16"
   },
   "repository": "https://github.com/i18next/i18next/",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "repository": "https://github.com/i18next/i18next/",
   "scripts": {
-    "test": "testacular start"
+    "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "repository": "https://github.com/i18next/i18next/",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt && grunt testacular:ci"
   }
 }


### PR DESCRIPTION
Running existing command of `testacular start` fails with error `testacular: not found`. Swap this for `grunt test`.

*Note: the tests still seem to be failing - I will investigate further and possbly add more commits to this PR if it's obvious*