### PR TITLE
Fix fallback to default namepsace when namespace passed as an option

### DIFF
--- a/spec/init/init.namespace.spec.js
+++ b/spec/init/init.namespace.spec.js
@@ -59,6 +59,11 @@ describe('with namespace', function() {
         expect(i18n.t('ns.common:simple_en-US')).to.be('ok_from_en-US');
         expect(i18n.t('ns.common:simple_en')).to.be('ok_from_en');
         expect(i18n.t('ns.common:simple_dev')).to.be('ok_from_dev');
+
+        // ns in options
+        expect(i18n.t('simple_en-US', { ns: 'ns.common' })).to.be('ok_from_en-US');
+        expect(i18n.t('simple_en', { ns: 'ns.common' })).to.be('ok_from_en');
+        expect(i18n.t('simple_dev', { ns: 'ns.common' })).to.be('ok_from_dev');
       });
 
     });

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -408,6 +408,7 @@ function _find(key, options) {
                 }
             }
         } else {
+            options.ns = o.ns.defaultNs;
             found = _find(key, options); // fallback to default NS
         }
         options.isFallbackLookup = false;


### PR DESCRIPTION
Falling back to default namespace works ok with namespace as a prefix because the prefix is stripped as part of the pass through `_find` in the first instance. However if the namespace is defined as part of the options parameter then it is still present on the options for the second (fallback) call to `_find`.

Fix by setting the namespace explicitly to the default namespace when passing through to the fallback call to `_find`.