### PR TITLE
Expose cache busting option from configuration options

### DIFF
--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -109,6 +109,7 @@ sync = {
                 // load all needed stuff once
                 f.ajax({
                     url: url,
+                    cache: options.cache,
                     success: function(data, status, xhr) {
                         f.log('loaded: ' + url);
                         loadComplete(null, data);
@@ -128,6 +129,7 @@ sync = {
         var url = applyReplacement(options.resGetPath, { lng: lng, ns: ns });
         f.ajax({
             url: url,
+            cache: options.cache,
             success: function(data, status, xhr) {
                 f.log('loaded: ' + url);
                 done(null, data);


### PR DESCRIPTION
Because HTML5 AppCache will obviously not fetch from cache when busting the url for the resource bundle. 

I could not see any other place that uses cache = true for ajax helper which resides in i18next.helpers.js on line 198. 

The configuration options should probably also receive a rename since it is now just called "cache" to something more explicit. 