### PR TITLE
Default namespace options to expected structure

### DIFF
--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -9,7 +9,10 @@ var o = {
     fallbackNS: [],
     detectLngQS: 'setLng',
     detectLngFromLocalStorage: false,
-    ns: 'translation',
+    ns: {
+        namespaces: ['translation'],
+        defaultNs: 'translation'
+    },
     fallbackOnNull: true,
     fallbackOnEmpty: false,
     fallbackToDefaultNS: false,


### PR DESCRIPTION
There are places in code where the namespaces are referenced by `o.ns.namespaces` which throws an error if init has not been run - in particular on `init.addResourceBundle` throws "Cannot call method 'indexOf' of undefined", which is difficult to debug. Setting the default values as the expected structure prevents this error.

*Note: I would add a failing test, but it's not possible to "uninitialise" to create the required state. Sorry.*