### PR TITLE
Allow to fallback to key when trans string is empty

### DIFF
--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -16,11 +16,12 @@ var o = {
     fallbackOnNull: true,
     fallbackOnEmpty: false,
     fallbackToDefaultNS: false,
+    showKeyIfEmpty: false,
     nsseparator: ':',
     keyseparator: '.',
     selectorAttr: 'data-i18n',
     debug: false,
-    
+
     resGetPath: 'locales/__lng__/__ns__.json',
     resPostPath: 'locales/add/__lng__/__ns__',
 

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -320,7 +320,7 @@ function _find(key, options) {
             optionWithoutCount.lng = optionWithoutCount._origLng;
             delete optionWithoutCount._origLng;
             translated = translate(ns + o.nsseparator + key, optionWithoutCount);
-            
+
             return applyReplacement(translated, {
                 count: options.count,
                 interpolationPrefix: options.interpolationPrefix,
@@ -354,7 +354,7 @@ function _find(key, options) {
             value = value && value[keys[x]];
             x++;
         }
-        if (value !== undefined) {
+        if (value !== undefined && (!o.showKeyIfEmpty || value !== '')) {
             var valueType = Object.prototype.toString.apply(value);
             if (typeof value === 'string') {
                 value = applyReplacement(value, options);


### PR DESCRIPTION
I think it's sensible to display the key (sometimes people use English string or whichever default language they use as key) instead of an empty string.