### PR TITLE
Add isInitialized method.

### DIFF
--- a/src/i18next.api.js
+++ b/src/i18next.api.js
@@ -1,5 +1,6 @@
 // public api interface
 i18n.init = init;
+i18n.isInitialized = isInitialized;
 i18n.setLng = setLng;
 i18n.preload = preload;
 i18n.addResourceBundle = addResourceBundle;

--- a/src/i18next.init.js
+++ b/src/i18next.init.js
@@ -1,11 +1,11 @@
 function init(options, cb) {
-    
+
     if (typeof options === 'function') {
         cb = options;
         options = {};
     }
     options = options || {};
-    
+
     // override defaults with passed in options
     f.extend(o, options);
     delete o.fixLng; /* passed in each time */
@@ -101,4 +101,8 @@ function init(options, cb) {
     });
 
     if (deferred) return deferred.promise();
+}
+
+function isInitialized() {
+    return initialized;
 }


### PR DESCRIPTION
Hello, 

This is just a proposal, I still need to figure how to add unit tests :sweat_smile: 

I'm using i18next with browserify in several projects, they work fine separately, but once loaded on the same web page, calling `init` several times produces unexpected results, which seems to be normal given how it is intended to work. 

Right now I have a workaround using `hasResourceBundle` to call `init` only once, but it's not really clean. 

This is why I propose to add a `isInitialized` method to the public API. 
What do you think? 
If you find it interesting, I'll continue the work on this PR. 

Cheers, 
Alex. 