### PR TITLE
#386: support for adding timeout in configuration

### DIFF
--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -60,7 +60,7 @@ var o = {
     postProcess: undefined,
     parseMissingKey: undefined,
     missingKeyHandler: sync.postMissing,
-    timeout: 0,
+    ajaxTimeout: 0,
 
     shortcutFunction: 'sprintf' // or: defaultValue
 };

--- a/src/i18next.defaults.js
+++ b/src/i18next.defaults.js
@@ -60,6 +60,7 @@ var o = {
     postProcess: undefined,
     parseMissingKey: undefined,
     missingKeyHandler: sync.postMissing,
+    timeout: 0,
 
     shortcutFunction: 'sprintf' // or: defaultValue
 };

--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -119,7 +119,7 @@ sync = {
                     },
                     dataType: "json",
                     async : options.getAsync,
-                    timeout: options.timeout
+                    timeout: options.ajaxTimeout
                 });
             }    
         }
@@ -148,7 +148,7 @@ sync = {
             },
             dataType: "json",
             async : options.getAsync,
-            timeout: options.timeout
+            timeout: options.ajaxTimeout
         });
     },
 
@@ -197,7 +197,7 @@ sync = {
                 },
                 dataType: "json",
                 async : o.postAsync,
-                timeout: o.timeout
+                timeout: o.ajaxTimeout
             });
         }
     },

--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -118,7 +118,8 @@ sync = {
                         loadComplete('failed loading resource.json error: ' + error);
                     },
                     dataType: "json",
-                    async : options.getAsync
+                    async : options.getAsync,
+                    timeout: options.timeout
                 });
             }    
         }
@@ -146,7 +147,8 @@ sync = {
                 done(error, {});
             },
             dataType: "json",
-            async : options.getAsync
+            async : options.getAsync,
+            timeout: options.timeout
         });
     },
 
@@ -194,7 +196,8 @@ sync = {
                     f.log('failed posting missing key \'' + key + '\' to: ' + item.url);
                 },
                 dataType: "json",
-                async : o.postAsync
+                async : o.postAsync,
+                timeout: o.timeout
             });
         }
     },


### PR DESCRIPTION
Add the ability to set timeout in the ajax request.

I would like to be able to set timeout for the ajax requests when fetching the translations.
If the file path is down, then I would like the default fallback to kick in where i18next displays the string key.