### PR TITLE
Added official MIT header to license

### DIFF
--- a/license
+++ b/license
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2011 Jan Mühlemann
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "jamuhl",
   "name": "i18next-client",
+  "license": "MIT",
   "version": "1.9.0",
   "private": false,
   "main": "i18next.js",


### PR DESCRIPTION
Added the official license header according to http://opensource.org/licenses/MIT. This will be of great help for preventing legal issues for users of this library. Would be great if you can merge it.