### PR TITLE
remove unnecessary console log

### DIFF
--- a/src/i18next.init.js
+++ b/src/i18next.init.js
@@ -39,7 +39,6 @@ function init(options, cb) {
 
     languages = f.toLanguages(o.lng);
     currentLng = languages[0];
-    f.log('currentLng set to: ' + currentLng);
 
     if (o.useCookie && f.cookie.read(o.cookieName) !== currentLng){ //cookie is unset or invalid
         f.cookie.create(o.cookieName, currentLng, o.cookieExpirationTime, o.cookieDomain);


### PR DESCRIPTION
Hello,

Logging current language to the console `f.log('currentLng set to: ' + currentLng)` is a greate in development mode,  but in production or in test mode it kind of unneeded.

Here what I see in console when I run tests:
```
currentLng set to: en-US
  Topic Controller
loaded file: home/talgat/projects/applic/server/config/locales/translation-en-US.json
    GET `/api/discussions` (list)
currentLng set to: en-US
    ✓ responds 401 for unauthorized users
      when user is authenticated
currentLng set to: en-US
currentLng set to: en-US
      ✓ returns a json list of topics
currentLng set to: en-US
currentLng set to: en-US
// ...
```
I propose to remove this console log. What do you think?

Regards, 
Talgat.