### PR TITLE
Forward the error from sync fetch methods to the init callback function

### DIFF
--- a/src/i18next.init.js
+++ b/src/i18next.init.js
@@ -96,6 +96,8 @@ function init(options, cb) {
         resStore = store;
         initialized = true;
 
+        if (err) return cb(err);
+
         if (cb) cb(lngTranslate);
         if (deferred) deferred.resolve(lngTranslate);
     });

--- a/src/i18next.sync.js
+++ b/src/i18next.sync.js
@@ -13,15 +13,15 @@ sync = {
                         f.extend(store, fetched);
                         sync._storeLocal(fetched);
 
-                        cb(null, store);
+                        cb(err, store);
                     });
                 } else {
-                    cb(null, store);
+                    cb(err, store);
                 }
             });
         } else {
             sync._fetch(lngs, options, function(err, store){
-                cb(null, store);
+                cb(err, store);
             });
         }
     },
@@ -98,7 +98,7 @@ sync = {
         } else {
             // Call this once our translation has returned.
             var loadComplete = function(err, data) {
-                cb(null, data);
+                cb(err, data);
             };
 
             if(typeof options.customLoad == 'function'){


### PR DESCRIPTION
It works but it's far to be perfect ;)

The init callback function doesn't respect the standard : it should pass the err object as the first argument, and the 't' object as the second.

For the moment, the only way to distinguish error from translate object (t) is to test the type of the argument...

````
$.i18n.init(i18nOption, function(t){  
  // error handling...
  if (typeof(t) === 'string'){ 
    return console.error(t); 
  }

  // Continue if there isn't any error :)
});
````
