### PR TITLE
Runs multiple post processes for missing translations

### DIFF
--- a/spec/functions/functions.postprocessor.spec.js
+++ b/spec/functions/functions.postprocessor.spec.js
@@ -36,6 +36,10 @@ describe('postprocessing tranlation', function() {
       expect(i18n.t('simpleTest', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
     });
 
+    it('it should postprocess on missing value with multiple post processes', function() {
+      expect(i18n.t('notFound2', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
+    });
+
     describe('or setting it as default on init', function() {
 
       beforeEach(function(done) {

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -218,10 +218,10 @@ function _translate(potentialKeys, options) {
         notFound = applyReuse(notFound, options);
 
         if (postProcessorsToApply.length) {
-            var val = _getDefaultValue(key, options);
+            found = _getDefaultValue(key, options);
             postProcessorsToApply.forEach(function(postProcessor) {
                 if (postProcessors[postProcessor]) {
-                    found = postProcessors[postProcessor](val, key, options);
+                    found = postProcessors[postProcessor](found, key, options);
                 }
             });
         }

--- a/test/server/i18next.functions.spec.js
+++ b/test/server/i18next.functions.spec.js
@@ -174,6 +174,10 @@ describe('i18next.functions', function() {
         expect(i18n.t('simpleTest', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
       });
   
+      it('it should postprocess on missing value with multiple post processes', function() {
+        expect(i18n.t('notFound2', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
+      });
+  
       describe('or setting it as default on init', function() {
   
         beforeEach(function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -1029,6 +1029,10 @@ describe('i18next', function() {
           expect(i18n.t('simpleTest', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
         });
     
+        it('it should postprocess on missing value with multiple post processes', function() {
+          expect(i18n.t('notFound2', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
+        });
+    
         describe('or setting it as default on init', function() {
     
           beforeEach(function(done) {


### PR DESCRIPTION
I found out that multiple post processes are not applied for the case of missing value. This should fix it. Let me know if I need to add anything.