### PR TITLE
Reimplement XSS-vulnerable sequential replacement code

### DIFF
--- a/spec/translate/translate.interpolation.spec.js
+++ b/spec/translate/translate.interpolation.spec.js
@@ -128,7 +128,8 @@ describe('default i18next way - with escaping interpolated arguments per default
         interpolationTest1: 'added __toAdd__',
         interpolationTest5: 'added __toAddHTML__',
         interpolationTest6: 'added __child.oneHTML__',
-        interpolationTest7: 'added __toAddHTML__ __toAdd__'
+        interpolationTest7: 'added __toAddHTML__ __toAdd__',
+        interpolationTest8: 'added __toAdd1__ __toAdd2__',
       } 
     }
   };
@@ -147,6 +148,10 @@ describe('default i18next way - with escaping interpolated arguments per default
   it("it should not escape when HTML is suffixed", function() {
     expect(i18n.t('interpolationTest5', {toAdd: '<html>'})).to.be('added <html>');
     expect(i18n.t('interpolationTest6', { child: { one: '<1>'}})).to.be('added <1>');
+  });
+
+  it("should not accept interpolations from inside interpolations", function() {
+      expect(i18n.t('interpolationTest8', { toAdd1: '__toAdd2HTML__', toAdd2: '<html>'})).to.be('added __toAdd2HTML__ &lt;html&gt;');
   });
 
   it("it should support both escaping and not escaping HTML", function() {


### PR DESCRIPTION
The interpolation resolution code inside translate.js is looping over
each key in the interpolation dictionary and applying the replacements
one at a time. This means that if untrusted user input contains the name
of another key in the dictionary, for example `'__lastName__'`, an
unexpected interpolation can happen:

````
i18n.t('__firstName__ __lastName__', {
    firstName: '__lastName__',
    lastName: 'foo',
});
// equals "foo foo"
````

This combines with the unescaping suffix feature to cause XSS injection,
even with escapeInterpolation set to true. For example,

````
i18n.t('__firstName__ __lastName__', {
    escapeInterpolation: true,
    firstName: '__lastNameHTML__',
    lastName: '<script>',
});
// equals "<script> &lt;script&gt;"
````

This PR fixes that by performing the replacements *all at the same
time*. This means that untrusted input cannot cause these unexpected
extra interpolations.