### PR TITLE
Fix use of sprintf as shortcutFunction when first argument falsey

### DIFF
--- a/spec/translate/translate.sprintf.spec.js
+++ b/spec/translate/translate.sprintf.spec.js
@@ -7,7 +7,8 @@ describe('using sprintf', function() {
       translation: {                      
         interpolationTest1: 'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
         interpolationTest2: 'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
-        interpolationTest3: 'The last letter of the english alphabet is %s'
+        interpolationTest3: 'The last letter of the english alphabet is %s',
+        interpolationTest4: 'Water freezes at %d degrees'
       } 
     }
   };
@@ -25,6 +26,7 @@ describe('using sprintf', function() {
   it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
     expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
     expect(i18n.t('interpolationTest3', 'z')).to.be('The last letter of the english alphabet is z');
+    expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
   });
   
 });

--- a/src/i18next.translate.js
+++ b/src/i18next.translate.js
@@ -99,11 +99,14 @@ function exists(key, options) {
 }
 
 function translate(key, options) {
-    options = options || {};
-
     if (!initialized) {
         f.log('i18next not finished initialization. you might have called t function before loading resources finished.')
-        return options.defaultValue || '';
+
+        if (options && options.defaultValue) {
+            return options.detaultValue;
+        } else {
+            return '';
+        }
     };
     replacementCounter = 0;
     return _translate.apply(null, arguments);
@@ -129,7 +132,7 @@ function _injectSprintfProcessor() {
 }
 
 function _translate(potentialKeys, options) {
-    if (options && typeof options !== 'object') {
+    if (typeof options !== 'undefined' && typeof options !== 'object') {
         if (o.shortcutFunction === 'sprintf') {
             // mh: gettext like sprintf syntax found, automatically create sprintf processor
             options = _injectSprintfProcessor.apply(null, arguments);

--- a/test/backward/compat.js
+++ b/test/backward/compat.js
@@ -2028,7 +2028,8 @@ describe('i18next', function() {
             translation: {                      
               interpolationTest1: 'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
               interpolationTest2: 'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
-              interpolationTest3: 'The last letter of the english alphabet is %s'
+              interpolationTest3: 'The last letter of the english alphabet is %s',
+              interpolationTest4: 'Water freezes at %d degrees'
             } 
           }
         };
@@ -2046,6 +2047,7 @@ describe('i18next', function() {
         it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
           expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
           expect(i18n.t('interpolationTest3', 'z')).to.be('The last letter of the english alphabet is z');
+          expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
         });
         
       });

--- a/test/server/i18next.translate.spec.js
+++ b/test/server/i18next.translate.spec.js
@@ -712,7 +712,8 @@ describe('i18next.translate', function() {
           translation: {                      
             interpolationTest1: 'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
             interpolationTest2: 'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
-            interpolationTest3: 'The last letter of the english alphabet is %s'
+            interpolationTest3: 'The last letter of the english alphabet is %s',
+            interpolationTest4: 'Water freezes at %d degrees'
           } 
         }
       };
@@ -730,6 +731,7 @@ describe('i18next.translate', function() {
       it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
         expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
         expect(i18n.t('interpolationTest3', 'z')).to.be('The last letter of the english alphabet is z');
+        expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
       });
       
     });

--- a/test/test.js
+++ b/test/test.js
@@ -2022,7 +2022,8 @@ describe('i18next', function() {
             translation: {                      
               interpolationTest1: 'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
               interpolationTest2: 'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
-              interpolationTest3: 'The last letter of the english alphabet is %s'
+              interpolationTest3: 'The last letter of the english alphabet is %s',
+              interpolationTest4: 'Water freezes at %d degrees'
             } 
           }
         };
@@ -2040,6 +2041,7 @@ describe('i18next', function() {
         it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
           expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
           expect(i18n.t('interpolationTest3', 'z')).to.be('The last letter of the english alphabet is z');
+          expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
         });
         
       });


### PR DESCRIPTION
Do not overwrite first sprintf argument when it is falsey. Also,
fix bad falsey check in _translate.

Resolves #451