### PR TITLE
Include key and value in 'added' event if adding a single resource

### DIFF
--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -49,7 +49,7 @@ class ResourceStore extends EventEmitter {
 
     utils.setPath(this.data, path, value);
 
-    if (!options.silent) this.emit('added', lng, ns);
+    if (!options.silent) this.emit('added', lng, ns, key, value);
   }
 
   addResources(lng, ns, resources) {


### PR DESCRIPTION
I've got a use case where some users are allowed to update the translations, which works fine using
`i18next.addResource(i18next.language, ns, key, translation)`. I'd like to listen to these changes, but unfortunately the `added` event emitted by `i18next.store` (docs seem to be incorrect [stating that it's emitted by i18next](http://i18next.com/docs/api/#on-added)) doesn't specify the key being added/updated.

This PR makes event listeners also receive key, along with value in case it could be useful. The latter could be removed if undesired.