### PR TITLE
Fixes detection when using both context and pluralization and context not found.

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -201,11 +201,17 @@ class Translator extends EventEmitter {
           let finalKey = key;
           let finalKeys = [finalKey];
 
+          let pluralSuffix;
+          if (needsPluralHandling) pluralSuffix = this.pluralResolver.getSuffix(code, options.count);
+
+          // fallback for plural if context not found
+          if (needsPluralHandling && needsContextHandling) finalKeys.push(finalKey + pluralSuffix);
+
           // get key for context if needed
           if (needsContextHandling) finalKeys.push(finalKey += `${this.options.contextSeparator}${options.context}`);
 
           // get key for plural if needed
-          if (needsPluralHandling) finalKeys.push(finalKey += this.pluralResolver.getSuffix(code, options.count));
+          if (needsPluralHandling) finalKeys.push(finalKey += pluralSuffix);
 
           // iterate over finalKeys starting with most specific pluralkey (-> contextkey only) -> singularkey only
           let possibleKey;

--- a/test/translator/translator.translate.combination.spec.js
+++ b/test/translator/translator.translate.combination.spec.js
@@ -15,7 +15,13 @@ describe('Translator', () => {
           translation: {
             'key1': 'hello world',
             'key2': 'It is: $t(key1)',
-            'key3': 'It is: {{val}}'
+            'key3': 'It is: {{val}}',
+
+            // context with pluralization
+            test: 'test_en',
+            test_plural: 'tests_en',
+            test_male: 'test_male_en',
+            test_male_plural: 'tests_male_en',
           }
         }
       });
@@ -26,6 +32,7 @@ describe('Translator', () => {
         pluralResolver: new PluralResolver(lu, {prepend: '_'}),
         interpolator: new Interpolator()
       }, {
+        contextSeparator: '_',
         ns: 'translation',
         defaultNS: 'translation',
         interpolation: {}
@@ -36,7 +43,13 @@ describe('Translator', () => {
     var tests = [
       // interpolation and nesting in var
       { args: ['key2'], expected: 'It is: hello world' },
-      { args: ['key3', { val: '$t(key1)' }], expected: 'It is: hello world' }
+      { args: ['key3', { val: '$t(key1)' }], expected: 'It is: hello world' },
+
+      // context with pluralization
+      {args: ['test', { context: 'unknown', count: 1 }], expected: 'test_en'},
+      {args: ['test', { context: 'unknown', count: 2 }], expected: 'tests_en'},
+      {args: ['test', { context: 'male', count: 1 }], expected: 'test_male_en'},
+      {args: ['test', { context: 'male', count: 2 }], expected: 'tests_male_en'},
     ];
 
     tests.forEach((test) => {

--- a/test/translator/translator.translate.context.spec.js
+++ b/test/translator/translator.translate.context.spec.js
@@ -44,6 +44,7 @@ describe('Translator', () => {
     });
 
     var tests = [
+      {args: ['translation:test', { context: 'unknown' }], expected: 'test_en'},
       {args: ['translation:test', { context: 'male' }], expected: 'test_male_en'},
       {args: ['translation:test', { context: 'female' }], expected: 'test_female_en'},
       {args: ['translation:test', { context: 'male', lngs: ['en-US', 'en'] }], expected: 'test_male_en'},


### PR DESCRIPTION
Fixes detection when using both context and pluralization and context not found. It now will fallback to default plural if no context is found.

Possible key list order:
key_context_plural
key_context
key_plural
key