### PR TITLE
Change defaultValue behavior

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -95,12 +95,14 @@ class Translator extends EventEmitter {
     }
     // string, empty or null
     else {
+      let usedKey = false;
       // fallback value
       if (!this.isValidLookup(res) && options.defaultValue !== undefined) {
         res = options.defaultValue;
       }
       if (!this.isValidLookup(res)) {
         res = key;
+        usedKey = true;
 
         this.logger.log('missingKey', lng, namespace, key, res);
 

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -95,23 +95,16 @@ class Translator extends EventEmitter {
     }
     // string, empty or null
     else {
-      let usedDefault = false,
-          usedKey = false;
-
       // fallback value
-      if (!this.isValidLookup(res) && options.defaultValue) {
-        usedDefault = true;
+      if (!this.isValidLookup(res) && options.defaultValue !== undefined) {
         res = options.defaultValue;
       }
       if (!this.isValidLookup(res)) {
-        usedKey = true;
         res = key;
-      }
 
-      // save missing
-      if (usedKey || usedDefault) {
         this.logger.log('missingKey', lng, namespace, key, res);
 
+        // save missing
         if (this.options.saveMissing) {
           var lngs = [];
           if (this.options.saveMissingTo === 'fallback' && this.options.fallbackLng && this.options.fallbackLng[0]) {


### PR DESCRIPTION
I figured I'd use `i18next.t()` to translate some optional strings after finding the `defaultValue` option. It didn't behave as I'd expected though, which would be that passing an empty string or null would result in nothing being returned if the translation key hadn't been defined. Instead I always got the key back, along with a `missingKey` log message.

Considering the fact that the developer has explicitly specified a default fallback value I would assume that missing translations are somewhat expected and therefore shouldn't log anything.

This PR changes the behaviour to only consider translations as missing if no defaultValue has been provided.

I also made the presence checking of the defaultValue stricter so that all values except for `undefined` is considered and then checked against with `isValidLookup()`, allowing them to be ignored through the `returnNull`and `returnEmptyString` options.
