### PR TITLE
Only add language to preload array when not yet present

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -231,8 +231,15 @@ class I18n extends EventEmitter {
 
   loadLanguages(lngs, callback) {
     if (typeof lngs === 'string') lngs = [lngs];
-    this.options.preload = this.options.preload ? this.options.preload.concat(lngs) : lngs;
+    var preloaded = this.options.preload || [];
 
+    var newLngs = lngs.filter(function (lng) {
+      return preloaded.indexOf(lng) < 0;
+    });
+    // Exit early if all given languages are already preloaded
+    if (!newLngs.length) return callback();
+
+    this.options.preload = preloaded.concat(newLngs);
     this.loadResources(callback);
   }
 


### PR DESCRIPTION
On each invocation, the function returned by `i18next.handle` adds the given language to the `i18next.options.preload` array without checking for doubles, and then goes on to load resources for all elements of that array. Over time, the preload array becomes huge, and because it is constantly iterated, this leads to a noticeable linear decrease in performance.

This PR is an attempt to fix that situation. It will only add a language to the `i18next.options.preload` array when it is not yet present, and it will call `loadResources` only when a new language has actually been added.