### PR TITLE
Allow falsy defaultValue

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -734,7 +734,7 @@
 	              usedKey = false;
 
 	          // fallback value
-	          if (!this.isValidLookup(res) && options.defaultValue) {
+	          if (!this.isValidLookup(res) && 'defaultValue' in options) {
 	            usedDefault = true;
 	            res = options.defaultValue;
 	          }


### PR DESCRIPTION
Need to allow falsy defaultValue such as '' or null to be used in conjunction with options.returnEmptyString or options.returnNull