### PR TITLE
Key based fallback plural support

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -106,6 +106,9 @@ class Translator extends EventEmitter {
       if (!this.isValidLookup(res)) {
         usedKey = true;
         res = key;
+        
+        // Fall back on plural hint
+        if (options.pluralHint && options.count && options.count > 1) res = options.pluralHint;
       }
 
       // save missing


### PR DESCRIPTION
I'd recommend to have pluralHint option so that i18next will fallback on this value as this is a very frequently used `gettext` option. With this, 
```
_n("{{count}} apple", "{{count}} apples", items);
```
becomes
```
i18n.t('{{count}} apple', {
  count: items,
  pluralHint: '{{count}} apples'
});
```