### PR TITLE
Fix Interpolator formatter exception error propagation due to not reset RegExp indices

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -30,6 +30,15 @@ class Interpolator {
     this.nestingSuffix = iOpts.nestingSuffix ? utils.regexEscape(iOpts.nestingSuffix) : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
 
     // the regexp
+    this.resetRegExp();
+  }
+
+  reset() {
+    if (this.options) this.init(this.options);
+  }
+
+  resetRegExp() {
+    // the regexp
     const regexpStr = this.prefix + '(.+?)' + this.suffix;
     this.regexp = new RegExp(regexpStr, 'g');
 
@@ -38,10 +47,6 @@ class Interpolator {
 
     const nestingRegexpStr = this.nestingPrefix + '(.+?)' + this.nestingSuffix;
     this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
-  }
-
-  reset() {
-    if (this.options) this.init(this.options);
   }
 
   interpolate(str, data, lng) {
@@ -60,6 +65,8 @@ class Interpolator {
 
       return this.format(utils.getPath(data, k), f, lng);
     }
+
+    this.resetRegExp();
 
     // unescape if has unescapePrefix/Suffix
     while(match = this.regexpUnescape.exec(str)) {

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -36,6 +36,7 @@ describe('Interpolator', () => {
           format: function(value, format, lng) {
             if (format === 'uppercase') return value.toUpperCase();
             if (format === 'lowercase') return value.toLowerCase();
+            if (format === 'throw') throw new Error('Formatter error');
             return value;
           }
         }
@@ -51,6 +52,16 @@ describe('Interpolator', () => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
+    });
+
+    it('correctly manage exception in formatter', () => {
+      expect(() => {
+        ip.interpolate.apply(ip,  ['test {{test, throw}}', {test: 'up'}])
+      }).to.throw(Error, 'Formatter error');
+
+      const test = tests[0];
+
+      expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
     });
   });
 


### PR DESCRIPTION
If we define a custom formatter function which raises an exception, this one can be handled but let a wrong Interpolator state leading to an error on the next translation loop.