### PR TITLE
Fix Interpolator.escapeValue defaulting to undefined in some cases

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -17,7 +17,7 @@ class Interpolator {
 
     const iOpts = options.interpolation;
 
-    this.escapeValue = iOpts.escapeValue;
+    this.escapeValue = iOpts.escapeValue !== undefined ? iOpts.escapeValue : true;
 
     this.prefix = iOpts.prefix ? utils.regexEscape(iOpts.prefix) : iOpts.prefixEscaped || '{{';
     this.suffix = iOpts.suffix ? utils.regexEscape(iOpts.suffix) : iOpts.suffixEscaped || '}}';

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -26,6 +26,71 @@ describe('Interpolator', () => {
     });
   });
 
+  describe('interpolate() - options', () => {
+    var tests = [
+      {
+        options: {interpolation: {}},
+        expected: {escapeValue: true, prefix: '{{', suffix: '}}', formatSeparator: ',', unescapePrefix: '-', unescapeSuffix: '', nestingPrefix: '\\$t\\(', nestingSuffix: '\\)' }
+      },
+      {
+        options: {},
+        expected: {escapeValue: true, prefix: '{{', suffix: '}}', formatSeparator: ',', unescapePrefix: '-', unescapeSuffix: '', nestingPrefix: '\\$t\\(', nestingSuffix: '\\)' }
+      },
+      {
+        description: 'uses and regex escapes prefix and suffix',
+        options: {interpolation: {prefix: '(*(', suffix: ')*)', prefixEscaped: '\\(\\^\\(', suffixEscaped: ')\\^\\)'}},
+        expected: {prefix: '\\(\\*\\(', suffix: '\\)\\*\\)'}
+      },
+      {
+        description: 'uses prefixEscaped and suffixEscaped if prefix and suffix not provided',
+        options: {interpolation: {prefixEscaped: '<<', suffixEscaped: '>>'}},
+        expected: {prefix: '<<', suffix: '>>'}
+      },
+      {
+        description: 'uses unescapePrefix if provided',
+        options: {interpolation: {unescapePrefix: '=>'}},
+        expected: {unescapePrefix: '=>', unescapeSuffix: ''}
+      },
+      {
+        description: 'uses unescapeSuffix if provided',
+        options: {interpolation: {unescapeSuffix: '<='}},
+        expected: {unescapePrefix: '', unescapeSuffix: '<='}
+      },
+      {
+        description: 'uses unescapeSuffix if both unescapePrefix and unescapeSuffix are provided',
+        options: {interpolation: {unescapePrefix: '=>', unescapeSuffix: '<='}},
+        expected: {unescapePrefix: '', unescapeSuffix: '<='}
+      },
+      {
+        description: 'uses and regex escapes nestingPrefix and nestingSuffix',
+        options: {interpolation: {nestingPrefix: 'nest(', nestingSuffix: ')nest', nestingPrefixEscaped: 'neste\\(', nestingSuffixEscaped: '\\)neste'}},
+        expected: {nestingPrefix: 'nest\\(', nestingSuffix: '\\)nest'}
+      },
+      {
+        description: 'uses nestingPrefixEscaped and nestingSuffixEscaped if nestingPrefix and nestingSuffix not provided',
+        options: {interpolation: {nestingPrefixEscaped: 'neste\\(', nestingSuffixEscaped: '\\)neste'}},
+        expected: {nestingPrefix: 'neste\\(', nestingSuffix: '\\)neste'}
+      }
+    ];
+
+    tests.forEach((test) => {
+
+      describe(test.description || 'when called with ' + JSON.stringify(test.options), () => {
+        var ip;
+
+        before(() => {
+          ip = new Interpolator(test.options);
+        });
+
+        Object.keys(test.expected).forEach((key) => {
+          it(key + ' is set correctly', () => {
+            expect(ip[key]).to.eql(test.expected[key]);
+          });
+        });
+      });
+    });
+  });
+
   describe('interpolate() - with formatter', () => {
     var ip;
 


### PR DESCRIPTION
I found that if I pass any `interpolation` options without including `escapeValue`, `this.escapeValue` will get set to `undefined` in `Interpolator`. The documentation indicates `escapeValue` defaults to `true`, so this could cause variables to not be escaped as expected in some cases.

This config, for example, will result in `i18next` not escaping variables as expected:
```
i18next.init({
  interpolation: {
    prefix: "__",
    suffix: "__"
  },
  ...
});
```
It's worth noting that it could potentially be a XSS security issue for users of `i18next` if they believe variables are getting escaped when they actually aren't.