### PR TITLE
Add module entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "i18next internationalization framework",
   "main": "./index.js",
   "jsnext:main": "dist/es/index.js",
+  "module": "dist/es/index.js",
   "keywords": [
     "i18next",
     "internationalization",


### PR DESCRIPTION
See https://github.com/webpack/webpack/issues/1979

This seems to be the preferred way to indicate where ES6 modules reside now.
