### PR TITLE
fix #873 allow desctructuring for es6 modules imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,19 @@
 import i18next from './i18next';
 
 export default i18next;
+
+export const changeLanguage = i18next.changeLanguage.bind(i18next);
+export const cloneInstance = i18next.cloneInstance.bind(i18next);
+export const createInstance = i18next.createInstance.bind(i18next);
+export const dir = i18next.dir.bind(i18next);
+export const exists = i18next.exists.bind(i18next);
+export const getFixedT = i18next.getFixedT.bind(i18next);
+export const init = i18next.init.bind(i18next);
+export const loadLanguages = i18next.loadLanguages.bind(i18next);
+export const loadNamespaces = i18next.loadNamespaces.bind(i18next);
+export const loadResources = i18next.loadResources.bind(i18next);
+export const off = i18next.off.bind(i18next);
+export const on = i18next.on.bind(i18next);
+export const setDefaultNamespace = i18next.setDefaultNamespace.bind(i18next);
+export const t = i18next.t.bind(i18next);
+export const use = i18next.use.bind(i18next);


### PR DESCRIPTION
export all functions off i18next to allow desctructuring i18next imports `import { t } from 'i18next';`