### PR TITLE
Fix: iterating over object's own properties

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -96,7 +96,9 @@ class Translator extends EventEmitter {
         let copy = (resType === '[object Array]') ? [] : {}; // apply child translation on a copy
 
         for (let m in res) {
-          copy[m] = this.translate(`${key}${keySeparator}${m}`, {...options, ...{joinArrays: false, ns: namespaces}});
+          if(res.hasOwnProperty(m)) {
+            copy[m] = this.translate(`${key}${keySeparator}${m}`, {...options, ...{joinArrays: false, ns: namespaces}});
+          }
         }
         res = copy;
       }


### PR DESCRIPTION
Hello,

When the result of a translation is an object (_Object, Array, etc_) and the copy is done, the translation function loops over all object's properties, even those that might be inherited and could not not have a translation.

We should use `hasOwnProperty` to not translate these properties.