### PR TITLE
Issue 906

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -14,16 +14,20 @@ function getLastOfPath(object, path, Empty) {
     return (key && key.indexOf('###') > -1) ? key.replace(/###/g, '.') : key;
   }
 
+  function canNotTraverseDeeper() {
+    return !object || typeof object === 'string';
+  }
+
   let stack = (typeof path !== 'string') ? [].concat(path) : path.split('.');
   while(stack.length > 1) {
-    if (!object) return {};
+    if (canNotTraverseDeeper()) return {};
 
     let key = cleanKey(stack.shift());
     if (!object[key] && Empty) object[key] = new Empty();
     object = object[key];
   }
 
-  if (!object) return {};
+  if (canNotTraverseDeeper()) return {};
   return {
     obj: object,
     k: cleanKey(stack.shift())

--- a/test/translator/translator.translate.systemProperties.spec.js
+++ b/test/translator/translator.translate.systemProperties.spec.js
@@ -1,0 +1,68 @@
+import Translator from '../../src/Translator';
+import ResourceStore from '../../src/ResourceStore.js';
+import LanguageUtils from '../../src/LanguageUtils';
+import PluralResolver from '../../src/PluralResolver';
+import Interpolator from '../../src/Interpolator';
+
+// These tests orignated from issues:
+//
+// https://github.com/i18next/i18next/issues/906
+// https://github.com/i18next/i18next-xhr-backend/issues/258
+//
+// should ignore non-string properties when finding 'deep' translations
+// (ex: `.length`, `.search`)
+// when a fallback is needed to find the actual definition of that property
+
+describe('Translator', () => {
+
+  describe('translate()', () => {
+    var t;
+
+    before(() => {
+      const rs = new ResourceStore({
+        en: {
+          translation: {
+            test: {
+              length: 'test_length',
+              search: 'test_search'
+            }
+          }
+        },
+        de: {
+          translation: {
+            test: 'test_de'
+          }
+        }
+      });
+      const lu = new LanguageUtils({ fallbackLng: 'en' });
+      t = new Translator({
+        resourceStore: rs,
+        languageUtils: lu,
+        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
+        interpolator: new Interpolator()
+      }, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true
+        }
+      });
+      t.changeLanguage('de');
+    });
+
+    var tests = [
+      {args: ['test', { lng: 'de', nsSeparator: '.' }], expected: 'test_de'},
+      {args: ['test.length', { lng: 'de', nsSeparator: '.' }], expected: 'test_length'},
+      {args: ['test.search', { lng: 'de', nsSeparator: '.' }], expected: 'test_search'}
+    ];
+
+    tests.forEach((test) => {
+      it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+        expect(t.translate.apply(t, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
# Changes:

* Added unit tests to demonstrate an issue where properties of a string could be returned when resolving a deep key.
* Logic change: When recursing into object properties to resolve "deep" keys, do not try to use properties on strings.

# Resolves Issues:

* #906 
* https://github.com/i18next/i18next-xhr-backend/issues/258

-----

I stared at this for a while and originally though I could have `Translator.isValidLookup()` just return `false` if the resolved object was not a string, but this caused a lot of issues with the `returnObjects` options, since in some cases an object tree is OK to return.

The `utils.getLastOfPath()` function ended up being the simplest and least intrusive place to change the logic that I could find.