### PR TITLE
Add nest option to translation function

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -173,7 +173,9 @@ class Translator extends EventEmitter {
     res = this.interpolator.interpolate(res, data, this.language);
 
     // nesting
-    res = this.interpolator.nest(res, (...args) => { return this.translate.apply(this, args); }, options);
+    if (options.nest !== false) {
+      res = this.interpolator.nest(res, (...args) => { return this.translate.apply(this, args); }, options);
+    }
 
     if (options.interpolation) this.interpolator.reset();
 

--- a/test/translator/translator.translate.combination.spec.js
+++ b/test/translator/translator.translate.combination.spec.js
@@ -45,6 +45,9 @@ describe('Translator', () => {
       { args: ['key2'], expected: 'It is: hello world' },
       { args: ['key3', { val: '$t(key1)' }], expected: 'It is: hello world' },
 
+      // disable nesting while interpolation
+      { args: ['key3', { val: '$t(key1)', nest: false }], expected: 'It is: $t(key1)' },
+
       // context with pluralization
       {args: ['test', { context: 'unknown', count: 1 }], expected: 'test_en'},
       {args: ['test', { context: 'unknown', count: 2 }], expected: 'tests_en'},


### PR DESCRIPTION
This PR adds a new option while running translation function.
- nest: if nest === false, nesting at interpolations will be disabled in this translation.

Example:
```js
i18next.t('result', {
  userInput: '$t(result)',
  result: 'random value',
  nest: false,
});
```
```json
{
    "result": "Your input is {{userInput}} and the execution result is {{result}}"
}
```
The result of this will be `Your input is $t(result) and the execution result is random value` instead of a `RangeError: Maximum call stack size exceeded`.

Note: This option is disabled by default, you need to call it explicitly with false as parameter to disable nesting. Any other value than false will not enable this option.

---

Closes: #917 