### PR TITLE
Fix languageChanged not getting emitted on initial load.

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -205,10 +205,10 @@ class I18n extends EventEmitter {
   }
 
   changeLanguage(lng, callback) {
-    const done = (err) => {
-      if (lng) {
-        this.emit('languageChanged', lng);
-        this.logger.log('languageChanged', lng);
+    const done = (err, l) => {
+      if (l) {
+        this.emit('languageChanged', l);
+        this.logger.log('languageChanged', l);
       }
 
       if (callback) callback(err, (...args) => this.t(...args));
@@ -225,7 +225,7 @@ class I18n extends EventEmitter {
       }
 
       this.loadResources((err) => {
-        done(err);
+        done(err, l);
       });
     };
 


### PR DESCRIPTION
The async support broke changeLanguage() function, so that languageChanged would not get emmitted, unless language was directly given to the function as parameter. Thus language detectors would not trigger the event.