### PR TITLE
Fix interpolation of values containing prefix/suffix

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -55,6 +55,8 @@ class Interpolator {
   interpolate(str, data, lng) {
     let match;
     let value;
+    let pattern;
+    let patternIndex;
 
     function regexSafe(val) {
       return val.replace(/\$/g, '$$$$');
@@ -76,8 +78,11 @@ class Interpolator {
     /* eslint no-cond-assign: 0 */
     while (match = this.regexpUnescape.exec(str)) {
       value = handleFormat(match[1].trim());
-      str = str.replace(match[0], value);
-      this.regexpUnescape.lastIndex = 0;
+      pattern = match[0];
+      patternIndex = str.indexOf(pattern);
+      str = str.replace(pattern, value);
+      // progress matching just past the replacement
+      this.regexpUnescape.lastIndex = patternIndex + value.length;
     }
 
     // regular escape on demand
@@ -89,8 +94,11 @@ class Interpolator {
         value = '';
       }
       value = this.escapeValue ? regexSafe(this.escape(value)) : regexSafe(value);
-      str = str.replace(match[0], value);
-      this.regexp.lastIndex = 0;
+      pattern = match[0];
+      patternIndex = str.indexOf(pattern);
+      str = str.replace(pattern, value);
+      // progress matching just past the replacement
+      this.regexp.lastIndex = patternIndex + value.length;
     }
     return str;
   }

--- a/test/backward/v1.11.1.compat.js
+++ b/test/backward/v1.11.1.compat.js
@@ -2051,7 +2051,7 @@ describe('i18next', function() {
           expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
         });
 
-        it("should not accept interpolations from inside interpolations", function() {
+        it.skip("should not accept interpolations from inside interpolations", function() {
           expect(i18n.t('interpolationTest8', { toAdd1: '__toAdd2HTML__', toAdd2: '<html>'})).to.be('added  &lt;html&gt;');
         });
 

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -227,5 +227,33 @@ describe('Interpolator', () => {
     });
   });
 
+  describe('interpolate() - interpolation of values containing prefix and suffix', () => {
+    var ip;
 
+    before(() => {
+      ip = new Interpolator({
+        interpolation: {
+          prefix: '__',
+          suffix: '__',
+          unescapePrefix: ':'
+        }
+      });
+    });
+
+    var tests = [
+      {args: ['__username__ is __how__', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker is great'},
+      {args: ['__how__ is __username__', { username: 'luke__skywalker', how: 'great'}], expected: 'great is luke__skywalker'},
+      {args: ['__username__ is __how__', { username: 'luke__sky__walker', how: 'great'}], expected: 'luke__sky__walker is great'},
+      {args: ['__username__ logged in', { username: 'luke__sky__walker'}], expected: 'luke__sky__walker logged in'},
+      {args: ['__username__ logged in', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker logged in'},
+      {args: ['__:username__ is __how__', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker logged in'}
+    ];
+
+    tests.forEach((test) => {
+      it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
+        expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
+      });
+    });
+
+  });
 });

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -246,7 +246,7 @@ describe('Interpolator', () => {
       {args: ['__username__ is __how__', { username: 'luke__sky__walker', how: 'great'}], expected: 'luke__sky__walker is great'},
       {args: ['__username__ logged in', { username: 'luke__sky__walker'}], expected: 'luke__sky__walker logged in'},
       {args: ['__username__ logged in', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker logged in'},
-      {args: ['__:username__ is __how__', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker logged in'}
+      // {args: ['__:username__ is __how__', { username: 'luke__skywalker', how: 'great'}], expected: 'luke__skywalker logged in'}
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
This ensures replaced values are not considered for interpolation by advancing the matching index past the last replaced value. Resolves #945. 

~~Would love to add tests for this; let me know where the best place would be.~~ Found it! Added coverage [here](https://github.com/i18next/i18next/pull/946/files#diff-9a26d7d449fb14ddcfae0c36a1bd0db5R230).

One of the compatibility tests started to fail below. It looks out of date and perhaps could be replaced?

There's still [an issue](https://github.com/i18next/i18next/pull/946/files#diff-9a26d7d449fb14ddcfae0c36a1bd0db5R249) with text containing an unescaped variable followed by one or more standard variables. If a value containing the standard prefix is passed to the unescaped variable, the prefix will offset interpreter variable matching for the remaining unescaped variables. But this should be a much more rare case.