### PR TITLE
getFixedT lng parameter of array type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules
 node_modules/**/*
 coverage/**/*
 dist/**/*
+
+# Ignore IntelliJ based IDEs project files
+.idea

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -242,10 +242,15 @@ class I18n extends EventEmitter {
     const fixedT = (key, opts = {}) => {
       const options = { ...opts };
       options.lng = options.lng || fixedT.lng;
+      options.lngs = options.lngs || fixedT.lngs;
       options.ns = options.ns || fixedT.ns;
       return this.t(key, options);
     };
-    fixedT.lng = lng;
+    if (typeof lng === 'string') {
+      fixedT.lng = lng;
+    } else {
+      fixedT.lngs = lng;
+    }
     fixedT.ns = ns;
     return fixedT;
   }


### PR DESCRIPTION
As mentioned in [documentation](https://www.i18next.com/api.html#getfixedt):

> Both params could be arrays of languages or namespaces and will be treated as fallbacks in that case.

Also I'm confused about "will be treated as fallbacks in that case" part because parameters of `getFixedT` are not used to fallback language or namespace. 