### PR TITLE
Missing bindings to this when using ES6 destructuring import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/commonjs/index.js').default;
+module.exports = require('./dist/commonjs/index.js');


### PR DESCRIPTION
Hello! Thanks for the nice library. I use it in my project for a long time, but today I found one issue I think we need to fix.

Using NodeJS v8.0.0 with babel-core@6.25.0, this:

```javascript
import { changeLanguage } from "i18next";

// ...

changeLanguage("en");
```

Produces the next error:

```bash
TypeError: Cannot set property 'language' of undefined
    at setLng (Z:\ZitRos\Projects\TimingKit\node_modules\i18next\dist\commonjs\i18next.js:315:25)
    at changeLanguage (Z:\ZitRos\Projects\TimingKit\node_modules\i18next\dist\commonjs\i18next.js:333:7)
    at Client.renderDashboard (Z:\ZitRos\Projects\TimingKit\build_base\server\...)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:169:7)
```

Whether this:

```javascript
import i18next from "i18next";

// ...

i18next.changeLanguage("en");
```

Does not.

I think it is expected that the imported function must work properly, because there is always one instance of i18next exported (default export).

The reason of the error is in [i18next/index.js](https://github.com/i18next/i18next/blob/master/index.js) file. There is only `default` property exported from `dist/commonjs/index.js` instead of all the properties. Requiring `i18next/index.js` gives the **i18next plain instance** (object), hence this results in i18next instance properties cast to a set of exports. This way, `changeLanguage`, being called as a plain exported function, has **this** equals to **undefined**.

This pull request fixes the problem.

Furthermore, I think there is no need in `index.js` file, we can just specify `"main"` property of `package.json` file to be equal to `"dist/commonjs/index.js"`. What do you think?

Thanks!