### PR TITLE
Added options.silent to addResources and addResourceBundle

### DIFF
--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -56,15 +56,15 @@ class ResourceStore extends EventEmitter {
     if (!options.silent) this.emit('added', lng, ns, key, value);
   }
 
-  addResources(lng, ns, resources) {
+  addResources(lng, ns, resources, options = { silent: false }) {
     /* eslint no-restricted-syntax: 0 */
     for (const m in resources) {
       if (typeof resources[m] === 'string') this.addResource(lng, ns, m, resources[m], { silent: true });
     }
-    this.emit('added', lng, ns, resources);
+    if (!options.silent) this.emit('added', lng, ns, resources);
   }
 
-  addResourceBundle(lng, ns, resources, deep, overwrite) {
+  addResourceBundle(lng, ns, resources, deep, overwrite, options = { silent: false }) {
     let path = [lng, ns];
     if (lng.indexOf('.') > -1) {
       path = lng.split('.');
@@ -85,7 +85,7 @@ class ResourceStore extends EventEmitter {
 
     utils.setPath(this.data, path, pack);
 
-    this.emit('added', lng, ns, resources);
+    if (!options.silent) this.emit('added', lng, ns, resources);
   }
 
   removeResourceBundle(lng, ns) {

--- a/test/resourceStore.spec.js
+++ b/test/resourceStore.spec.js
@@ -50,6 +50,60 @@ describe('ResourceStore', () => {
         // getting object
         expect(rs.getResource('de.translation.nest.object')).to.eql({ something: 'deeper' });
       });
+
+      it('it should emit \'added\' event on addResource call', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResource('fr', 'translation', 'hi', 'salut');
+        expect(spy.calledWithExactly('fr', 'translation', 'hi', 'salut')).to.be.true;
+      });
+
+      it('it should not emit \'added\' event on addResource call with silent option', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResource('fr', 'translation', 'hi', 'salut', { silent: true });
+        expect(spy.notCalled).to.be.true;
+      });
+
+      it('it should emit \'added\' event on addResources call', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResources('fr', 'translation', {
+          'hi': 'salut',
+          'hello': 'bonjour',
+        });
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('it should not emit \'added\' event on addResources call with silent option', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResources('fr', 'translation', {
+          'hi': 'salut',
+          'hello': 'bonjour',
+        }, { silent: true });
+        expect(spy.notCalled).to.be.true;
+      });
+
+      it('it should emit \'added\' event on addResourceBundle call', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResourceBundle('fr', 'translation', {
+          'hi': 'salut',
+          'hello': 'bonjour',
+        }, true, true);
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('it should not emit \'added\' event on addResourceBundle call with silent option', () => {
+        const spy = sinon.spy();
+        rs.on('added', spy);
+        rs.addResourceBundle('fr', 'translation', {
+          'hi': 'salut',
+          'hello': 'bonjour',
+        }, true, true, { silent: true });
+        expect(spy.notCalled).to.be.true;
+      });
     });
 
     describe('can extend resources bundle', () => {


### PR DESCRIPTION
Issue #1022 

Sometimes you want to load resource bundles in background without triggering events and re-rendering the whole app (ie. with react-i18next).

Added an optional parameter to addResources() and addResourceBundle() (`option = { silent: false}`), similar to addResource(), to ignore the emitting of 'added' event.