### PR TITLE
Avoid mutating whitelist array. Fixes #1036

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -71,7 +71,7 @@ export function transformOptions(options) {
 
   // extend whitelist with cimode
   if (options.whitelist && options.whitelist.indexOf('cimode') < 0) {
-    options.whitelist = options.whitelist.concat(['cimode'])
+    options.whitelist = options.whitelist.concat(['cimode']);
   }
 
   return options;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -70,7 +70,9 @@ export function transformOptions(options) {
   if (typeof options.fallbackNS === 'string') options.fallbackNS = [options.fallbackNS];
 
   // extend whitelist with cimode
-  if (options.whitelist && options.whitelist.indexOf('cimode') < 0) options.whitelist.push('cimode');
+  if (options.whitelist && options.whitelist.indexOf('cimode') < 0) {
+    options.whitelist = options.whitelist.concat(['cimode'])
+  }
 
   return options;
 }


### PR DESCRIPTION
This replaces Array.push with Array.concat in order to avoid mutation. This prevents the issue described in #1036.