### PR TITLE
Properly handle arguments containing arrays while listening to a wildcard event

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -38,7 +38,7 @@ class EventEmitter {
     if (this.observers['*']) {
       const cloned = [].concat(this.observers['*']);
       cloned.forEach((observer) => {
-        observer.apply(observer, [event].concat(...args));
+        observer.apply(observer, [event, ...args]);
       });
     }
   }

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -52,8 +52,8 @@ describe('i18next', () => {
 
     it('it should emit wildcard with array params', (done) => {
       // test on
-      emitter.on('*', (event, array, data) => {
-        expect(event).to.equal('array-event');
+      emitter.on('*', (ev, array, data) => {
+        expect(ev).to.equal('array-event');
         expect(array).to.eql(['array ok 1', 'array ok 2']);
         expect(data).to.equal('data ok');
         done();

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -1,13 +1,14 @@
 import EventEmitter from '../src/EventEmitter';
 
 describe('i18next', () => {
-  let emitter;
-
-  before(() => {
-    emitter = new EventEmitter();
-  });
 
   describe('published', () => {
+    
+    let emitter;
+    beforeEach(() => {
+      emitter = new EventEmitter();
+    });
+
     it('it should emit', (done) => {
       // test on
       emitter.on('ok', (payload) => {
@@ -36,6 +37,29 @@ describe('i18next', () => {
       });
 
       emitter.emit('ok', 'data ok');
+    });
+
+    it('it should emit with array params', (done) => {
+      // test on
+      emitter.on('array-event', (array, data) => {
+        expect(array).to.eql(['array ok 1', 'array ok 2']);
+        expect(data).to.equal('data ok');
+        done();
+      });
+
+      emitter.emit('array-event', ['array ok 1', 'array ok 2'], 'data ok');
+    });
+
+    it('it should emit wildcard with array params', (done) => {
+      // test on
+      emitter.on('*', (event, array, data) => {
+        expect(event).to.equal('array-event');
+        expect(array).to.eql(['array ok 1', 'array ok 2']);
+        expect(data).to.equal('data ok');
+        done();
+      });
+
+      emitter.emit('array-event', ['array ok 1', 'array ok 2'], 'data ok');
     });
   });
 


### PR DESCRIPTION
Currently, it spread all the arguments because of how `concat` works but this is fixed in this PR.

e.g if you pass `emitter.emit('event', ['en', 'pt'], 'key')` it was resulting in args as `'en', 'pt', 'key'`. This PR fixes the arguments to result in `['en', 'pt'], 'key'` while listening to wildcard. Previous behaviour breaks listening to 'missingKey' event.