### PR TITLE
Allow to pass raw value to the custom interpolation escape function

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -13,13 +13,14 @@ class Interpolator {
     if (reset) {
       this.options = options;
       this.format = (options.interpolation && options.interpolation.format) || (value => value);
-      this.escape = (options.interpolation && options.interpolation.escape) || utils.escape;
     }
     if (!options.interpolation) options.interpolation = { escapeValue: true };
 
     const iOpts = options.interpolation;
 
+    this.escape = iOpts.escape !== undefined ? iOpts.escape : utils.escape;
     this.escapeValue = iOpts.escapeValue !== undefined ? iOpts.escapeValue : true;
+    this.useRawValueToEscape = iOpts.useRawValueToEscape !== undefined ? iOpts.useRawValueToEscape : false;
 
     this.prefix = iOpts.prefix ? utils.regexEscape(iOpts.prefix) : iOpts.prefixEscaped || '{{';
     this.suffix = iOpts.suffix ? utils.regexEscape(iOpts.suffix) : iOpts.suffixEscaped || '}}';
@@ -100,7 +101,7 @@ class Interpolator {
           this.logger.warn(`missed to pass in variable ${match[1]} for interpolating ${str}`);
           value = '';
         }
-      } else if (typeof value !== 'string') {
+      } else if (typeof value !== 'string' && !this.useRawValueToEscape) {
         value = utils.makeString(value);
       }
       value = this.escapeValue ? regexSafe(this.escape(value)) : regexSafe(value);

--- a/test/translator/translator.translate.escape.spec.js
+++ b/test/translator/translator.translate.escape.spec.js
@@ -38,7 +38,9 @@ describe('Translator', () => {
 
     var tests = [
       {args: ['translation:test', { var: 'a&b' }], expected: 'text a&amp;b'},
-      {args: ['translation:test', { var: 'a&b', interpolation: { escapeValue: false } }], expected: 'text a&b'}
+      {args: ['translation:test', { var: 'a&b', interpolation: { escapeValue: false } }], expected: 'text a&b'},
+      {args: ['translation:test', { var: ['a', 'b'] }], expected: 'text a,b'},
+      {args: ['translation:test', { var: ['a', 'b'], interpolation: { useRawValueToEscape: true, escape: (value) => value.join('-') } }], expected: 'text a-b'},
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
If custom escape function is used, then raw value (not type casted to String) can be passed to it.

This PR solves issue #1058 

New Interpolation options is added:

| option | default | description
-- | -- | --
useRawValueToEscape | false | If true, then value passed into escape function is not casted to string, use with custom escape function that does its own type check)

My example use-case: `Handlebars.Utils.escapeExpression` is used as escape function and `useRawValueToEscape` is true then escaping can be disabled for a specific value as soon as it is wrapped in Handlebars.SafeString.