### PR TITLE
EventEmitter.prototype.on returns this

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -8,6 +8,7 @@ class EventEmitter {
       this.observers[event] = this.observers[event] || [];
       this.observers[event].push(listener);
     });
+    return this;
   }
 
   off(event, listener) {

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -3,7 +3,7 @@ import EventEmitter from '../src/EventEmitter';
 describe('i18next', () => {
 
   describe('published', () => {
-    
+
     let emitter;
     beforeEach(() => {
       emitter = new EventEmitter();
@@ -60,6 +60,13 @@ describe('i18next', () => {
       });
 
       emitter.emit('array-event', ['array ok 1', 'array ok 2'], 'data ok');
+    });
+
+    it('it should return itself', () => {
+      // test on
+      const returned = emitter.on('*');
+
+      expect(returned).to.equal(emitter);
     });
   });
 


### PR DESCRIPTION
Having `EventEmitter.prototype.on` return`this` enables subscribing to events as part of the config chain. 
```js
i18n.createInstance()
  .use(ChainedBackend)
  .use(LanguageDetector)
  .use(reactI18nextModule)
  .on('initialized', () => console.log('initialized'))
  .init(i18nOptions);
```
This commit closes #1077.