### PR TITLE
Add getDataByLanguage method to return language data currently in store #1086

### DIFF
--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -112,6 +112,10 @@ class ResourceStore extends EventEmitter {
     return this.getResource(lng, ns);
   }
 
+  getDataByLanguage(lng) {
+    return this.data[lng]
+  }
+
   toJSON() {
     return this.data;
   }

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -113,7 +113,7 @@ class ResourceStore extends EventEmitter {
   }
 
   getDataByLanguage(lng) {
-    return this.data[lng]
+    return this.data[lng];
   }
 
   toJSON() {

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -90,7 +90,7 @@ class I18n extends EventEmitter {
     }
 
     // append api
-    const storeApi = ['getResource', 'addResource', 'addResources', 'addResourceBundle', 'removeResourceBundle', 'hasResourceBundle', 'getResourceBundle'];
+    const storeApi = ['getResource', 'addResource', 'addResources', 'addResourceBundle', 'removeResourceBundle', 'hasResourceBundle', 'getResourceBundle', 'getDataByLanguage'];
     storeApi.forEach((fcName) => {
       this[fcName] = (...args) => this.store[fcName](...args);
     });

--- a/test/resourceStore.spec.js
+++ b/test/resourceStore.spec.js
@@ -156,6 +156,17 @@ describe('ResourceStore', () => {
         expect(rs.getResourceBundle('en', 'translation')).to.be.not.ok;
       });
     });
+
+    describe('can get data by language', () => {
+      beforeEach(() => {
+        const data = { en: { translation: { test: 'test' } } };
+        rs = new ResourceStore(data);
+      });
+
+      it('it gets data by getDataByLanguage', () => {
+        expect(rs.getDataByLanguage('en')).to.be.eql({ translation: { test: 'test' } });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Simple method to return the whole language (i.e. namespaces loaded so far) from the store. Mostly so we don't have to access `resourceStore` object directly.  Closes #1086.