### PR TITLE
Add Hebrew plural support

### DIFF
--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -34,7 +34,8 @@ let sets = [
   { lngs: ['mt'], nr: [1,2,11,20], fc: 19 },
   { lngs: ['or'], nr: [2,1], fc: 2 },
   { lngs: ['ro'], nr: [1,2,20], fc: 20 },
-  { lngs: ['sl'], nr: [5,1,2,3], fc: 21 }
+  { lngs: ['sl'], nr: [5,1,2,3], fc: 21 },
+  { lngs: ['he'], nr: [1,2,20,21], fc: 22 }
 ]
 
 let _rulesPluralsTypes = {
@@ -58,7 +59,8 @@ let _rulesPluralsTypes = {
   18: function(n) {return Number(n==0 ? 0 : n==1 ? 1 : 2);},
   19: function(n) {return Number(n==1 ? 0 : n===0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);},
   20: function(n) {return Number(n==1 ? 0 : (n===0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);},
-  21: function(n) {return Number(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0); }
+  21: function(n) {return Number(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0); },
+  22: function(n) {return Number(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 3 : 4); }
 };
 /* eslint-enable */
 

--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -60,7 +60,7 @@ let _rulesPluralsTypes = {
   19: function(n) {return Number(n==1 ? 0 : n===0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);},
   20: function(n) {return Number(n==1 ? 0 : (n===0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);},
   21: function(n) {return Number(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0); },
-  22: function(n) {return Number(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 3 : 4); }
+  22: function(n) {return Number(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 2 : 3); }
 };
 /* eslint-enable */
 

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -38,7 +38,8 @@ describe('PluralResolver', () => {
       {args: ['mt'], expected: true},
       {args: ['or'], expected: true},
       {args: ['ro'], expected: true},
-      {args: ['sl'], expected: true}
+      {args: ['sl'], expected: true},
+      {args: ['he'], expected: true}
     ];
 
     tests.forEach((test) => {
@@ -193,6 +194,17 @@ describe('PluralResolver', () => {
       {args: ['sl', 2], expected: '2'},
       {args: ['sl', 3], expected: '3'},
 
+      // he
+      {args: ['he', 0], expected: '3'},
+      {args: ['he', 0.5], expected: '3'},
+      {args: ['he', 1], expected: '0'},
+      {args: ['he', 2], expected: '1'},
+      {args: ['he', 3], expected: '3'},
+      {args: ['he', 20], expected: '2'},
+      {args: ['he', 21], expected: '3'},
+      {args: ['he', 30], expected: '2'},
+      {args: ['he', 100], expected: '2'},
+      {args: ['he', 101], expected: '3'},
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
Using this [doc](http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html#he) as reference.

Ongoing PR for the translate documentation: https://github.com/translate/l10n-guide/pull/71/

Fixes https://github.com/i18next/i18next/issues/1120