### PR TITLE
update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 src/
 test/
 coverage/
+assets/
 .babelrc
 .editorconfig
 .eslintignore
@@ -10,3 +11,6 @@ bower.json
 gulpfile.js
 karma.conf.js
 sample.html
+.codeclimate.yml
+.coveralls.yml
+.travis.yml


### PR DESCRIPTION
Hi 👋

I’ve been doing a little research for a conference talk on how npm package size relates to their content, and your package was one in the several ones that were flagged by my scripts.  It has an outstanding weekly download count on npm and relatively large content or filetypes that is not related directly to the package functionality.

I've added some files and folders to the .npmignore file, so they won't get packaged next time you release it on npm.

Thanks, and have a great day!
