### PR TITLE
refactor non valid keys handling

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -55,7 +55,7 @@ class Translator extends EventEmitter {
 
     // non valid keys handling
     if (keys === undefined || keys === null) return '';
-    if(!Array.isArray(keys)) keys = [String(keys)];
+    if (!Array.isArray(keys)) keys = [String(keys)];
 
     // separators
     const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -54,9 +54,8 @@ class Translator extends EventEmitter {
     if (!options) options = {};
 
     // non valid keys handling
-    if (keys === undefined || keys === null || keys === '') return '';
-    if (typeof keys === 'number') keys = String(keys);
-    if (typeof keys === 'string') keys = [keys];
+    if (keys === undefined || keys === null) return '';
+    if(!Array.isArray(keys)) keys = [String(keys)];
 
     // separators
     const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;


### PR DESCRIPTION
The translate function was breaking in cases when the passed argument to the function is an object. This should handle pretty much all of the cases.