### PR TITLE
Add `transEmptyNodeValue` to `ReactOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,6 +131,11 @@ declare namespace i18next {
          * @default 'added removed'
          */
         bindStore?: string | false;
+        /**
+         * Set fallback value for Trans components without children
+         * @default undefined
+         */
+        transEmptyNodeValue?: string;
     }
 
     interface InitOptions {


### PR DESCRIPTION
This PR adds typings for option `transEmptyNodeValue` introduced in https://github.com/i18next/react-i18next/pull/462.