### PR TITLE
Add lint-staged prettier

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,3 +25,16 @@ exclude_paths:
   - 'rollup.config.js'
   - 'karma.conf.js'
   - 'karma.backward.conf.js'
+checks:
+  file-lines:
+    config:
+      threshold: 300
+  method-lines:
+    config:
+      threshold: 70
+  complex-logic:
+    config:
+      threshold: 5
+  nested-control-flow:
+    config:
+      threshold: 5

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,7 @@
 parser: babel-eslint
-extends: airbnb
+extends: 
+  - airbnb
+  - prettier
 
 rules:
   max-len: [0, 100]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+i18next.js
+i18next.min.js
+src/PluralResolver.js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ i18next is a very popular internationalization framework for browser or any othe
 
 ![ecosystem](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-L9iS6Wm2hynS5H9Gj7j%2F-L9iS7LlT2W7wFtJH-2n%2F-L9iSBP9U65-bHJBRSDv%2Fi18next-ecosystem.jpg?generation=1523345318122913&alt=media)
 
-
 i18next provides:
 
 - Flexible connection to [backend](https://www.i18next.com/plugins-and-utils.html#backends) (loading translations via xhr, ...)
@@ -24,17 +23,15 @@ i18next provides:
 - Extensibility: eg. [sprintf](https://www.i18next.com/plugins-and-utils.html#post-processors)
 - ...
 
-
 For more information visit the website:
 
 - [Getting started](https://www.i18next.com/getting-started.html)
 - [Translation Functionality](https://www.i18next.com/essentials.html)
 - [API](https://www.i18next.com/api.html)
 
-
 Our focus is providing the core to building a booming ecosystem. Independent of the building blocks you choose, be it react, angular or even good old jquery proper translation capabilities are just [one step away](https://www.i18next.com/supported-frameworks.html).
 
---------------
+---
 
 <h3 align="center">Gold Sponsors</h3>
 
@@ -44,7 +41,8 @@ Our focus is providing the core to building a booming ecosystem. Independent of 
   </a>
 </p>
 
---------------
+---
+
 **NEWS: localization as a service - locize.com**
 
 Having done a big rewrite of i18next in spring we are proud to announce the next big step to get your webproject translated with less effort. We just released [locize](http://locize.com/?utm_source=i18next_readme&utm_medium=github) a translation management system built around the i18next ecosystem.
@@ -53,4 +51,4 @@ Having done a big rewrite of i18next in spring we are proud to announce the next
 
 With using [locize](http://locize.com/?utm_source=i18next_readme&utm_medium=github) you directly support the future of i18next.
 
---------------
+---

--- a/i18next.js
+++ b/i18next.js
@@ -1,2095 +1,2525 @@
-(function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-	typeof define === 'function' && define.amd ? define(factory) :
-	(global.i18next = factory());
-}(this, (function () { 'use strict';
+(function(global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined'
+    ? (module.exports = factory())
+    : typeof define === 'function' && define.amd
+    ? define(factory)
+    : (global.i18next = factory());
+})(this, function() {
+  'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
-  return typeof obj;
-} : function (obj) {
-  return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-};
+  var _typeof =
+    typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol'
+      ? function(obj) {
+          return typeof obj;
+        }
+      : function(obj) {
+          return obj &&
+            typeof Symbol === 'function' &&
+            obj.constructor === Symbol &&
+            obj !== Symbol.prototype
+            ? 'symbol'
+            : typeof obj;
+        };
 
-
-
-
-
-
-
-
-
-
-
-var classCallCheck = function (instance, Constructor) {
-  if (!(instance instanceof Constructor)) {
-    throw new TypeError("Cannot call a class as a function");
-  }
-};
-
-
-
-
-
-
-
-
-
-var _extends = Object.assign || function (target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i];
-
-    for (var key in source) {
-      if (Object.prototype.hasOwnProperty.call(source, key)) {
-        target[key] = source[key];
-      }
-    }
-  }
-
-  return target;
-};
-
-
-
-var inherits = function (subClass, superClass) {
-  if (typeof superClass !== "function" && superClass !== null) {
-    throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
-  }
-
-  subClass.prototype = Object.create(superClass && superClass.prototype, {
-    constructor: {
-      value: subClass,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    }
-  });
-  if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
-};
-
-
-
-
-
-
-
-
-
-
-
-var possibleConstructorReturn = function (self, call) {
-  if (!self) {
-    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
-  }
-
-  return call && (typeof call === "object" || typeof call === "function") ? call : self;
-};
-
-
-
-
-
-var slicedToArray = function () {
-  function sliceIterator(arr, i) {
-    var _arr = [];
-    var _n = true;
-    var _d = false;
-    var _e = undefined;
-
-    try {
-      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-        _arr.push(_s.value);
-
-        if (i && _arr.length === i) break;
-      }
-    } catch (err) {
-      _d = true;
-      _e = err;
-    } finally {
-      try {
-        if (!_n && _i["return"]) _i["return"]();
-      } finally {
-        if (_d) throw _e;
-      }
-    }
-
-    return _arr;
-  }
-
-  return function (arr, i) {
-    if (Array.isArray(arr)) {
-      return arr;
-    } else if (Symbol.iterator in Object(arr)) {
-      return sliceIterator(arr, i);
-    } else {
-      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+  var classCallCheck = function(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError('Cannot call a class as a function');
     }
   };
-}();
 
+  var _extends =
+    Object.assign ||
+    function(target) {
+      for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i];
 
-
-
-
-
-
-
-
-
-
-
-
-var toConsumableArray = function (arr) {
-  if (Array.isArray(arr)) {
-    for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
-
-    return arr2;
-  } else {
-    return Array.from(arr);
-  }
-};
-
-var consoleLogger = {
-  type: 'logger',
-
-  log: function log(args) {
-    this.output('log', args);
-  },
-  warn: function warn(args) {
-    this.output('warn', args);
-  },
-  error: function error(args) {
-    this.output('error', args);
-  },
-  output: function output(type, args) {
-    var _console;
-
-    /* eslint no-console: 0 */
-    if (console && console[type]) (_console = console)[type].apply(_console, toConsumableArray(args));
-  }
-};
-
-var Logger = function () {
-  function Logger(concreteLogger) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    classCallCheck(this, Logger);
-
-    this.init(concreteLogger, options);
-  }
-
-  Logger.prototype.init = function init(concreteLogger) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    this.prefix = options.prefix || 'i18next:';
-    this.logger = concreteLogger || consoleLogger;
-    this.options = options;
-    this.debug = options.debug;
-  };
-
-  Logger.prototype.setDebug = function setDebug(bool) {
-    this.debug = bool;
-  };
-
-  Logger.prototype.log = function log() {
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
-
-    return this.forward(args, 'log', '', true);
-  };
-
-  Logger.prototype.warn = function warn() {
-    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-      args[_key2] = arguments[_key2];
-    }
-
-    return this.forward(args, 'warn', '', true);
-  };
-
-  Logger.prototype.error = function error() {
-    for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
-      args[_key3] = arguments[_key3];
-    }
-
-    return this.forward(args, 'error', '');
-  };
-
-  Logger.prototype.deprecate = function deprecate() {
-    for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
-      args[_key4] = arguments[_key4];
-    }
-
-    return this.forward(args, 'warn', 'WARNING DEPRECATED: ', true);
-  };
-
-  Logger.prototype.forward = function forward(args, lvl, prefix, debugOnly) {
-    if (debugOnly && !this.debug) return null;
-    if (typeof args[0] === 'string') args[0] = '' + prefix + this.prefix + ' ' + args[0];
-    return this.logger[lvl](args);
-  };
-
-  Logger.prototype.create = function create(moduleName) {
-    return new Logger(this.logger, _extends({ prefix: this.prefix + ':' + moduleName + ':' }, this.options));
-  };
-
-  return Logger;
-}();
-
-var baseLogger = new Logger();
-
-var EventEmitter = function () {
-  function EventEmitter() {
-    classCallCheck(this, EventEmitter);
-
-    this.observers = {};
-  }
-
-  EventEmitter.prototype.on = function on(events, listener) {
-    var _this = this;
-
-    events.split(' ').forEach(function (event) {
-      _this.observers[event] = _this.observers[event] || [];
-      _this.observers[event].push(listener);
-    });
-    return this;
-  };
-
-  EventEmitter.prototype.off = function off(event, listener) {
-    var _this2 = this;
-
-    if (!this.observers[event]) {
-      return;
-    }
-
-    this.observers[event].forEach(function () {
-      if (!listener) {
-        delete _this2.observers[event];
-      } else {
-        var index = _this2.observers[event].indexOf(listener);
-        if (index > -1) {
-          _this2.observers[event].splice(index, 1);
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
         }
       }
+
+      return target;
+    };
+
+  var inherits = function(subClass, superClass) {
+    if (typeof superClass !== 'function' && superClass !== null) {
+      throw new TypeError(
+        'Super expression must either be null or a function, not ' + typeof superClass,
+      );
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
     });
+    if (superClass)
+      Object.setPrototypeOf
+        ? Object.setPrototypeOf(subClass, superClass)
+        : (subClass.__proto__ = superClass);
   };
 
-  EventEmitter.prototype.emit = function emit(event) {
-    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-      args[_key - 1] = arguments[_key];
+  var possibleConstructorReturn = function(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
     }
 
-    if (this.observers[event]) {
-      var cloned = [].concat(this.observers[event]);
-      cloned.forEach(function (observer) {
-        observer.apply(undefined, args);
-      });
+    return call && (typeof call === 'object' || typeof call === 'function') ? call : self;
+  };
+
+  var slicedToArray = (function() {
+    function sliceIterator(arr, i) {
+      var _arr = [];
+      var _n = true;
+      var _d = false;
+      var _e = undefined;
+
+      try {
+        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+          _arr.push(_s.value);
+
+          if (i && _arr.length === i) break;
+        }
+      } catch (err) {
+        _d = true;
+        _e = err;
+      } finally {
+        try {
+          if (!_n && _i['return']) _i['return']();
+        } finally {
+          if (_d) throw _e;
+        }
+      }
+
+      return _arr;
     }
 
-    if (this.observers['*']) {
-      var _cloned = [].concat(this.observers['*']);
-      _cloned.forEach(function (observer) {
-        observer.apply(observer, [event].concat(args));
-      });
+    return function(arr, i) {
+      if (Array.isArray(arr)) {
+        return arr;
+      } else if (Symbol.iterator in Object(arr)) {
+        return sliceIterator(arr, i);
+      } else {
+        throw new TypeError('Invalid attempt to destructure non-iterable instance');
+      }
+    };
+  })();
+
+  var toConsumableArray = function(arr) {
+    if (Array.isArray(arr)) {
+      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+      return arr2;
+    } else {
+      return Array.from(arr);
     }
   };
 
-  return EventEmitter;
-}();
+  var consoleLogger = {
+    type: 'logger',
 
-// http://lea.verou.me/2016/12/resolve-promises-externally-with-this-one-weird-trick/
-function defer() {
-  var res = void 0;
-  var rej = void 0;
+    log: function log(args) {
+      this.output('log', args);
+    },
+    warn: function warn(args) {
+      this.output('warn', args);
+    },
+    error: function error(args) {
+      this.output('error', args);
+    },
+    output: function output(type, args) {
+      var _console;
 
-  var promise = new Promise(function (resolve, reject) {
-    res = resolve;
-    rej = reject;
-  });
+      /* eslint no-console: 0 */
+      if (console && console[type])
+        (_console = console)[type].apply(_console, toConsumableArray(args));
+    },
+  };
 
-  promise.resolve = res;
-  promise.reject = rej;
+  var Logger = (function() {
+    function Logger(concreteLogger) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      classCallCheck(this, Logger);
 
-  return promise;
-}
+      this.init(concreteLogger, options);
+    }
 
-function makeString(object) {
-  if (object == null) return '';
-  /* eslint prefer-template: 0 */
-  return '' + object;
-}
+    Logger.prototype.init = function init(concreteLogger) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-function copy(a, s, t) {
-  a.forEach(function (m) {
-    if (s[m]) t[m] = s[m];
-  });
-}
+      this.prefix = options.prefix || 'i18next:';
+      this.logger = concreteLogger || consoleLogger;
+      this.options = options;
+      this.debug = options.debug;
+    };
 
-function getLastOfPath(object, path, Empty) {
-  function cleanKey(key) {
-    return key && key.indexOf('###') > -1 ? key.replace(/###/g, '.') : key;
+    Logger.prototype.setDebug = function setDebug(bool) {
+      this.debug = bool;
+    };
+
+    Logger.prototype.log = function log() {
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      return this.forward(args, 'log', '', true);
+    };
+
+    Logger.prototype.warn = function warn() {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      return this.forward(args, 'warn', '', true);
+    };
+
+    Logger.prototype.error = function error() {
+      for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+        args[_key3] = arguments[_key3];
+      }
+
+      return this.forward(args, 'error', '');
+    };
+
+    Logger.prototype.deprecate = function deprecate() {
+      for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
+        args[_key4] = arguments[_key4];
+      }
+
+      return this.forward(args, 'warn', 'WARNING DEPRECATED: ', true);
+    };
+
+    Logger.prototype.forward = function forward(args, lvl, prefix, debugOnly) {
+      if (debugOnly && !this.debug) return null;
+      if (typeof args[0] === 'string') args[0] = '' + prefix + this.prefix + ' ' + args[0];
+      return this.logger[lvl](args);
+    };
+
+    Logger.prototype.create = function create(moduleName) {
+      return new Logger(
+        this.logger,
+        _extends({ prefix: this.prefix + ':' + moduleName + ':' }, this.options),
+      );
+    };
+
+    return Logger;
+  })();
+
+  var baseLogger = new Logger();
+
+  var EventEmitter = (function() {
+    function EventEmitter() {
+      classCallCheck(this, EventEmitter);
+
+      this.observers = {};
+    }
+
+    EventEmitter.prototype.on = function on(events, listener) {
+      var _this = this;
+
+      events.split(' ').forEach(function(event) {
+        _this.observers[event] = _this.observers[event] || [];
+        _this.observers[event].push(listener);
+      });
+      return this;
+    };
+
+    EventEmitter.prototype.off = function off(event, listener) {
+      var _this2 = this;
+
+      if (!this.observers[event]) {
+        return;
+      }
+
+      this.observers[event].forEach(function() {
+        if (!listener) {
+          delete _this2.observers[event];
+        } else {
+          var index = _this2.observers[event].indexOf(listener);
+          if (index > -1) {
+            _this2.observers[event].splice(index, 1);
+          }
+        }
+      });
+    };
+
+    EventEmitter.prototype.emit = function emit(event) {
+      for (
+        var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1;
+        _key < _len;
+        _key++
+      ) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      if (this.observers[event]) {
+        var cloned = [].concat(this.observers[event]);
+        cloned.forEach(function(observer) {
+          observer.apply(undefined, args);
+        });
+      }
+
+      if (this.observers['*']) {
+        var _cloned = [].concat(this.observers['*']);
+        _cloned.forEach(function(observer) {
+          observer.apply(observer, [event].concat(args));
+        });
+      }
+    };
+
+    return EventEmitter;
+  })();
+
+  // http://lea.verou.me/2016/12/resolve-promises-externally-with-this-one-weird-trick/
+  function defer() {
+    var res = void 0;
+    var rej = void 0;
+
+    var promise = new Promise(function(resolve, reject) {
+      res = resolve;
+      rej = reject;
+    });
+
+    promise.resolve = res;
+    promise.reject = rej;
+
+    return promise;
   }
 
-  function canNotTraverseDeeper() {
-    return !object || typeof object === 'string';
+  function makeString(object) {
+    if (object == null) return '';
+    /* eslint prefer-template: 0 */
+    return '' + object;
   }
 
-  var stack = typeof path !== 'string' ? [].concat(path) : path.split('.');
-  while (stack.length > 1) {
+  function copy(a, s, t) {
+    a.forEach(function(m) {
+      if (s[m]) t[m] = s[m];
+    });
+  }
+
+  function getLastOfPath(object, path, Empty) {
+    function cleanKey(key) {
+      return key && key.indexOf('###') > -1 ? key.replace(/###/g, '.') : key;
+    }
+
+    function canNotTraverseDeeper() {
+      return !object || typeof object === 'string';
+    }
+
+    var stack = typeof path !== 'string' ? [].concat(path) : path.split('.');
+    while (stack.length > 1) {
+      if (canNotTraverseDeeper()) return {};
+
+      var key = cleanKey(stack.shift());
+      if (!object[key] && Empty) object[key] = new Empty();
+      object = object[key];
+    }
+
     if (canNotTraverseDeeper()) return {};
-
-    var key = cleanKey(stack.shift());
-    if (!object[key] && Empty) object[key] = new Empty();
-    object = object[key];
+    return {
+      obj: object,
+      k: cleanKey(stack.shift()),
+    };
   }
 
-  if (canNotTraverseDeeper()) return {};
-  return {
-    obj: object,
-    k: cleanKey(stack.shift())
-  };
-}
-
-function setPath(object, path, newValue) {
-  var _getLastOfPath = getLastOfPath(object, path, Object),
+  function setPath(object, path, newValue) {
+    var _getLastOfPath = getLastOfPath(object, path, Object),
       obj = _getLastOfPath.obj,
       k = _getLastOfPath.k;
 
-  obj[k] = newValue;
-}
+    obj[k] = newValue;
+  }
 
-function pushPath(object, path, newValue, concat) {
-  var _getLastOfPath2 = getLastOfPath(object, path, Object),
+  function pushPath(object, path, newValue, concat) {
+    var _getLastOfPath2 = getLastOfPath(object, path, Object),
       obj = _getLastOfPath2.obj,
       k = _getLastOfPath2.k;
 
-  obj[k] = obj[k] || [];
-  if (concat) obj[k] = obj[k].concat(newValue);
-  if (!concat) obj[k].push(newValue);
-}
+    obj[k] = obj[k] || [];
+    if (concat) obj[k] = obj[k].concat(newValue);
+    if (!concat) obj[k].push(newValue);
+  }
 
-function getPath(object, path) {
-  var _getLastOfPath3 = getLastOfPath(object, path),
+  function getPath(object, path) {
+    var _getLastOfPath3 = getLastOfPath(object, path),
       obj = _getLastOfPath3.obj,
       k = _getLastOfPath3.k;
 
-  if (!obj) return undefined;
-  return obj[k];
-}
-
-function deepExtend(target, source, overwrite) {
-  /* eslint no-restricted-syntax: 0 */
-  for (var prop in source) {
-    if (prop in target) {
-      // If we reached a leaf string in target or source then replace with source or skip depending on the 'overwrite' switch
-      if (typeof target[prop] === 'string' || target[prop] instanceof String || typeof source[prop] === 'string' || source[prop] instanceof String) {
-        if (overwrite) target[prop] = source[prop];
-      } else {
-        deepExtend(target[prop], source[prop], overwrite);
-      }
-    } else {
-      target[prop] = source[prop];
-    }
-  }
-  return target;
-}
-
-function regexEscape(str) {
-  /* eslint no-useless-escape: 0 */
-  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-}
-
-/* eslint-disable */
-var _entityMap = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': '&quot;',
-  "'": '&#39;',
-  "/": '&#x2F;'
-};
-/* eslint-enable */
-
-function escape(data) {
-  if (typeof data === 'string') {
-    return data.replace(/[&<>"'\/]/g, function (s) {
-      return _entityMap[s];
-    });
+    if (!obj) return undefined;
+    return obj[k];
   }
 
-  return data;
-}
-
-var ResourceStore = function (_EventEmitter) {
-  inherits(ResourceStore, _EventEmitter);
-
-  function ResourceStore(data) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { ns: ['translation'], defaultNS: 'translation' };
-    classCallCheck(this, ResourceStore);
-
-    var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
-
-    _this.data = data || {};
-    _this.options = options;
-    if (_this.options.keySeparator === undefined) {
-      _this.options.keySeparator = '.';
-    }
-    return _this;
-  }
-
-  ResourceStore.prototype.addNamespaces = function addNamespaces(ns) {
-    if (this.options.ns.indexOf(ns) < 0) {
-      this.options.ns.push(ns);
-    }
-  };
-
-  ResourceStore.prototype.removeNamespaces = function removeNamespaces(ns) {
-    var index = this.options.ns.indexOf(ns);
-    if (index > -1) {
-      this.options.ns.splice(index, 1);
-    }
-  };
-
-  ResourceStore.prototype.getResource = function getResource(lng, ns, key) {
-    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
-
-    var keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
-
-    var path = [lng, ns];
-    if (key && typeof key !== 'string') path = path.concat(key);
-    if (key && typeof key === 'string') path = path.concat(keySeparator ? key.split(keySeparator) : key);
-
-    if (lng.indexOf('.') > -1) {
-      path = lng.split('.');
-    }
-
-    return getPath(this.data, path);
-  };
-
-  ResourceStore.prototype.addResource = function addResource(lng, ns, key, value) {
-    var options = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : { silent: false };
-
-    var keySeparator = this.options.keySeparator;
-    if (keySeparator === undefined) keySeparator = '.';
-
-    var path = [lng, ns];
-    if (key) path = path.concat(keySeparator ? key.split(keySeparator) : key);
-
-    if (lng.indexOf('.') > -1) {
-      path = lng.split('.');
-      value = ns;
-      ns = path[1];
-    }
-
-    this.addNamespaces(ns);
-
-    setPath(this.data, path, value);
-
-    if (!options.silent) this.emit('added', lng, ns, key, value);
-  };
-
-  ResourceStore.prototype.addResources = function addResources(lng, ns, resources) {
-    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : { silent: false };
-
+  function deepExtend(target, source, overwrite) {
     /* eslint no-restricted-syntax: 0 */
-    for (var m in resources) {
-      if (typeof resources[m] === 'string') this.addResource(lng, ns, m, resources[m], { silent: true });
+    for (var prop in source) {
+      if (prop in target) {
+        // If we reached a leaf string in target or source then replace with source or skip depending on the 'overwrite' switch
+        if (
+          typeof target[prop] === 'string' ||
+          target[prop] instanceof String ||
+          typeof source[prop] === 'string' ||
+          source[prop] instanceof String
+        ) {
+          if (overwrite) target[prop] = source[prop];
+        } else {
+          deepExtend(target[prop], source[prop], overwrite);
+        }
+      } else {
+        target[prop] = source[prop];
+      }
     }
-    if (!options.silent) this.emit('added', lng, ns, resources);
-  };
-
-  ResourceStore.prototype.addResourceBundle = function addResourceBundle(lng, ns, resources, deep, overwrite) {
-    var options = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : { silent: false };
-
-    var path = [lng, ns];
-    if (lng.indexOf('.') > -1) {
-      path = lng.split('.');
-      deep = resources;
-      resources = ns;
-      ns = path[1];
-    }
-
-    this.addNamespaces(ns);
-
-    var pack = getPath(this.data, path) || {};
-
-    if (deep) {
-      deepExtend(pack, resources, overwrite);
-    } else {
-      pack = _extends({}, pack, resources);
-    }
-
-    setPath(this.data, path, pack);
-
-    if (!options.silent) this.emit('added', lng, ns, resources);
-  };
-
-  ResourceStore.prototype.removeResourceBundle = function removeResourceBundle(lng, ns) {
-    if (this.hasResourceBundle(lng, ns)) {
-      delete this.data[lng][ns];
-    }
-    this.removeNamespaces(ns);
-
-    this.emit('removed', lng, ns);
-  };
-
-  ResourceStore.prototype.hasResourceBundle = function hasResourceBundle(lng, ns) {
-    return this.getResource(lng, ns) !== undefined;
-  };
-
-  ResourceStore.prototype.getResourceBundle = function getResourceBundle(lng, ns) {
-    if (!ns) ns = this.options.defaultNS;
-
-    // COMPATIBILITY: remove extend in v2.1.0
-    if (this.options.compatibilityAPI === 'v1') return _extends({}, this.getResource(lng, ns));
-
-    return this.getResource(lng, ns);
-  };
-
-  ResourceStore.prototype.getDataByLanguage = function getDataByLanguage(lng) {
-    return this.data[lng];
-  };
-
-  ResourceStore.prototype.toJSON = function toJSON() {
-    return this.data;
-  };
-
-  return ResourceStore;
-}(EventEmitter);
-
-var postProcessor = {
-
-  processors: {},
-
-  addPostProcessor: function addPostProcessor(module) {
-    this.processors[module.name] = module;
-  },
-  handle: function handle(processors, value, key, options, translator) {
-    var _this = this;
-
-    processors.forEach(function (processor) {
-      if (_this.processors[processor]) value = _this.processors[processor].process(value, key, options, translator);
-    });
-
-    return value;
-  }
-};
-
-var Translator = function (_EventEmitter) {
-  inherits(Translator, _EventEmitter);
-
-  function Translator(services) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    classCallCheck(this, Translator);
-
-    var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
-
-    copy(['resourceStore', 'languageUtils', 'pluralResolver', 'interpolator', 'backendConnector', 'i18nFormat'], services, _this);
-
-    _this.options = options;
-    if (_this.options.keySeparator === undefined) {
-      _this.options.keySeparator = '.';
-    }
-
-    _this.logger = baseLogger.create('translator');
-    return _this;
+    return target;
   }
 
-  Translator.prototype.changeLanguage = function changeLanguage(lng) {
-    if (lng) this.language = lng;
+  function regexEscape(str) {
+    /* eslint no-useless-escape: 0 */
+    return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+  }
+
+  /* eslint-disable */
+  var _entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
   };
+  /* eslint-enable */
 
-  Translator.prototype.exists = function exists(key) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { interpolation: {} };
-
-    var resolved = this.resolve(key, options);
-    return resolved && resolved.res !== undefined;
-  };
-
-  Translator.prototype.extractFromKey = function extractFromKey(key, options) {
-    var nsSeparator = options.nsSeparator || this.options.nsSeparator;
-    if (nsSeparator === undefined) nsSeparator = ':';
-
-    var keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
-
-    var namespaces = options.ns || this.options.defaultNS;
-    if (nsSeparator && key.indexOf(nsSeparator) > -1) {
-      var parts = key.split(nsSeparator);
-      if (nsSeparator !== keySeparator || nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1) namespaces = parts.shift();
-      key = parts.join(keySeparator);
+  function escape(data) {
+    if (typeof data === 'string') {
+      return data.replace(/[&<>"'\/]/g, function(s) {
+        return _entityMap[s];
+      });
     }
-    if (typeof namespaces === 'string') namespaces = [namespaces];
 
-    return {
-      key: key,
-      namespaces: namespaces
+    return data;
+  }
+
+  var ResourceStore = (function(_EventEmitter) {
+    inherits(ResourceStore, _EventEmitter);
+
+    function ResourceStore(data) {
+      var options =
+        arguments.length > 1 && arguments[1] !== undefined
+          ? arguments[1]
+          : { ns: ['translation'], defaultNS: 'translation' };
+      classCallCheck(this, ResourceStore);
+
+      var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
+
+      _this.data = data || {};
+      _this.options = options;
+      if (_this.options.keySeparator === undefined) {
+        _this.options.keySeparator = '.';
+      }
+      return _this;
+    }
+
+    ResourceStore.prototype.addNamespaces = function addNamespaces(ns) {
+      if (this.options.ns.indexOf(ns) < 0) {
+        this.options.ns.push(ns);
+      }
     };
+
+    ResourceStore.prototype.removeNamespaces = function removeNamespaces(ns) {
+      var index = this.options.ns.indexOf(ns);
+      if (index > -1) {
+        this.options.ns.splice(index, 1);
+      }
+    };
+
+    ResourceStore.prototype.getResource = function getResource(lng, ns, key) {
+      var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+      var keySeparator =
+        options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+
+      var path = [lng, ns];
+      if (key && typeof key !== 'string') path = path.concat(key);
+      if (key && typeof key === 'string')
+        path = path.concat(keySeparator ? key.split(keySeparator) : key);
+
+      if (lng.indexOf('.') > -1) {
+        path = lng.split('.');
+      }
+
+      return getPath(this.data, path);
+    };
+
+    ResourceStore.prototype.addResource = function addResource(lng, ns, key, value) {
+      var options =
+        arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : { silent: false };
+
+      var keySeparator = this.options.keySeparator;
+      if (keySeparator === undefined) keySeparator = '.';
+
+      var path = [lng, ns];
+      if (key) path = path.concat(keySeparator ? key.split(keySeparator) : key);
+
+      if (lng.indexOf('.') > -1) {
+        path = lng.split('.');
+        value = ns;
+        ns = path[1];
+      }
+
+      this.addNamespaces(ns);
+
+      setPath(this.data, path, value);
+
+      if (!options.silent) this.emit('added', lng, ns, key, value);
+    };
+
+    ResourceStore.prototype.addResources = function addResources(lng, ns, resources) {
+      var options =
+        arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : { silent: false };
+
+      /* eslint no-restricted-syntax: 0 */
+      for (var m in resources) {
+        if (typeof resources[m] === 'string')
+          this.addResource(lng, ns, m, resources[m], { silent: true });
+      }
+      if (!options.silent) this.emit('added', lng, ns, resources);
+    };
+
+    ResourceStore.prototype.addResourceBundle = function addResourceBundle(
+      lng,
+      ns,
+      resources,
+      deep,
+      overwrite,
+    ) {
+      var options =
+        arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : { silent: false };
+
+      var path = [lng, ns];
+      if (lng.indexOf('.') > -1) {
+        path = lng.split('.');
+        deep = resources;
+        resources = ns;
+        ns = path[1];
+      }
+
+      this.addNamespaces(ns);
+
+      var pack = getPath(this.data, path) || {};
+
+      if (deep) {
+        deepExtend(pack, resources, overwrite);
+      } else {
+        pack = _extends({}, pack, resources);
+      }
+
+      setPath(this.data, path, pack);
+
+      if (!options.silent) this.emit('added', lng, ns, resources);
+    };
+
+    ResourceStore.prototype.removeResourceBundle = function removeResourceBundle(lng, ns) {
+      if (this.hasResourceBundle(lng, ns)) {
+        delete this.data[lng][ns];
+      }
+      this.removeNamespaces(ns);
+
+      this.emit('removed', lng, ns);
+    };
+
+    ResourceStore.prototype.hasResourceBundle = function hasResourceBundle(lng, ns) {
+      return this.getResource(lng, ns) !== undefined;
+    };
+
+    ResourceStore.prototype.getResourceBundle = function getResourceBundle(lng, ns) {
+      if (!ns) ns = this.options.defaultNS;
+
+      // COMPATIBILITY: remove extend in v2.1.0
+      if (this.options.compatibilityAPI === 'v1') return _extends({}, this.getResource(lng, ns));
+
+      return this.getResource(lng, ns);
+    };
+
+    ResourceStore.prototype.getDataByLanguage = function getDataByLanguage(lng) {
+      return this.data[lng];
+    };
+
+    ResourceStore.prototype.toJSON = function toJSON() {
+      return this.data;
+    };
+
+    return ResourceStore;
+  })(EventEmitter);
+
+  var postProcessor = {
+    processors: {},
+
+    addPostProcessor: function addPostProcessor(module) {
+      this.processors[module.name] = module;
+    },
+    handle: function handle(processors, value, key, options, translator) {
+      var _this = this;
+
+      processors.forEach(function(processor) {
+        if (_this.processors[processor])
+          value = _this.processors[processor].process(value, key, options, translator);
+      });
+
+      return value;
+    },
   };
 
-  Translator.prototype.translate = function translate(keys, options) {
-    var _this2 = this;
+  var Translator = (function(_EventEmitter) {
+    inherits(Translator, _EventEmitter);
 
-    if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) !== 'object' && this.options.overloadTranslationOptionHandler) {
-      /* eslint prefer-rest-params: 0 */
-      options = this.options.overloadTranslationOptionHandler(arguments);
+    function Translator(services) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      classCallCheck(this, Translator);
+
+      var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
+
+      copy(
+        [
+          'resourceStore',
+          'languageUtils',
+          'pluralResolver',
+          'interpolator',
+          'backendConnector',
+          'i18nFormat',
+        ],
+        services,
+        _this,
+      );
+
+      _this.options = options;
+      if (_this.options.keySeparator === undefined) {
+        _this.options.keySeparator = '.';
+      }
+
+      _this.logger = baseLogger.create('translator');
+      return _this;
     }
-    if (!options) options = {};
 
-    // non valid keys handling
-    if (keys === undefined || keys === null) return '';
-    if (!Array.isArray(keys)) keys = [String(keys)];
+    Translator.prototype.changeLanguage = function changeLanguage(lng) {
+      if (lng) this.language = lng;
+    };
 
-    // separators
-    var keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+    Translator.prototype.exists = function exists(key) {
+      var options =
+        arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { interpolation: {} };
 
-    // get namespace(s)
+      var resolved = this.resolve(key, options);
+      return resolved && resolved.res !== undefined;
+    };
 
-    var _extractFromKey = this.extractFromKey(keys[keys.length - 1], options),
+    Translator.prototype.extractFromKey = function extractFromKey(key, options) {
+      var nsSeparator = options.nsSeparator || this.options.nsSeparator;
+      if (nsSeparator === undefined) nsSeparator = ':';
+
+      var keySeparator =
+        options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+
+      var namespaces = options.ns || this.options.defaultNS;
+      if (nsSeparator && key.indexOf(nsSeparator) > -1) {
+        var parts = key.split(nsSeparator);
+        if (
+          nsSeparator !== keySeparator ||
+          (nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1)
+        )
+          namespaces = parts.shift();
+        key = parts.join(keySeparator);
+      }
+      if (typeof namespaces === 'string') namespaces = [namespaces];
+
+      return {
+        key: key,
+        namespaces: namespaces,
+      };
+    };
+
+    Translator.prototype.translate = function translate(keys, options) {
+      var _this2 = this;
+
+      if (
+        (typeof options === 'undefined' ? 'undefined' : _typeof(options)) !== 'object' &&
+        this.options.overloadTranslationOptionHandler
+      ) {
+        /* eslint prefer-rest-params: 0 */
+        options = this.options.overloadTranslationOptionHandler(arguments);
+      }
+      if (!options) options = {};
+
+      // non valid keys handling
+      if (keys === undefined || keys === null) return '';
+      if (!Array.isArray(keys)) keys = [String(keys)];
+
+      // separators
+      var keySeparator =
+        options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+
+      // get namespace(s)
+
+      var _extractFromKey = this.extractFromKey(keys[keys.length - 1], options),
         key = _extractFromKey.key,
         namespaces = _extractFromKey.namespaces;
 
-    var namespace = namespaces[namespaces.length - 1];
+      var namespace = namespaces[namespaces.length - 1];
 
-    // return key on CIMode
-    var lng = options.lng || this.language;
-    var appendNamespaceToCIMode = options.appendNamespaceToCIMode || this.options.appendNamespaceToCIMode;
-    if (lng && lng.toLowerCase() === 'cimode') {
-      if (appendNamespaceToCIMode) {
-        var nsSeparator = options.nsSeparator || this.options.nsSeparator;
-        return namespace + nsSeparator + key;
-      }
-
-      return key;
-    }
-
-    // resolve from store
-    var resolved = this.resolve(keys, options);
-    var res = resolved && resolved.res;
-    var resUsedKey = resolved && resolved.usedKey || key;
-
-    var resType = Object.prototype.toString.apply(res);
-    var noObject = ['[object Number]', '[object Function]', '[object RegExp]'];
-    var joinArrays = options.joinArrays !== undefined ? options.joinArrays : this.options.joinArrays;
-
-    // object
-    var handleAsObjectInI18nFormat = !this.i18nFormat || this.i18nFormat.handleAsObject;
-    var handleAsObject = typeof res !== 'string' && typeof res !== 'boolean' && typeof res !== 'number';
-    if (handleAsObjectInI18nFormat && res && handleAsObject && noObject.indexOf(resType) < 0 && !(joinArrays && resType === '[object Array]')) {
-      if (!options.returnObjects && !this.options.returnObjects) {
-        this.logger.warn('accessing an object - but returnObjects options is not enabled!');
-        return this.options.returnedObjectHandler ? this.options.returnedObjectHandler(resUsedKey, res, options) : 'key \'' + key + ' (' + this.language + ')\' returned an object instead of string.';
-      }
-
-      // if we got a separator we loop over children - else we just return object as is
-      // as having it set to false means no hierarchy so no lookup for nested values
-      if (keySeparator) {
-        var copy$$1 = resType === '[object Array]' ? [] : {}; // apply child translation on a copy
-
-        /* eslint no-restricted-syntax: 0 */
-        for (var m in res) {
-          if (Object.prototype.hasOwnProperty.call(res, m)) {
-            var deepKey = '' + resUsedKey + keySeparator + m;
-            copy$$1[m] = this.translate(deepKey, _extends({}, options, { joinArrays: false, ns: namespaces }));
-            if (copy$$1[m] === deepKey) copy$$1[m] = res[m]; // if nothing found use orginal value as fallback
-          }
-        }
-        res = copy$$1;
-      }
-    } else if (handleAsObjectInI18nFormat && joinArrays && resType === '[object Array]') {
-      // array special treatment
-      res = res.join(joinArrays);
-      if (res) res = this.extendTranslation(res, keys, options);
-    } else {
-      // string, empty or null
-      var usedDefault = false;
-      var usedKey = false;
-
-      // fallback value
-      if (!this.isValidLookup(res) && options.defaultValue !== undefined) {
-        usedDefault = true;
-
-        if (options.count !== undefined) {
-          var suffix = this.pluralResolver.getSuffix(lng, options.count);
-          res = options['defaultValue' + suffix];
-        }
-        if (!res) res = options.defaultValue;
-      }
-      if (!this.isValidLookup(res)) {
-        usedKey = true;
-        res = key;
-      }
-
-      // save missing
-      var updateMissing = options.defaultValue && options.defaultValue !== res && this.options.updateMissing;
-      if (usedKey || usedDefault || updateMissing) {
-        this.logger.log(updateMissing ? 'updateKey' : 'missingKey', lng, namespace, key, updateMissing ? options.defaultValue : res);
-
-        var lngs = [];
-        var fallbackLngs = this.languageUtils.getFallbackCodes(this.options.fallbackLng, options.lng || this.language);
-        if (this.options.saveMissingTo === 'fallback' && fallbackLngs && fallbackLngs[0]) {
-          for (var i = 0; i < fallbackLngs.length; i++) {
-            lngs.push(fallbackLngs[i]);
-          }
-        } else if (this.options.saveMissingTo === 'all') {
-          lngs = this.languageUtils.toResolveHierarchy(options.lng || this.language);
-        } else {
-          lngs.push(options.lng || this.language);
+      // return key on CIMode
+      var lng = options.lng || this.language;
+      var appendNamespaceToCIMode =
+        options.appendNamespaceToCIMode || this.options.appendNamespaceToCIMode;
+      if (lng && lng.toLowerCase() === 'cimode') {
+        if (appendNamespaceToCIMode) {
+          var nsSeparator = options.nsSeparator || this.options.nsSeparator;
+          return namespace + nsSeparator + key;
         }
 
-        var send = function send(l, k) {
-          if (_this2.options.missingKeyHandler) {
-            _this2.options.missingKeyHandler(l, namespace, k, updateMissing ? options.defaultValue : res, updateMissing, options);
-          } else if (_this2.backendConnector && _this2.backendConnector.saveMissing) {
-            _this2.backendConnector.saveMissing(l, namespace, k, updateMissing ? options.defaultValue : res, updateMissing, options);
-          }
-          _this2.emit('missingKey', l, namespace, k, res);
-        };
-
-        if (this.options.saveMissing) {
-          var needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
-          if (this.options.saveMissingPlurals && needsPluralHandling) {
-            lngs.forEach(function (l) {
-              var plurals = _this2.pluralResolver.getPluralFormsOfKey(l, key);
-
-              plurals.forEach(function (p) {
-                return send([l], p);
-              });
-            });
-          } else {
-            send(lngs, key);
-          }
-        }
+        return key;
       }
 
-      // extend
-      res = this.extendTranslation(res, keys, options, resolved);
+      // resolve from store
+      var resolved = this.resolve(keys, options);
+      var res = resolved && resolved.res;
+      var resUsedKey = (resolved && resolved.usedKey) || key;
 
-      // append namespace if still key
-      if (usedKey && res === key && this.options.appendNamespaceToMissingKey) res = namespace + ':' + key;
+      var resType = Object.prototype.toString.apply(res);
+      var noObject = ['[object Number]', '[object Function]', '[object RegExp]'];
+      var joinArrays =
+        options.joinArrays !== undefined ? options.joinArrays : this.options.joinArrays;
 
-      // parseMissingKeyHandler
-      if (usedKey && this.options.parseMissingKeyHandler) res = this.options.parseMissingKeyHandler(res);
-    }
+      // object
+      var handleAsObjectInI18nFormat = !this.i18nFormat || this.i18nFormat.handleAsObject;
+      var handleAsObject =
+        typeof res !== 'string' && typeof res !== 'boolean' && typeof res !== 'number';
+      if (
+        handleAsObjectInI18nFormat &&
+        res &&
+        handleAsObject &&
+        noObject.indexOf(resType) < 0 &&
+        !(joinArrays && resType === '[object Array]')
+      ) {
+        if (!options.returnObjects && !this.options.returnObjects) {
+          this.logger.warn('accessing an object - but returnObjects options is not enabled!');
+          return this.options.returnedObjectHandler
+            ? this.options.returnedObjectHandler(resUsedKey, res, options)
+            : "key '" + key + ' (' + this.language + ")' returned an object instead of string.";
+        }
 
-    // return
-    return res;
-  };
+        // if we got a separator we loop over children - else we just return object as is
+        // as having it set to false means no hierarchy so no lookup for nested values
+        if (keySeparator) {
+          var copy$$1 = resType === '[object Array]' ? [] : {}; // apply child translation on a copy
 
-  Translator.prototype.extendTranslation = function extendTranslation(res, key, options, resolved) {
-    var _this3 = this;
-
-    if (this.i18nFormat && this.i18nFormat.parse) {
-      res = this.i18nFormat.parse(res, options, resolved.usedLng, resolved.usedNS, resolved.usedKey, { resolved: resolved });
-    } else if (!options.skipInterpolation) {
-      // i18next.parsing
-      if (options.interpolation) this.interpolator.init(_extends({}, options, { interpolation: _extends({}, this.options.interpolation, options.interpolation) }));
-
-      // interpolate
-      var data = options.replace && typeof options.replace !== 'string' ? options.replace : options;
-      if (this.options.interpolation.defaultVariables) data = _extends({}, this.options.interpolation.defaultVariables, data);
-      res = this.interpolator.interpolate(res, data, options.lng || this.language, options);
-
-      // nesting
-      if (options.nest !== false) res = this.interpolator.nest(res, function () {
-        return _this3.translate.apply(_this3, arguments);
-      }, options);
-
-      if (options.interpolation) this.interpolator.reset();
-    }
-
-    // post process
-    var postProcess = options.postProcess || this.options.postProcess;
-    var postProcessorNames = typeof postProcess === 'string' ? [postProcess] : postProcess;
-
-    if (res !== undefined && res !== null && postProcessorNames && postProcessorNames.length && options.applyPostProcessor !== false) {
-      res = postProcessor.handle(postProcessorNames, res, key, options, this);
-    }
-
-    return res;
-  };
-
-  Translator.prototype.resolve = function resolve(keys) {
-    var _this4 = this;
-
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    var found = void 0;
-    var usedKey = void 0;
-    var usedLng = void 0;
-    var usedNS = void 0;
-
-    if (typeof keys === 'string') keys = [keys];
-
-    // forEach possible key
-    keys.forEach(function (k) {
-      if (_this4.isValidLookup(found)) return;
-      var extracted = _this4.extractFromKey(k, options);
-      var key = extracted.key;
-      usedKey = key;
-      var namespaces = extracted.namespaces;
-      if (_this4.options.fallbackNS) namespaces = namespaces.concat(_this4.options.fallbackNS);
-
-      var needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
-      var needsContextHandling = options.context !== undefined && typeof options.context === 'string' && options.context !== '';
-
-      var codes = options.lngs ? options.lngs : _this4.languageUtils.toResolveHierarchy(options.lng || _this4.language, options.fallbackLng);
-
-      namespaces.forEach(function (ns) {
-        if (_this4.isValidLookup(found)) return;
-        usedNS = ns;
-
-        codes.forEach(function (code) {
-          if (_this4.isValidLookup(found)) return;
-          usedLng = code;
-
-          var finalKey = key;
-          var finalKeys = [finalKey];
-
-          if (_this4.i18nFormat && _this4.i18nFormat.addLookupKeys) {
-            _this4.i18nFormat.addLookupKeys(finalKeys, key, code, ns, options);
-          } else {
-            var pluralSuffix = void 0;
-            if (needsPluralHandling) pluralSuffix = _this4.pluralResolver.getSuffix(code, options.count);
-
-            // fallback for plural if context not found
-            if (needsPluralHandling && needsContextHandling) finalKeys.push(finalKey + pluralSuffix);
-
-            // get key for context if needed
-            if (needsContextHandling) finalKeys.push(finalKey += '' + _this4.options.contextSeparator + options.context);
-
-            // get key for plural if needed
-            if (needsPluralHandling) finalKeys.push(finalKey += pluralSuffix);
-          }
-
-          // iterate over finalKeys starting with most specific pluralkey (-> contextkey only) -> singularkey only
-          var possibleKey = void 0;
-          /* eslint no-cond-assign: 0 */
-          while (possibleKey = finalKeys.pop()) {
-            if (!_this4.isValidLookup(found)) {
-              found = _this4.getResource(code, ns, possibleKey, options);
+          /* eslint no-restricted-syntax: 0 */
+          for (var m in res) {
+            if (Object.prototype.hasOwnProperty.call(res, m)) {
+              var deepKey = '' + resUsedKey + keySeparator + m;
+              copy$$1[m] = this.translate(
+                deepKey,
+                _extends({}, options, { joinArrays: false, ns: namespaces }),
+              );
+              if (copy$$1[m] === deepKey) copy$$1[m] = res[m]; // if nothing found use orginal value as fallback
             }
           }
-        });
-      });
-    });
-
-    return { res: found, usedKey: usedKey, usedLng: usedLng, usedNS: usedNS };
-  };
-
-  Translator.prototype.isValidLookup = function isValidLookup(res) {
-    return res !== undefined && !(!this.options.returnNull && res === null) && !(!this.options.returnEmptyString && res === '');
-  };
-
-  Translator.prototype.getResource = function getResource(code, ns, key) {
-    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
-
-    if (this.i18nFormat && this.i18nFormat.getResource) return this.i18nFormat.getResource(code, ns, key, options);
-    return this.resourceStore.getResource(code, ns, key, options);
-  };
-
-  return Translator;
-}(EventEmitter);
-
-function capitalize(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-var LanguageUtil = function () {
-  function LanguageUtil(options) {
-    classCallCheck(this, LanguageUtil);
-
-    this.options = options;
-
-    this.whitelist = this.options.whitelist || false;
-    this.logger = baseLogger.create('languageUtils');
-  }
-
-  LanguageUtil.prototype.getScriptPartFromCode = function getScriptPartFromCode(code) {
-    if (!code || code.indexOf('-') < 0) return null;
-
-    var p = code.split('-');
-    if (p.length === 2) return null;
-    p.pop();
-    return this.formatLanguageCode(p.join('-'));
-  };
-
-  LanguageUtil.prototype.getLanguagePartFromCode = function getLanguagePartFromCode(code) {
-    if (!code || code.indexOf('-') < 0) return code;
-
-    var p = code.split('-');
-    return this.formatLanguageCode(p[0]);
-  };
-
-  LanguageUtil.prototype.formatLanguageCode = function formatLanguageCode(code) {
-    // http://www.iana.org/assignments/language-tags/language-tags.xhtml
-    if (typeof code === 'string' && code.indexOf('-') > -1) {
-      var specialCases = ['hans', 'hant', 'latn', 'cyrl', 'cans', 'mong', 'arab'];
-      var p = code.split('-');
-
-      if (this.options.lowerCaseLng) {
-        p = p.map(function (part) {
-          return part.toLowerCase();
-        });
-      } else if (p.length === 2) {
-        p[0] = p[0].toLowerCase();
-        p[1] = p[1].toUpperCase();
-
-        if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
-      } else if (p.length === 3) {
-        p[0] = p[0].toLowerCase();
-
-        // if lenght 2 guess it's a country
-        if (p[1].length === 2) p[1] = p[1].toUpperCase();
-        if (p[0] !== 'sgn' && p[2].length === 2) p[2] = p[2].toUpperCase();
-
-        if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
-        if (specialCases.indexOf(p[2].toLowerCase()) > -1) p[2] = capitalize(p[2].toLowerCase());
-      }
-
-      return p.join('-');
-    }
-
-    return this.options.cleanCode || this.options.lowerCaseLng ? code.toLowerCase() : code;
-  };
-
-  LanguageUtil.prototype.isWhitelisted = function isWhitelisted(code) {
-    if (this.options.load === 'languageOnly' || this.options.nonExplicitWhitelist) {
-      code = this.getLanguagePartFromCode(code);
-    }
-    return !this.whitelist || !this.whitelist.length || this.whitelist.indexOf(code) > -1;
-  };
-
-  LanguageUtil.prototype.getFallbackCodes = function getFallbackCodes(fallbacks, code) {
-    if (!fallbacks) return [];
-    if (typeof fallbacks === 'string') fallbacks = [fallbacks];
-    if (Object.prototype.toString.apply(fallbacks) === '[object Array]') return fallbacks;
-
-    if (!code) return fallbacks.default || [];
-
-    // asume we have an object defining fallbacks
-    var found = fallbacks[code];
-    if (!found) found = fallbacks[this.getScriptPartFromCode(code)];
-    if (!found) found = fallbacks[this.formatLanguageCode(code)];
-    if (!found) found = fallbacks.default;
-
-    return found || [];
-  };
-
-  LanguageUtil.prototype.toResolveHierarchy = function toResolveHierarchy(code, fallbackCode) {
-    var _this = this;
-
-    var fallbackCodes = this.getFallbackCodes(fallbackCode || this.options.fallbackLng || [], code);
-
-    var codes = [];
-    var addCode = function addCode(c) {
-      if (!c) return;
-      if (_this.isWhitelisted(c)) {
-        codes.push(c);
+          res = copy$$1;
+        }
+      } else if (handleAsObjectInI18nFormat && joinArrays && resType === '[object Array]') {
+        // array special treatment
+        res = res.join(joinArrays);
+        if (res) res = this.extendTranslation(res, keys, options);
       } else {
-        _this.logger.warn('rejecting non-whitelisted language code: ' + c);
+        // string, empty or null
+        var usedDefault = false;
+        var usedKey = false;
+
+        // fallback value
+        if (!this.isValidLookup(res) && options.defaultValue !== undefined) {
+          usedDefault = true;
+
+          if (options.count !== undefined) {
+            var suffix = this.pluralResolver.getSuffix(lng, options.count);
+            res = options['defaultValue' + suffix];
+          }
+          if (!res) res = options.defaultValue;
+        }
+        if (!this.isValidLookup(res)) {
+          usedKey = true;
+          res = key;
+        }
+
+        // save missing
+        var updateMissing =
+          options.defaultValue && options.defaultValue !== res && this.options.updateMissing;
+        if (usedKey || usedDefault || updateMissing) {
+          this.logger.log(
+            updateMissing ? 'updateKey' : 'missingKey',
+            lng,
+            namespace,
+            key,
+            updateMissing ? options.defaultValue : res,
+          );
+
+          var lngs = [];
+          var fallbackLngs = this.languageUtils.getFallbackCodes(
+            this.options.fallbackLng,
+            options.lng || this.language,
+          );
+          if (this.options.saveMissingTo === 'fallback' && fallbackLngs && fallbackLngs[0]) {
+            for (var i = 0; i < fallbackLngs.length; i++) {
+              lngs.push(fallbackLngs[i]);
+            }
+          } else if (this.options.saveMissingTo === 'all') {
+            lngs = this.languageUtils.toResolveHierarchy(options.lng || this.language);
+          } else {
+            lngs.push(options.lng || this.language);
+          }
+
+          var send = function send(l, k) {
+            if (_this2.options.missingKeyHandler) {
+              _this2.options.missingKeyHandler(
+                l,
+                namespace,
+                k,
+                updateMissing ? options.defaultValue : res,
+                updateMissing,
+                options,
+              );
+            } else if (_this2.backendConnector && _this2.backendConnector.saveMissing) {
+              _this2.backendConnector.saveMissing(
+                l,
+                namespace,
+                k,
+                updateMissing ? options.defaultValue : res,
+                updateMissing,
+                options,
+              );
+            }
+            _this2.emit('missingKey', l, namespace, k, res);
+          };
+
+          if (this.options.saveMissing) {
+            var needsPluralHandling =
+              options.count !== undefined && typeof options.count !== 'string';
+            if (this.options.saveMissingPlurals && needsPluralHandling) {
+              lngs.forEach(function(l) {
+                var plurals = _this2.pluralResolver.getPluralFormsOfKey(l, key);
+
+                plurals.forEach(function(p) {
+                  return send([l], p);
+                });
+              });
+            } else {
+              send(lngs, key);
+            }
+          }
+        }
+
+        // extend
+        res = this.extendTranslation(res, keys, options, resolved);
+
+        // append namespace if still key
+        if (usedKey && res === key && this.options.appendNamespaceToMissingKey)
+          res = namespace + ':' + key;
+
+        // parseMissingKeyHandler
+        if (usedKey && this.options.parseMissingKeyHandler)
+          res = this.options.parseMissingKeyHandler(res);
       }
+
+      // return
+      return res;
     };
 
-    if (typeof code === 'string' && code.indexOf('-') > -1) {
-      if (this.options.load !== 'languageOnly') addCode(this.formatLanguageCode(code));
-      if (this.options.load !== 'languageOnly' && this.options.load !== 'currentOnly') addCode(this.getScriptPartFromCode(code));
-      if (this.options.load !== 'currentOnly') addCode(this.getLanguagePartFromCode(code));
-    } else if (typeof code === 'string') {
-      addCode(this.formatLanguageCode(code));
+    Translator.prototype.extendTranslation = function extendTranslation(
+      res,
+      key,
+      options,
+      resolved,
+    ) {
+      var _this3 = this;
+
+      if (this.i18nFormat && this.i18nFormat.parse) {
+        res = this.i18nFormat.parse(
+          res,
+          options,
+          resolved.usedLng,
+          resolved.usedNS,
+          resolved.usedKey,
+          { resolved: resolved },
+        );
+      } else if (!options.skipInterpolation) {
+        // i18next.parsing
+        if (options.interpolation)
+          this.interpolator.init(
+            _extends({}, options, {
+              interpolation: _extends({}, this.options.interpolation, options.interpolation),
+            }),
+          );
+
+        // interpolate
+        var data =
+          options.replace && typeof options.replace !== 'string' ? options.replace : options;
+        if (this.options.interpolation.defaultVariables)
+          data = _extends({}, this.options.interpolation.defaultVariables, data);
+        res = this.interpolator.interpolate(res, data, options.lng || this.language, options);
+
+        // nesting
+        if (options.nest !== false)
+          res = this.interpolator.nest(
+            res,
+            function() {
+              return _this3.translate.apply(_this3, arguments);
+            },
+            options,
+          );
+
+        if (options.interpolation) this.interpolator.reset();
+      }
+
+      // post process
+      var postProcess = options.postProcess || this.options.postProcess;
+      var postProcessorNames = typeof postProcess === 'string' ? [postProcess] : postProcess;
+
+      if (
+        res !== undefined &&
+        res !== null &&
+        postProcessorNames &&
+        postProcessorNames.length &&
+        options.applyPostProcessor !== false
+      ) {
+        res = postProcessor.handle(postProcessorNames, res, key, options, this);
+      }
+
+      return res;
+    };
+
+    Translator.prototype.resolve = function resolve(keys) {
+      var _this4 = this;
+
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      var found = void 0;
+      var usedKey = void 0;
+      var usedLng = void 0;
+      var usedNS = void 0;
+
+      if (typeof keys === 'string') keys = [keys];
+
+      // forEach possible key
+      keys.forEach(function(k) {
+        if (_this4.isValidLookup(found)) return;
+        var extracted = _this4.extractFromKey(k, options);
+        var key = extracted.key;
+        usedKey = key;
+        var namespaces = extracted.namespaces;
+        if (_this4.options.fallbackNS) namespaces = namespaces.concat(_this4.options.fallbackNS);
+
+        var needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
+        var needsContextHandling =
+          options.context !== undefined &&
+          typeof options.context === 'string' &&
+          options.context !== '';
+
+        var codes = options.lngs
+          ? options.lngs
+          : _this4.languageUtils.toResolveHierarchy(
+              options.lng || _this4.language,
+              options.fallbackLng,
+            );
+
+        namespaces.forEach(function(ns) {
+          if (_this4.isValidLookup(found)) return;
+          usedNS = ns;
+
+          codes.forEach(function(code) {
+            if (_this4.isValidLookup(found)) return;
+            usedLng = code;
+
+            var finalKey = key;
+            var finalKeys = [finalKey];
+
+            if (_this4.i18nFormat && _this4.i18nFormat.addLookupKeys) {
+              _this4.i18nFormat.addLookupKeys(finalKeys, key, code, ns, options);
+            } else {
+              var pluralSuffix = void 0;
+              if (needsPluralHandling)
+                pluralSuffix = _this4.pluralResolver.getSuffix(code, options.count);
+
+              // fallback for plural if context not found
+              if (needsPluralHandling && needsContextHandling)
+                finalKeys.push(finalKey + pluralSuffix);
+
+              // get key for context if needed
+              if (needsContextHandling)
+                finalKeys.push(
+                  (finalKey += '' + _this4.options.contextSeparator + options.context),
+                );
+
+              // get key for plural if needed
+              if (needsPluralHandling) finalKeys.push((finalKey += pluralSuffix));
+            }
+
+            // iterate over finalKeys starting with most specific pluralkey (-> contextkey only) -> singularkey only
+            var possibleKey = void 0;
+            /* eslint no-cond-assign: 0 */
+            while ((possibleKey = finalKeys.pop())) {
+              if (!_this4.isValidLookup(found)) {
+                found = _this4.getResource(code, ns, possibleKey, options);
+              }
+            }
+          });
+        });
+      });
+
+      return { res: found, usedKey: usedKey, usedLng: usedLng, usedNS: usedNS };
+    };
+
+    Translator.prototype.isValidLookup = function isValidLookup(res) {
+      return (
+        res !== undefined &&
+        !(!this.options.returnNull && res === null) &&
+        !(!this.options.returnEmptyString && res === '')
+      );
+    };
+
+    Translator.prototype.getResource = function getResource(code, ns, key) {
+      var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+      if (this.i18nFormat && this.i18nFormat.getResource)
+        return this.i18nFormat.getResource(code, ns, key, options);
+      return this.resourceStore.getResource(code, ns, key, options);
+    };
+
+    return Translator;
+  })(EventEmitter);
+
+  function capitalize(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+
+  var LanguageUtil = (function() {
+    function LanguageUtil(options) {
+      classCallCheck(this, LanguageUtil);
+
+      this.options = options;
+
+      this.whitelist = this.options.whitelist || false;
+      this.logger = baseLogger.create('languageUtils');
     }
 
-    fallbackCodes.forEach(function (fc) {
-      if (codes.indexOf(fc) < 0) addCode(_this.formatLanguageCode(fc));
-    });
+    LanguageUtil.prototype.getScriptPartFromCode = function getScriptPartFromCode(code) {
+      if (!code || code.indexOf('-') < 0) return null;
 
-    return codes;
-  };
+      var p = code.split('-');
+      if (p.length === 2) return null;
+      p.pop();
+      return this.formatLanguageCode(p.join('-'));
+    };
 
-  return LanguageUtil;
-}();
+    LanguageUtil.prototype.getLanguagePartFromCode = function getLanguagePartFromCode(code) {
+      if (!code || code.indexOf('-') < 0) return code;
 
-// definition http://translate.sourceforge.net/wiki/l10n/pluralforms
-/* eslint-disable */
-var sets = [{ lngs: ['ach', 'ak', 'am', 'arn', 'br', 'fil', 'gun', 'ln', 'mfe', 'mg', 'mi', 'oc', 'pt', 'pt-BR', 'tg', 'ti', 'tr', 'uz', 'wa'], nr: [1, 2], fc: 1 }, { lngs: ['af', 'an', 'ast', 'az', 'bg', 'bn', 'ca', 'da', 'de', 'dev', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fi', 'fo', 'fur', 'fy', 'gl', 'gu', 'ha', 'hi', 'hu', 'hy', 'ia', 'it', 'kn', 'ku', 'lb', 'mai', 'ml', 'mn', 'mr', 'nah', 'nap', 'nb', 'ne', 'nl', 'nn', 'no', 'nso', 'pa', 'pap', 'pms', 'ps', 'pt-PT', 'rm', 'sco', 'se', 'si', 'so', 'son', 'sq', 'sv', 'sw', 'ta', 'te', 'tk', 'ur', 'yo'], nr: [1, 2], fc: 2 }, { lngs: ['ay', 'bo', 'cgg', 'fa', 'id', 'ja', 'jbo', 'ka', 'kk', 'km', 'ko', 'ky', 'lo', 'ms', 'sah', 'su', 'th', 'tt', 'ug', 'vi', 'wo', 'zh'], nr: [1], fc: 3 }, { lngs: ['be', 'bs', 'dz', 'hr', 'ru', 'sr', 'uk'], nr: [1, 2, 5], fc: 4 }, { lngs: ['ar'], nr: [0, 1, 2, 3, 11, 100], fc: 5 }, { lngs: ['cs', 'sk'], nr: [1, 2, 5], fc: 6 }, { lngs: ['csb', 'pl'], nr: [1, 2, 5], fc: 7 }, { lngs: ['cy'], nr: [1, 2, 3, 8], fc: 8 }, { lngs: ['fr'], nr: [1, 2], fc: 9 }, { lngs: ['ga'], nr: [1, 2, 3, 7, 11], fc: 10 }, { lngs: ['gd'], nr: [1, 2, 3, 20], fc: 11 }, { lngs: ['is'], nr: [1, 2], fc: 12 }, { lngs: ['jv'], nr: [0, 1], fc: 13 }, { lngs: ['kw'], nr: [1, 2, 3, 4], fc: 14 }, { lngs: ['lt'], nr: [1, 2, 10], fc: 15 }, { lngs: ['lv'], nr: [1, 2, 0], fc: 16 }, { lngs: ['mk'], nr: [1, 2], fc: 17 }, { lngs: ['mnk'], nr: [0, 1, 2], fc: 18 }, { lngs: ['mt'], nr: [1, 2, 11, 20], fc: 19 }, { lngs: ['or'], nr: [2, 1], fc: 2 }, { lngs: ['ro'], nr: [1, 2, 20], fc: 20 }, { lngs: ['sl'], nr: [5, 1, 2, 3], fc: 21 }, { lngs: ['he'], nr: [1, 2, 20, 21], fc: 22 }];
+      var p = code.split('-');
+      return this.formatLanguageCode(p[0]);
+    };
 
-var _rulesPluralsTypes = {
-  1: function _(n) {
-    return Number(n > 1);
-  },
-  2: function _(n) {
-    return Number(n != 1);
-  },
-  3: function _(n) {
-    return 0;
-  },
-  4: function _(n) {
-    return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
-  },
-  5: function _(n) {
-    return Number(n === 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : n % 100 >= 3 && n % 100 <= 10 ? 3 : n % 100 >= 11 ? 4 : 5);
-  },
-  6: function _(n) {
-    return Number(n == 1 ? 0 : n >= 2 && n <= 4 ? 1 : 2);
-  },
-  7: function _(n) {
-    return Number(n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
-  },
-  8: function _(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n != 8 && n != 11 ? 2 : 3);
-  },
-  9: function _(n) {
-    return Number(n >= 2);
-  },
-  10: function _(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n < 7 ? 2 : n < 11 ? 3 : 4);
-  },
-  11: function _(n) {
-    return Number(n == 1 || n == 11 ? 0 : n == 2 || n == 12 ? 1 : n > 2 && n < 20 ? 2 : 3);
-  },
-  12: function _(n) {
-    return Number(n % 10 != 1 || n % 100 == 11);
-  },
-  13: function _(n) {
-    return Number(n !== 0);
-  },
-  14: function _(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n == 3 ? 2 : 3);
-  },
-  15: function _(n) {
-    return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
-  },
-  16: function _(n) {
-    return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n !== 0 ? 1 : 2);
-  },
-  17: function _(n) {
-    return Number(n == 1 || n % 10 == 1 ? 0 : 1);
-  },
-  18: function _(n) {
-    return Number(n == 0 ? 0 : n == 1 ? 1 : 2);
-  },
-  19: function _(n) {
-    return Number(n == 1 ? 0 : n === 0 || n % 100 > 1 && n % 100 < 11 ? 1 : n % 100 > 10 && n % 100 < 20 ? 2 : 3);
-  },
-  20: function _(n) {
-    return Number(n == 1 ? 0 : n === 0 || n % 100 > 0 && n % 100 < 20 ? 1 : 2);
-  },
-  21: function _(n) {
-    return Number(n % 100 == 1 ? 1 : n % 100 == 2 ? 2 : n % 100 == 3 || n % 100 == 4 ? 3 : 0);
-  },
-  22: function _(n) {
-    return Number(n === 1 ? 0 : n === 2 ? 1 : (n < 0 || n > 10) && n % 10 == 0 ? 2 : 3);
-  }
-};
-/* eslint-enable */
+    LanguageUtil.prototype.formatLanguageCode = function formatLanguageCode(code) {
+      // http://www.iana.org/assignments/language-tags/language-tags.xhtml
+      if (typeof code === 'string' && code.indexOf('-') > -1) {
+        var specialCases = ['hans', 'hant', 'latn', 'cyrl', 'cans', 'mong', 'arab'];
+        var p = code.split('-');
 
-function createRules() {
-  var rules = {};
-  sets.forEach(function (set$$1) {
-    set$$1.lngs.forEach(function (l) {
-      rules[l] = {
-        numbers: set$$1.nr,
-        plurals: _rulesPluralsTypes[set$$1.fc]
+        if (this.options.lowerCaseLng) {
+          p = p.map(function(part) {
+            return part.toLowerCase();
+          });
+        } else if (p.length === 2) {
+          p[0] = p[0].toLowerCase();
+          p[1] = p[1].toUpperCase();
+
+          if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
+        } else if (p.length === 3) {
+          p[0] = p[0].toLowerCase();
+
+          // if lenght 2 guess it's a country
+          if (p[1].length === 2) p[1] = p[1].toUpperCase();
+          if (p[0] !== 'sgn' && p[2].length === 2) p[2] = p[2].toUpperCase();
+
+          if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
+          if (specialCases.indexOf(p[2].toLowerCase()) > -1) p[2] = capitalize(p[2].toLowerCase());
+        }
+
+        return p.join('-');
+      }
+
+      return this.options.cleanCode || this.options.lowerCaseLng ? code.toLowerCase() : code;
+    };
+
+    LanguageUtil.prototype.isWhitelisted = function isWhitelisted(code) {
+      if (this.options.load === 'languageOnly' || this.options.nonExplicitWhitelist) {
+        code = this.getLanguagePartFromCode(code);
+      }
+      return !this.whitelist || !this.whitelist.length || this.whitelist.indexOf(code) > -1;
+    };
+
+    LanguageUtil.prototype.getFallbackCodes = function getFallbackCodes(fallbacks, code) {
+      if (!fallbacks) return [];
+      if (typeof fallbacks === 'string') fallbacks = [fallbacks];
+      if (Object.prototype.toString.apply(fallbacks) === '[object Array]') return fallbacks;
+
+      if (!code) return fallbacks.default || [];
+
+      // asume we have an object defining fallbacks
+      var found = fallbacks[code];
+      if (!found) found = fallbacks[this.getScriptPartFromCode(code)];
+      if (!found) found = fallbacks[this.formatLanguageCode(code)];
+      if (!found) found = fallbacks.default;
+
+      return found || [];
+    };
+
+    LanguageUtil.prototype.toResolveHierarchy = function toResolveHierarchy(code, fallbackCode) {
+      var _this = this;
+
+      var fallbackCodes = this.getFallbackCodes(
+        fallbackCode || this.options.fallbackLng || [],
+        code,
+      );
+
+      var codes = [];
+      var addCode = function addCode(c) {
+        if (!c) return;
+        if (_this.isWhitelisted(c)) {
+          codes.push(c);
+        } else {
+          _this.logger.warn('rejecting non-whitelisted language code: ' + c);
+        }
       };
+
+      if (typeof code === 'string' && code.indexOf('-') > -1) {
+        if (this.options.load !== 'languageOnly') addCode(this.formatLanguageCode(code));
+        if (this.options.load !== 'languageOnly' && this.options.load !== 'currentOnly')
+          addCode(this.getScriptPartFromCode(code));
+        if (this.options.load !== 'currentOnly') addCode(this.getLanguagePartFromCode(code));
+      } else if (typeof code === 'string') {
+        addCode(this.formatLanguageCode(code));
+      }
+
+      fallbackCodes.forEach(function(fc) {
+        if (codes.indexOf(fc) < 0) addCode(_this.formatLanguageCode(fc));
+      });
+
+      return codes;
+    };
+
+    return LanguageUtil;
+  })();
+
+  // definition http://translate.sourceforge.net/wiki/l10n/pluralforms
+  /* eslint-disable */
+  var sets = [
+    {
+      lngs: [
+        'ach',
+        'ak',
+        'am',
+        'arn',
+        'br',
+        'fil',
+        'gun',
+        'ln',
+        'mfe',
+        'mg',
+        'mi',
+        'oc',
+        'pt',
+        'pt-BR',
+        'tg',
+        'ti',
+        'tr',
+        'uz',
+        'wa',
+      ],
+      nr: [1, 2],
+      fc: 1,
+    },
+    {
+      lngs: [
+        'af',
+        'an',
+        'ast',
+        'az',
+        'bg',
+        'bn',
+        'ca',
+        'da',
+        'de',
+        'dev',
+        'el',
+        'en',
+        'eo',
+        'es',
+        'et',
+        'eu',
+        'fi',
+        'fo',
+        'fur',
+        'fy',
+        'gl',
+        'gu',
+        'ha',
+        'hi',
+        'hu',
+        'hy',
+        'ia',
+        'it',
+        'kn',
+        'ku',
+        'lb',
+        'mai',
+        'ml',
+        'mn',
+        'mr',
+        'nah',
+        'nap',
+        'nb',
+        'ne',
+        'nl',
+        'nn',
+        'no',
+        'nso',
+        'pa',
+        'pap',
+        'pms',
+        'ps',
+        'pt-PT',
+        'rm',
+        'sco',
+        'se',
+        'si',
+        'so',
+        'son',
+        'sq',
+        'sv',
+        'sw',
+        'ta',
+        'te',
+        'tk',
+        'ur',
+        'yo',
+      ],
+      nr: [1, 2],
+      fc: 2,
+    },
+    {
+      lngs: [
+        'ay',
+        'bo',
+        'cgg',
+        'fa',
+        'id',
+        'ja',
+        'jbo',
+        'ka',
+        'kk',
+        'km',
+        'ko',
+        'ky',
+        'lo',
+        'ms',
+        'sah',
+        'su',
+        'th',
+        'tt',
+        'ug',
+        'vi',
+        'wo',
+        'zh',
+      ],
+      nr: [1],
+      fc: 3,
+    },
+    { lngs: ['be', 'bs', 'dz', 'hr', 'ru', 'sr', 'uk'], nr: [1, 2, 5], fc: 4 },
+    { lngs: ['ar'], nr: [0, 1, 2, 3, 11, 100], fc: 5 },
+    { lngs: ['cs', 'sk'], nr: [1, 2, 5], fc: 6 },
+    { lngs: ['csb', 'pl'], nr: [1, 2, 5], fc: 7 },
+    { lngs: ['cy'], nr: [1, 2, 3, 8], fc: 8 },
+    { lngs: ['fr'], nr: [1, 2], fc: 9 },
+    { lngs: ['ga'], nr: [1, 2, 3, 7, 11], fc: 10 },
+    { lngs: ['gd'], nr: [1, 2, 3, 20], fc: 11 },
+    { lngs: ['is'], nr: [1, 2], fc: 12 },
+    { lngs: ['jv'], nr: [0, 1], fc: 13 },
+    { lngs: ['kw'], nr: [1, 2, 3, 4], fc: 14 },
+    { lngs: ['lt'], nr: [1, 2, 10], fc: 15 },
+    { lngs: ['lv'], nr: [1, 2, 0], fc: 16 },
+    { lngs: ['mk'], nr: [1, 2], fc: 17 },
+    { lngs: ['mnk'], nr: [0, 1, 2], fc: 18 },
+    { lngs: ['mt'], nr: [1, 2, 11, 20], fc: 19 },
+    { lngs: ['or'], nr: [2, 1], fc: 2 },
+    { lngs: ['ro'], nr: [1, 2, 20], fc: 20 },
+    { lngs: ['sl'], nr: [5, 1, 2, 3], fc: 21 },
+    { lngs: ['he'], nr: [1, 2, 20, 21], fc: 22 },
+  ];
+
+  var _rulesPluralsTypes = {
+    1: function _(n) {
+      return Number(n > 1);
+    },
+    2: function _(n) {
+      return Number(n != 1);
+    },
+    3: function _(n) {
+      return 0;
+    },
+    4: function _(n) {
+      return Number(
+        n % 10 == 1 && n % 100 != 11
+          ? 0
+          : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)
+          ? 1
+          : 2,
+      );
+    },
+    5: function _(n) {
+      return Number(
+        n === 0
+          ? 0
+          : n == 1
+          ? 1
+          : n == 2
+          ? 2
+          : n % 100 >= 3 && n % 100 <= 10
+          ? 3
+          : n % 100 >= 11
+          ? 4
+          : 5,
+      );
+    },
+    6: function _(n) {
+      return Number(n == 1 ? 0 : n >= 2 && n <= 4 ? 1 : 2);
+    },
+    7: function _(n) {
+      return Number(
+        n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
+      );
+    },
+    8: function _(n) {
+      return Number(n == 1 ? 0 : n == 2 ? 1 : n != 8 && n != 11 ? 2 : 3);
+    },
+    9: function _(n) {
+      return Number(n >= 2);
+    },
+    10: function _(n) {
+      return Number(n == 1 ? 0 : n == 2 ? 1 : n < 7 ? 2 : n < 11 ? 3 : 4);
+    },
+    11: function _(n) {
+      return Number(n == 1 || n == 11 ? 0 : n == 2 || n == 12 ? 1 : n > 2 && n < 20 ? 2 : 3);
+    },
+    12: function _(n) {
+      return Number(n % 10 != 1 || n % 100 == 11);
+    },
+    13: function _(n) {
+      return Number(n !== 0);
+    },
+    14: function _(n) {
+      return Number(n == 1 ? 0 : n == 2 ? 1 : n == 3 ? 2 : 3);
+    },
+    15: function _(n) {
+      return Number(
+        n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
+      );
+    },
+    16: function _(n) {
+      return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n !== 0 ? 1 : 2);
+    },
+    17: function _(n) {
+      return Number(n == 1 || n % 10 == 1 ? 0 : 1);
+    },
+    18: function _(n) {
+      return Number(n == 0 ? 0 : n == 1 ? 1 : 2);
+    },
+    19: function _(n) {
+      return Number(
+        n == 1
+          ? 0
+          : n === 0 || (n % 100 > 1 && n % 100 < 11)
+          ? 1
+          : n % 100 > 10 && n % 100 < 20
+          ? 2
+          : 3,
+      );
+    },
+    20: function _(n) {
+      return Number(n == 1 ? 0 : n === 0 || (n % 100 > 0 && n % 100 < 20) ? 1 : 2);
+    },
+    21: function _(n) {
+      return Number(n % 100 == 1 ? 1 : n % 100 == 2 ? 2 : n % 100 == 3 || n % 100 == 4 ? 3 : 0);
+    },
+    22: function _(n) {
+      return Number(n === 1 ? 0 : n === 2 ? 1 : (n < 0 || n > 10) && n % 10 == 0 ? 2 : 3);
+    },
+  };
+  /* eslint-enable */
+
+  function createRules() {
+    var rules = {};
+    sets.forEach(function(set$$1) {
+      set$$1.lngs.forEach(function(l) {
+        rules[l] = {
+          numbers: set$$1.nr,
+          plurals: _rulesPluralsTypes[set$$1.fc],
+        };
+      });
     });
-  });
-  return rules;
-}
-
-var PluralResolver = function () {
-  function PluralResolver(languageUtils) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    classCallCheck(this, PluralResolver);
-
-    this.languageUtils = languageUtils;
-    this.options = options;
-
-    this.logger = baseLogger.create('pluralResolver');
-
-    this.rules = createRules();
+    return rules;
   }
 
-  PluralResolver.prototype.addRule = function addRule(lng, obj) {
-    this.rules[lng] = obj;
-  };
+  var PluralResolver = (function() {
+    function PluralResolver(languageUtils) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      classCallCheck(this, PluralResolver);
 
-  PluralResolver.prototype.getRule = function getRule(code) {
-    return this.rules[code] || this.rules[this.languageUtils.getLanguagePartFromCode(code)];
-  };
+      this.languageUtils = languageUtils;
+      this.options = options;
 
-  PluralResolver.prototype.needsPlural = function needsPlural(code) {
-    var rule = this.getRule(code);
+      this.logger = baseLogger.create('pluralResolver');
 
-    return rule && rule.numbers.length > 1;
-  };
+      this.rules = createRules();
+    }
 
-  PluralResolver.prototype.getPluralFormsOfKey = function getPluralFormsOfKey(code, key) {
-    var _this = this;
+    PluralResolver.prototype.addRule = function addRule(lng, obj) {
+      this.rules[lng] = obj;
+    };
 
-    var ret = [];
+    PluralResolver.prototype.getRule = function getRule(code) {
+      return this.rules[code] || this.rules[this.languageUtils.getLanguagePartFromCode(code)];
+    };
 
-    var rule = this.getRule(code);
+    PluralResolver.prototype.needsPlural = function needsPlural(code) {
+      var rule = this.getRule(code);
 
-    if (!rule) return ret;
+      return rule && rule.numbers.length > 1;
+    };
 
-    rule.numbers.forEach(function (n) {
-      var suffix = _this.getSuffix(code, n);
-      ret.push('' + key + suffix);
-    });
+    PluralResolver.prototype.getPluralFormsOfKey = function getPluralFormsOfKey(code, key) {
+      var _this = this;
 
-    return ret;
-  };
+      var ret = [];
 
-  PluralResolver.prototype.getSuffix = function getSuffix(code, count) {
-    var _this2 = this;
+      var rule = this.getRule(code);
 
-    var rule = this.getRule(code);
+      if (!rule) return ret;
 
-    if (rule) {
-      // if (rule.numbers.length === 1) return ''; // only singular
+      rule.numbers.forEach(function(n) {
+        var suffix = _this.getSuffix(code, n);
+        ret.push('' + key + suffix);
+      });
 
-      var idx = rule.noAbs ? rule.plurals(count) : rule.plurals(Math.abs(count));
-      var suffix = rule.numbers[idx];
+      return ret;
+    };
 
-      // special treatment for lngs only having singular and plural
-      if (this.options.simplifyPluralSuffix && rule.numbers.length === 2 && rule.numbers[0] === 1) {
-        if (suffix === 2) {
-          suffix = 'plural';
-        } else if (suffix === 1) {
-          suffix = '';
+    PluralResolver.prototype.getSuffix = function getSuffix(code, count) {
+      var _this2 = this;
+
+      var rule = this.getRule(code);
+
+      if (rule) {
+        // if (rule.numbers.length === 1) return ''; // only singular
+
+        var idx = rule.noAbs ? rule.plurals(count) : rule.plurals(Math.abs(count));
+        var suffix = rule.numbers[idx];
+
+        // special treatment for lngs only having singular and plural
+        if (
+          this.options.simplifyPluralSuffix &&
+          rule.numbers.length === 2 &&
+          rule.numbers[0] === 1
+        ) {
+          if (suffix === 2) {
+            suffix = 'plural';
+          } else if (suffix === 1) {
+            suffix = '';
+          }
+        }
+
+        var returnSuffix = function returnSuffix() {
+          return _this2.options.prepend && suffix.toString()
+            ? _this2.options.prepend + suffix.toString()
+            : suffix.toString();
+        };
+
+        // COMPATIBILITY JSON
+        // v1
+        if (this.options.compatibilityJSON === 'v1') {
+          if (suffix === 1) return '';
+          if (typeof suffix === 'number') return '_plural_' + suffix.toString();
+          return returnSuffix();
+        } else if (/* v2 */ this.options.compatibilityJSON === 'v2') {
+          return returnSuffix();
+        } else if (
+          /* v3 - gettext index */ this.options.simplifyPluralSuffix &&
+          rule.numbers.length === 2 &&
+          rule.numbers[0] === 1
+        ) {
+          return returnSuffix();
+        }
+        return this.options.prepend && idx.toString()
+          ? this.options.prepend + idx.toString()
+          : idx.toString();
+      }
+
+      this.logger.warn('no plural rule found for: ' + code);
+      return '';
+    };
+
+    return PluralResolver;
+  })();
+
+  var Interpolator = (function() {
+    function Interpolator() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      classCallCheck(this, Interpolator);
+
+      this.logger = baseLogger.create('interpolator');
+
+      this.init(options, true);
+    }
+
+    /* eslint no-param-reassign: 0 */
+
+    Interpolator.prototype.init = function init() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var reset = arguments[1];
+
+      if (reset) {
+        this.options = options;
+        this.format =
+          (options.interpolation && options.interpolation.format) ||
+          function(value) {
+            return value;
+          };
+      }
+      if (!options.interpolation) options.interpolation = { escapeValue: true };
+
+      var iOpts = options.interpolation;
+
+      this.escape = iOpts.escape !== undefined ? iOpts.escape : escape;
+      this.escapeValue = iOpts.escapeValue !== undefined ? iOpts.escapeValue : true;
+      this.useRawValueToEscape =
+        iOpts.useRawValueToEscape !== undefined ? iOpts.useRawValueToEscape : false;
+
+      this.prefix = iOpts.prefix ? regexEscape(iOpts.prefix) : iOpts.prefixEscaped || '{{';
+      this.suffix = iOpts.suffix ? regexEscape(iOpts.suffix) : iOpts.suffixEscaped || '}}';
+
+      this.formatSeparator = iOpts.formatSeparator
+        ? iOpts.formatSeparator
+        : iOpts.formatSeparator || ',';
+
+      this.unescapePrefix = iOpts.unescapeSuffix ? '' : iOpts.unescapePrefix || '-';
+      this.unescapeSuffix = this.unescapePrefix ? '' : iOpts.unescapeSuffix || '';
+
+      this.nestingPrefix = iOpts.nestingPrefix
+        ? regexEscape(iOpts.nestingPrefix)
+        : iOpts.nestingPrefixEscaped || regexEscape('$t(');
+      this.nestingSuffix = iOpts.nestingSuffix
+        ? regexEscape(iOpts.nestingSuffix)
+        : iOpts.nestingSuffixEscaped || regexEscape(')');
+
+      this.maxReplaces = iOpts.maxReplaces ? iOpts.maxReplaces : 1000;
+
+      // the regexp
+      this.resetRegExp();
+    };
+
+    Interpolator.prototype.reset = function reset() {
+      if (this.options) this.init(this.options);
+    };
+
+    Interpolator.prototype.resetRegExp = function resetRegExp() {
+      // the regexp
+      var regexpStr = this.prefix + '(.+?)' + this.suffix;
+      this.regexp = new RegExp(regexpStr, 'g');
+
+      var regexpUnescapeStr =
+        '' + this.prefix + this.unescapePrefix + '(.+?)' + this.unescapeSuffix + this.suffix;
+      this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
+
+      var nestingRegexpStr = this.nestingPrefix + '(.+?)' + this.nestingSuffix;
+      this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
+    };
+
+    Interpolator.prototype.interpolate = function interpolate(str, data, lng, options) {
+      var _this = this;
+
+      var match = void 0;
+      var value = void 0;
+      var replaces = void 0;
+
+      function regexSafe(val) {
+        return val.replace(/\$/g, '$$$$');
+      }
+
+      var handleFormat = function handleFormat(key) {
+        if (key.indexOf(_this.formatSeparator) < 0) return getPath(data, key);
+
+        var p = key.split(_this.formatSeparator);
+        var k = p.shift().trim();
+        var f = p.join(_this.formatSeparator).trim();
+
+        return _this.format(getPath(data, k), f, lng);
+      };
+
+      this.resetRegExp();
+
+      var missingInterpolationHandler =
+        (options && options.missingInterpolationHandler) ||
+        this.options.missingInterpolationHandler;
+
+      replaces = 0;
+      // unescape if has unescapePrefix/Suffix
+      /* eslint no-cond-assign: 0 */
+      while ((match = this.regexpUnescape.exec(str))) {
+        value = handleFormat(match[1].trim());
+        str = str.replace(match[0], value);
+        this.regexpUnescape.lastIndex = 0;
+        replaces++;
+        if (replaces >= this.maxReplaces) {
+          break;
         }
       }
 
-      var returnSuffix = function returnSuffix() {
-        return _this2.options.prepend && suffix.toString() ? _this2.options.prepend + suffix.toString() : suffix.toString();
-      };
-
-      // COMPATIBILITY JSON
-      // v1
-      if (this.options.compatibilityJSON === 'v1') {
-        if (suffix === 1) return '';
-        if (typeof suffix === 'number') return '_plural_' + suffix.toString();
-        return returnSuffix();
-      } else if ( /* v2 */this.options.compatibilityJSON === 'v2') {
-        return returnSuffix();
-      } else if ( /* v3 - gettext index */this.options.simplifyPluralSuffix && rule.numbers.length === 2 && rule.numbers[0] === 1) {
-        return returnSuffix();
+      replaces = 0;
+      // regular escape on demand
+      while ((match = this.regexp.exec(str))) {
+        value = handleFormat(match[1].trim());
+        if (value === undefined) {
+          if (typeof missingInterpolationHandler === 'function') {
+            var temp = missingInterpolationHandler(str, match, options);
+            value = typeof temp === 'string' ? temp : '';
+          } else {
+            this.logger.warn(
+              'missed to pass in variable ' + match[1] + ' for interpolating ' + str,
+            );
+            value = '';
+          }
+        } else if (typeof value !== 'string' && !this.useRawValueToEscape) {
+          value = makeString(value);
+        }
+        value = this.escapeValue ? regexSafe(this.escape(value)) : regexSafe(value);
+        str = str.replace(match[0], value);
+        this.regexp.lastIndex = 0;
+        replaces++;
+        if (replaces >= this.maxReplaces) {
+          break;
+        }
       }
-      return this.options.prepend && idx.toString() ? this.options.prepend + idx.toString() : idx.toString();
-    }
-
-    this.logger.warn('no plural rule found for: ' + code);
-    return '';
-  };
-
-  return PluralResolver;
-}();
-
-var Interpolator = function () {
-  function Interpolator() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    classCallCheck(this, Interpolator);
-
-    this.logger = baseLogger.create('interpolator');
-
-    this.init(options, true);
-  }
-
-  /* eslint no-param-reassign: 0 */
-
-
-  Interpolator.prototype.init = function init() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var reset = arguments[1];
-
-    if (reset) {
-      this.options = options;
-      this.format = options.interpolation && options.interpolation.format || function (value) {
-        return value;
-      };
-    }
-    if (!options.interpolation) options.interpolation = { escapeValue: true };
-
-    var iOpts = options.interpolation;
-
-    this.escape = iOpts.escape !== undefined ? iOpts.escape : escape;
-    this.escapeValue = iOpts.escapeValue !== undefined ? iOpts.escapeValue : true;
-    this.useRawValueToEscape = iOpts.useRawValueToEscape !== undefined ? iOpts.useRawValueToEscape : false;
-
-    this.prefix = iOpts.prefix ? regexEscape(iOpts.prefix) : iOpts.prefixEscaped || '{{';
-    this.suffix = iOpts.suffix ? regexEscape(iOpts.suffix) : iOpts.suffixEscaped || '}}';
-
-    this.formatSeparator = iOpts.formatSeparator ? iOpts.formatSeparator : iOpts.formatSeparator || ',';
-
-    this.unescapePrefix = iOpts.unescapeSuffix ? '' : iOpts.unescapePrefix || '-';
-    this.unescapeSuffix = this.unescapePrefix ? '' : iOpts.unescapeSuffix || '';
-
-    this.nestingPrefix = iOpts.nestingPrefix ? regexEscape(iOpts.nestingPrefix) : iOpts.nestingPrefixEscaped || regexEscape('$t(');
-    this.nestingSuffix = iOpts.nestingSuffix ? regexEscape(iOpts.nestingSuffix) : iOpts.nestingSuffixEscaped || regexEscape(')');
-
-    this.maxReplaces = iOpts.maxReplaces ? iOpts.maxReplaces : 1000;
-
-    // the regexp
-    this.resetRegExp();
-  };
-
-  Interpolator.prototype.reset = function reset() {
-    if (this.options) this.init(this.options);
-  };
-
-  Interpolator.prototype.resetRegExp = function resetRegExp() {
-    // the regexp
-    var regexpStr = this.prefix + '(.+?)' + this.suffix;
-    this.regexp = new RegExp(regexpStr, 'g');
-
-    var regexpUnescapeStr = '' + this.prefix + this.unescapePrefix + '(.+?)' + this.unescapeSuffix + this.suffix;
-    this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
-
-    var nestingRegexpStr = this.nestingPrefix + '(.+?)' + this.nestingSuffix;
-    this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
-  };
-
-  Interpolator.prototype.interpolate = function interpolate(str, data, lng, options) {
-    var _this = this;
-
-    var match = void 0;
-    var value = void 0;
-    var replaces = void 0;
-
-    function regexSafe(val) {
-      return val.replace(/\$/g, '$$$$');
-    }
-
-    var handleFormat = function handleFormat(key) {
-      if (key.indexOf(_this.formatSeparator) < 0) return getPath(data, key);
-
-      var p = key.split(_this.formatSeparator);
-      var k = p.shift().trim();
-      var f = p.join(_this.formatSeparator).trim();
-
-      return _this.format(getPath(data, k), f, lng);
+      return str;
     };
 
-    this.resetRegExp();
+    Interpolator.prototype.nest = function nest(str, fc) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-    var missingInterpolationHandler = options && options.missingInterpolationHandler || this.options.missingInterpolationHandler;
+      var match = void 0;
+      var value = void 0;
 
-    replaces = 0;
-    // unescape if has unescapePrefix/Suffix
-    /* eslint no-cond-assign: 0 */
-    while (match = this.regexpUnescape.exec(str)) {
-      value = handleFormat(match[1].trim());
-      str = str.replace(match[0], value);
-      this.regexpUnescape.lastIndex = 0;
-      replaces++;
-      if (replaces >= this.maxReplaces) {
-        break;
+      var clonedOptions = _extends({}, options);
+      clonedOptions.applyPostProcessor = false; // avoid post processing on nested lookup
+
+      // if value is something like "myKey": "lorem $(anotherKey, { "count": {{aValueInOptions}} })"
+      function handleHasOptions(key, inheritedOptions) {
+        if (key.indexOf(',') < 0) return key;
+
+        var p = key.split(',');
+        key = p.shift();
+        var optionsString = p.join(',');
+        optionsString = this.interpolate(optionsString, clonedOptions);
+        optionsString = optionsString.replace(/'/g, '"');
+
+        try {
+          clonedOptions = JSON.parse(optionsString);
+
+          if (inheritedOptions) clonedOptions = _extends({}, inheritedOptions, clonedOptions);
+        } catch (e) {
+          this.logger.error('failed parsing options string in nesting for key ' + key, e);
+        }
+
+        return key;
       }
-    }
 
-    replaces = 0;
-    // regular escape on demand
-    while (match = this.regexp.exec(str)) {
-      value = handleFormat(match[1].trim());
-      if (value === undefined) {
-        if (typeof missingInterpolationHandler === 'function') {
-          var temp = missingInterpolationHandler(str, match, options);
-          value = typeof temp === 'string' ? temp : '';
-        } else {
-          this.logger.warn('missed to pass in variable ' + match[1] + ' for interpolating ' + str);
+      // regular escape on demand
+      while ((match = this.nestingRegexp.exec(str))) {
+        value = fc(handleHasOptions.call(this, match[1].trim(), clonedOptions), clonedOptions);
+
+        // is only the nesting key (key1 = '$(key2)') return the value without stringify
+        if (value && match[0] === str && typeof value !== 'string') return value;
+
+        // no string to include or empty
+        if (typeof value !== 'string') value = makeString(value);
+        if (!value) {
+          this.logger.warn('missed to resolve ' + match[1] + ' for nesting ' + str);
           value = '';
         }
-      } else if (typeof value !== 'string' && !this.useRawValueToEscape) {
-        value = makeString(value);
+        // Nested keys should not be escaped by default #854
+        // value = this.escapeValue ? regexSafe(utils.escape(value)) : regexSafe(value);
+        str = str.replace(match[0], value);
+        this.regexp.lastIndex = 0;
       }
-      value = this.escapeValue ? regexSafe(this.escape(value)) : regexSafe(value);
-      str = str.replace(match[0], value);
-      this.regexp.lastIndex = 0;
-      replaces++;
-      if (replaces >= this.maxReplaces) {
-        break;
-      }
-    }
-    return str;
-  };
-
-  Interpolator.prototype.nest = function nest(str, fc) {
-    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-
-    var match = void 0;
-    var value = void 0;
-
-    var clonedOptions = _extends({}, options);
-    clonedOptions.applyPostProcessor = false; // avoid post processing on nested lookup
-
-    // if value is something like "myKey": "lorem $(anotherKey, { "count": {{aValueInOptions}} })"
-    function handleHasOptions(key, inheritedOptions) {
-      if (key.indexOf(',') < 0) return key;
-
-      var p = key.split(',');
-      key = p.shift();
-      var optionsString = p.join(',');
-      optionsString = this.interpolate(optionsString, clonedOptions);
-      optionsString = optionsString.replace(/'/g, '"');
-
-      try {
-        clonedOptions = JSON.parse(optionsString);
-
-        if (inheritedOptions) clonedOptions = _extends({}, inheritedOptions, clonedOptions);
-      } catch (e) {
-        this.logger.error('failed parsing options string in nesting for key ' + key, e);
-      }
-
-      return key;
-    }
-
-    // regular escape on demand
-    while (match = this.nestingRegexp.exec(str)) {
-      value = fc(handleHasOptions.call(this, match[1].trim(), clonedOptions), clonedOptions);
-
-      // is only the nesting key (key1 = '$(key2)') return the value without stringify
-      if (value && match[0] === str && typeof value !== 'string') return value;
-
-      // no string to include or empty
-      if (typeof value !== 'string') value = makeString(value);
-      if (!value) {
-        this.logger.warn('missed to resolve ' + match[1] + ' for nesting ' + str);
-        value = '';
-      }
-      // Nested keys should not be escaped by default #854
-      // value = this.escapeValue ? regexSafe(utils.escape(value)) : regexSafe(value);
-      str = str.replace(match[0], value);
-      this.regexp.lastIndex = 0;
-    }
-    return str;
-  };
-
-  return Interpolator;
-}();
-
-function remove(arr, what) {
-  var found = arr.indexOf(what);
-
-  while (found !== -1) {
-    arr.splice(found, 1);
-    found = arr.indexOf(what);
-  }
-}
-
-var Connector = function (_EventEmitter) {
-  inherits(Connector, _EventEmitter);
-
-  function Connector(backend, store, services) {
-    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
-    classCallCheck(this, Connector);
-
-    var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
-
-    _this.backend = backend;
-    _this.store = store;
-    _this.languageUtils = services.languageUtils;
-    _this.options = options;
-    _this.logger = baseLogger.create('backendConnector');
-
-    _this.state = {};
-    _this.queue = [];
-
-    if (_this.backend && _this.backend.init) {
-      _this.backend.init(services, options.backend, options);
-    }
-    return _this;
-  }
-
-  Connector.prototype.queueLoad = function queueLoad(languages, namespaces, options, callback) {
-    var _this2 = this;
-
-    // find what needs to be loaded
-    var toLoad = [];
-    var pending = [];
-    var toLoadLanguages = [];
-    var toLoadNamespaces = [];
-
-    languages.forEach(function (lng) {
-      var hasAllNamespaces = true;
-
-      namespaces.forEach(function (ns) {
-        var name = lng + '|' + ns;
-
-        if (!options.reload && _this2.store.hasResourceBundle(lng, ns)) {
-          _this2.state[name] = 2; // loaded
-        } else if (_this2.state[name] < 0) {
-          // nothing to do for err
-        } else if (_this2.state[name] === 1) {
-          if (pending.indexOf(name) < 0) pending.push(name);
-        } else {
-          _this2.state[name] = 1; // pending
-
-          hasAllNamespaces = false;
-
-          if (pending.indexOf(name) < 0) pending.push(name);
-          if (toLoad.indexOf(name) < 0) toLoad.push(name);
-          if (toLoadNamespaces.indexOf(ns) < 0) toLoadNamespaces.push(ns);
-        }
-      });
-
-      if (!hasAllNamespaces) toLoadLanguages.push(lng);
-    });
-
-    if (toLoad.length || pending.length) {
-      this.queue.push({
-        pending: pending,
-        loaded: {},
-        errors: [],
-        callback: callback
-      });
-    }
-
-    return {
-      toLoad: toLoad,
-      pending: pending,
-      toLoadLanguages: toLoadLanguages,
-      toLoadNamespaces: toLoadNamespaces
+      return str;
     };
-  };
 
-  Connector.prototype.loaded = function loaded(name, err, data) {
-    var _name$split = name.split('|'),
+    return Interpolator;
+  })();
+
+  function remove(arr, what) {
+    var found = arr.indexOf(what);
+
+    while (found !== -1) {
+      arr.splice(found, 1);
+      found = arr.indexOf(what);
+    }
+  }
+
+  var Connector = (function(_EventEmitter) {
+    inherits(Connector, _EventEmitter);
+
+    function Connector(backend, store, services) {
+      var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+      classCallCheck(this, Connector);
+
+      var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
+
+      _this.backend = backend;
+      _this.store = store;
+      _this.languageUtils = services.languageUtils;
+      _this.options = options;
+      _this.logger = baseLogger.create('backendConnector');
+
+      _this.state = {};
+      _this.queue = [];
+
+      if (_this.backend && _this.backend.init) {
+        _this.backend.init(services, options.backend, options);
+      }
+      return _this;
+    }
+
+    Connector.prototype.queueLoad = function queueLoad(languages, namespaces, options, callback) {
+      var _this2 = this;
+
+      // find what needs to be loaded
+      var toLoad = [];
+      var pending = [];
+      var toLoadLanguages = [];
+      var toLoadNamespaces = [];
+
+      languages.forEach(function(lng) {
+        var hasAllNamespaces = true;
+
+        namespaces.forEach(function(ns) {
+          var name = lng + '|' + ns;
+
+          if (!options.reload && _this2.store.hasResourceBundle(lng, ns)) {
+            _this2.state[name] = 2; // loaded
+          } else if (_this2.state[name] < 0) {
+            // nothing to do for err
+          } else if (_this2.state[name] === 1) {
+            if (pending.indexOf(name) < 0) pending.push(name);
+          } else {
+            _this2.state[name] = 1; // pending
+
+            hasAllNamespaces = false;
+
+            if (pending.indexOf(name) < 0) pending.push(name);
+            if (toLoad.indexOf(name) < 0) toLoad.push(name);
+            if (toLoadNamespaces.indexOf(ns) < 0) toLoadNamespaces.push(ns);
+          }
+        });
+
+        if (!hasAllNamespaces) toLoadLanguages.push(lng);
+      });
+
+      if (toLoad.length || pending.length) {
+        this.queue.push({
+          pending: pending,
+          loaded: {},
+          errors: [],
+          callback: callback,
+        });
+      }
+
+      return {
+        toLoad: toLoad,
+        pending: pending,
+        toLoadLanguages: toLoadLanguages,
+        toLoadNamespaces: toLoadNamespaces,
+      };
+    };
+
+    Connector.prototype.loaded = function loaded(name, err, data) {
+      var _name$split = name.split('|'),
         _name$split2 = slicedToArray(_name$split, 2),
         lng = _name$split2[0],
         ns = _name$split2[1];
 
-    if (err) this.emit('failedLoading', lng, ns, err);
+      if (err) this.emit('failedLoading', lng, ns, err);
 
-    if (data) {
-      this.store.addResourceBundle(lng, ns, data);
-    }
+      if (data) {
+        this.store.addResourceBundle(lng, ns, data);
+      }
 
-    // set loaded
-    this.state[name] = err ? -1 : 2;
+      // set loaded
+      this.state[name] = err ? -1 : 2;
 
-    // consolidated loading done in this run - only emit once for a loaded namespace
-    var loaded = {};
+      // consolidated loading done in this run - only emit once for a loaded namespace
+      var loaded = {};
 
-    // callback if ready
-    this.queue.forEach(function (q) {
-      pushPath(q.loaded, [lng], ns);
-      remove(q.pending, name);
+      // callback if ready
+      this.queue.forEach(function(q) {
+        pushPath(q.loaded, [lng], ns);
+        remove(q.pending, name);
 
-      if (err) q.errors.push(err);
+        if (err) q.errors.push(err);
 
-      if (q.pending.length === 0 && !q.done) {
-        // only do once per loaded -> this.emit('loaded', q.loaded);
-        Object.keys(q.loaded).forEach(function (l) {
-          if (!loaded[l]) loaded[l] = [];
-          if (q.loaded[l].length) {
-            q.loaded[l].forEach(function (ns) {
-              if (loaded[l].indexOf(ns) < 0) loaded[l].push(ns);
-            });
+        if (q.pending.length === 0 && !q.done) {
+          // only do once per loaded -> this.emit('loaded', q.loaded);
+          Object.keys(q.loaded).forEach(function(l) {
+            if (!loaded[l]) loaded[l] = [];
+            if (q.loaded[l].length) {
+              q.loaded[l].forEach(function(ns) {
+                if (loaded[l].indexOf(ns) < 0) loaded[l].push(ns);
+              });
+            }
+          });
+
+          /* eslint no-param-reassign: 0 */
+          q.done = true;
+          if (q.errors.length) {
+            q.callback(q.errors);
+          } else {
+            q.callback();
           }
-        });
-
-        /* eslint no-param-reassign: 0 */
-        q.done = true;
-        if (q.errors.length) {
-          q.callback(q.errors);
-        } else {
-          q.callback();
         }
+      });
+
+      // emit consolidated loaded event
+      this.emit('loaded', loaded);
+
+      // remove done load requests
+      this.queue = this.queue.filter(function(q) {
+        return !q.done;
+      });
+    };
+
+    Connector.prototype.read = function read(lng, ns, fcName) {
+      var tried = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0;
+
+      var _this3 = this;
+
+      var wait = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 250;
+      var callback = arguments[5];
+
+      if (!lng.length) return callback(null, {}); // noting to load
+
+      return this.backend[fcName](lng, ns, function(err, data) {
+        if (err && data /* = retryFlag */ && tried < 5) {
+          setTimeout(function() {
+            _this3.read.call(_this3, lng, ns, fcName, tried + 1, wait * 2, callback);
+          }, wait);
+          return;
+        }
+        callback(err, data);
+      });
+    };
+
+    /* eslint consistent-return: 0 */
+
+    Connector.prototype.prepareLoading = function prepareLoading(languages, namespaces) {
+      var _this4 = this;
+
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var callback = arguments[3];
+
+      if (!this.backend) {
+        this.logger.warn('No backend was added via i18next.use. Will not load resources.');
+        return callback && callback();
       }
-    });
 
-    // emit consolidated loaded event
-    this.emit('loaded', loaded);
+      if (typeof languages === 'string')
+        languages = this.languageUtils.toResolveHierarchy(languages);
+      if (typeof namespaces === 'string') namespaces = [namespaces];
 
-    // remove done load requests
-    this.queue = this.queue.filter(function (q) {
-      return !q.done;
-    });
-  };
-
-  Connector.prototype.read = function read(lng, ns, fcName) {
-    var tried = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0;
-
-    var _this3 = this;
-
-    var wait = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : 250;
-    var callback = arguments[5];
-
-    if (!lng.length) return callback(null, {}); // noting to load
-
-    return this.backend[fcName](lng, ns, function (err, data) {
-      if (err && data /* = retryFlag */ && tried < 5) {
-        setTimeout(function () {
-          _this3.read.call(_this3, lng, ns, fcName, tried + 1, wait * 2, callback);
-        }, wait);
-        return;
+      var toLoad = this.queueLoad(languages, namespaces, options, callback);
+      if (!toLoad.toLoad.length) {
+        if (!toLoad.pending.length) callback(); // nothing to load and no pendings...callback now
+        return null; // pendings will trigger callback
       }
-      callback(err, data);
-    });
-  };
 
-  /* eslint consistent-return: 0 */
+      toLoad.toLoad.forEach(function(name) {
+        _this4.loadOne(name);
+      });
+    };
 
+    Connector.prototype.load = function load(languages, namespaces, callback) {
+      this.prepareLoading(languages, namespaces, {}, callback);
+    };
 
-  Connector.prototype.prepareLoading = function prepareLoading(languages, namespaces) {
-    var _this4 = this;
+    Connector.prototype.reload = function reload(languages, namespaces, callback) {
+      this.prepareLoading(languages, namespaces, { reload: true }, callback);
+    };
 
-    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    var callback = arguments[3];
+    Connector.prototype.loadOne = function loadOne(name) {
+      var _this5 = this;
 
-    if (!this.backend) {
-      this.logger.warn('No backend was added via i18next.use. Will not load resources.');
-      return callback && callback();
-    }
+      var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
 
-    if (typeof languages === 'string') languages = this.languageUtils.toResolveHierarchy(languages);
-    if (typeof namespaces === 'string') namespaces = [namespaces];
-
-    var toLoad = this.queueLoad(languages, namespaces, options, callback);
-    if (!toLoad.toLoad.length) {
-      if (!toLoad.pending.length) callback(); // nothing to load and no pendings...callback now
-      return null; // pendings will trigger callback
-    }
-
-    toLoad.toLoad.forEach(function (name) {
-      _this4.loadOne(name);
-    });
-  };
-
-  Connector.prototype.load = function load(languages, namespaces, callback) {
-    this.prepareLoading(languages, namespaces, {}, callback);
-  };
-
-  Connector.prototype.reload = function reload(languages, namespaces, callback) {
-    this.prepareLoading(languages, namespaces, { reload: true }, callback);
-  };
-
-  Connector.prototype.loadOne = function loadOne(name) {
-    var _this5 = this;
-
-    var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
-
-    var _name$split3 = name.split('|'),
+      var _name$split3 = name.split('|'),
         _name$split4 = slicedToArray(_name$split3, 2),
         lng = _name$split4[0],
         ns = _name$split4[1];
 
-    this.read(lng, ns, 'read', null, null, function (err, data) {
-      if (err) _this5.logger.warn(prefix + 'loading namespace ' + ns + ' for language ' + lng + ' failed', err);
-      if (!err && data) _this5.logger.log(prefix + 'loaded namespace ' + ns + ' for language ' + lng, data);
+      this.read(lng, ns, 'read', null, null, function(err, data) {
+        if (err)
+          _this5.logger.warn(
+            prefix + 'loading namespace ' + ns + ' for language ' + lng + ' failed',
+            err,
+          );
+        if (!err && data)
+          _this5.logger.log(prefix + 'loaded namespace ' + ns + ' for language ' + lng, data);
 
-      _this5.loaded(name, err, data);
-    });
-  };
+        _this5.loaded(name, err, data);
+      });
+    };
 
-  Connector.prototype.saveMissing = function saveMissing(languages, namespace, key, fallbackValue, isUpdate) {
-    var options = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : {};
+    Connector.prototype.saveMissing = function saveMissing(
+      languages,
+      namespace,
+      key,
+      fallbackValue,
+      isUpdate,
+    ) {
+      var options = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : {};
 
-    if (this.backend && this.backend.create) {
-      this.backend.create(languages, namespace, key, fallbackValue, null /* unused callback */, _extends({}, options, { isUpdate: isUpdate }));
-    }
-
-    // write to store to avoid resending
-    if (!languages || !languages[0]) return;
-    this.store.addResource(languages[0], namespace, key, fallbackValue);
-  };
-
-  return Connector;
-}(EventEmitter);
-
-function get$1() {
-  return {
-    debug: false,
-    initImmediate: true,
-
-    ns: ['translation'],
-    defaultNS: ['translation'],
-    fallbackLng: ['dev'],
-    fallbackNS: false, // string or array of namespaces
-
-    whitelist: false, // array with whitelisted languages
-    nonExplicitWhitelist: false,
-    load: 'all', // | currentOnly | languageOnly
-    preload: false, // array with preload languages
-
-    simplifyPluralSuffix: true,
-    keySeparator: '.',
-    nsSeparator: ':',
-    pluralSeparator: '_',
-    contextSeparator: '_',
-
-    partialBundledLanguages: false, // allow bundling certain languages that are not remotely fetched
-    saveMissing: false, // enable to send missing values
-    updateMissing: false, // enable to update default values if different from translated value (only useful on initial development, or when keeping code as source of truth)
-    saveMissingTo: 'fallback', // 'current' || 'all'
-    saveMissingPlurals: true, // will save all forms not only singular key
-    missingKeyHandler: false, // function(lng, ns, key, fallbackValue) -> override if prefer on handling
-    missingInterpolationHandler: false, // function(str, match)
-
-    postProcess: false, // string or array of postProcessor names
-    returnNull: true, // allows null value as valid translation
-    returnEmptyString: true, // allows empty string value as valid translation
-    returnObjects: false,
-    joinArrays: false, // or string to join array
-    returnedObjectHandler: function returnedObjectHandler() {}, // function(key, value, options) triggered if key returns object but returnObjects is set to false
-    parseMissingKeyHandler: false, // function(key) parsed a key that was not found in t() before returning
-    appendNamespaceToMissingKey: false,
-    appendNamespaceToCIMode: false,
-    overloadTranslationOptionHandler: function handle(args) {
-      var ret = {};
-      if (_typeof(args[1]) === 'object') ret = args[1];
-      if (typeof args[1] === 'string') ret.defaultValue = args[1];
-      if (typeof args[2] === 'string') ret.tDescription = args[2];
-      if (_typeof(args[2]) === 'object' || _typeof(args[3]) === 'object') {
-        var options = args[3] || args[2];
-        Object.keys(options).forEach(function (key) {
-          ret[key] = options[key];
-        });
+      if (this.backend && this.backend.create) {
+        this.backend.create(
+          languages,
+          namespace,
+          key,
+          fallbackValue,
+          null /* unused callback */,
+          _extends({}, options, { isUpdate: isUpdate }),
+        );
       }
-      return ret;
-    },
-    interpolation: {
-      escapeValue: true,
-      format: function format(value, _format, lng) {
-        return value;
+
+      // write to store to avoid resending
+      if (!languages || !languages[0]) return;
+      this.store.addResource(languages[0], namespace, key, fallbackValue);
+    };
+
+    return Connector;
+  })(EventEmitter);
+
+  function get$1() {
+    return {
+      debug: false,
+      initImmediate: true,
+
+      ns: ['translation'],
+      defaultNS: ['translation'],
+      fallbackLng: ['dev'],
+      fallbackNS: false, // string or array of namespaces
+
+      whitelist: false, // array with whitelisted languages
+      nonExplicitWhitelist: false,
+      load: 'all', // | currentOnly | languageOnly
+      preload: false, // array with preload languages
+
+      simplifyPluralSuffix: true,
+      keySeparator: '.',
+      nsSeparator: ':',
+      pluralSeparator: '_',
+      contextSeparator: '_',
+
+      partialBundledLanguages: false, // allow bundling certain languages that are not remotely fetched
+      saveMissing: false, // enable to send missing values
+      updateMissing: false, // enable to update default values if different from translated value (only useful on initial development, or when keeping code as source of truth)
+      saveMissingTo: 'fallback', // 'current' || 'all'
+      saveMissingPlurals: true, // will save all forms not only singular key
+      missingKeyHandler: false, // function(lng, ns, key, fallbackValue) -> override if prefer on handling
+      missingInterpolationHandler: false, // function(str, match)
+
+      postProcess: false, // string or array of postProcessor names
+      returnNull: true, // allows null value as valid translation
+      returnEmptyString: true, // allows empty string value as valid translation
+      returnObjects: false,
+      joinArrays: false, // or string to join array
+      returnedObjectHandler: function returnedObjectHandler() {}, // function(key, value, options) triggered if key returns object but returnObjects is set to false
+      parseMissingKeyHandler: false, // function(key) parsed a key that was not found in t() before returning
+      appendNamespaceToMissingKey: false,
+      appendNamespaceToCIMode: false,
+      overloadTranslationOptionHandler: function handle(args) {
+        var ret = {};
+        if (_typeof(args[1]) === 'object') ret = args[1];
+        if (typeof args[1] === 'string') ret.defaultValue = args[1];
+        if (typeof args[2] === 'string') ret.tDescription = args[2];
+        if (_typeof(args[2]) === 'object' || _typeof(args[3]) === 'object') {
+          var options = args[3] || args[2];
+          Object.keys(options).forEach(function(key) {
+            ret[key] = options[key];
+          });
+        }
+        return ret;
       },
-      prefix: '{{',
-      suffix: '}}',
-      formatSeparator: ',',
-      // prefixEscaped: '{{',
-      // suffixEscaped: '}}',
-      // unescapeSuffix: '',
-      unescapePrefix: '-',
+      interpolation: {
+        escapeValue: true,
+        format: function format(value, _format, lng) {
+          return value;
+        },
+        prefix: '{{',
+        suffix: '}}',
+        formatSeparator: ',',
+        // prefixEscaped: '{{',
+        // suffixEscaped: '}}',
+        // unescapeSuffix: '',
+        unescapePrefix: '-',
 
-      nestingPrefix: '$t(',
-      nestingSuffix: ')',
-      // nestingPrefixEscaped: '$t(',
-      // nestingSuffixEscaped: ')',
-      // defaultVariables: undefined // object that can have values to interpolate on - extends passed in interpolation data
-      maxReplaces: 1000 // max replaces to prevent endless loop
-    }
-  };
-}
-
-/* eslint no-param-reassign: 0 */
-function transformOptions(options) {
-  // create namespace object if namespace is passed in as string
-  if (typeof options.ns === 'string') options.ns = [options.ns];
-  if (typeof options.fallbackLng === 'string') options.fallbackLng = [options.fallbackLng];
-  if (typeof options.fallbackNS === 'string') options.fallbackNS = [options.fallbackNS];
-
-  // extend whitelist with cimode
-  if (options.whitelist && options.whitelist.indexOf('cimode') < 0) {
-    options.whitelist = options.whitelist.concat(['cimode']);
+        nestingPrefix: '$t(',
+        nestingSuffix: ')',
+        // nestingPrefixEscaped: '$t(',
+        // nestingSuffixEscaped: ')',
+        // defaultVariables: undefined // object that can have values to interpolate on - extends passed in interpolation data
+        maxReplaces: 1000, // max replaces to prevent endless loop
+      },
+    };
   }
 
-  return options;
-}
+  /* eslint no-param-reassign: 0 */
+  function transformOptions(options) {
+    // create namespace object if namespace is passed in as string
+    if (typeof options.ns === 'string') options.ns = [options.ns];
+    if (typeof options.fallbackLng === 'string') options.fallbackLng = [options.fallbackLng];
+    if (typeof options.fallbackNS === 'string') options.fallbackNS = [options.fallbackNS];
 
-function noop() {}
-
-var I18n = function (_EventEmitter) {
-  inherits(I18n, _EventEmitter);
-
-  function I18n() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var callback = arguments[1];
-    classCallCheck(this, I18n);
-
-    var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
-
-    _this.options = transformOptions(options);
-    _this.services = {};
-    _this.logger = baseLogger;
-    _this.modules = { external: [] };
-
-    if (callback && !_this.isInitialized && !options.isClone) {
-      // https://github.com/i18next/i18next/issues/879
-      if (!_this.options.initImmediate) {
-        var _ret;
-
-        _this.init(options, callback);
-        return _ret = _this, possibleConstructorReturn(_this, _ret);
-      }
-      setTimeout(function () {
-        _this.init(options, callback);
-      }, 0);
+    // extend whitelist with cimode
+    if (options.whitelist && options.whitelist.indexOf('cimode') < 0) {
+      options.whitelist = options.whitelist.concat(['cimode']);
     }
-    return _this;
+
+    return options;
   }
 
-  I18n.prototype.init = function init() {
-    var _this2 = this;
+  function noop() {}
 
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var callback = arguments[1];
+  var I18n = (function(_EventEmitter) {
+    inherits(I18n, _EventEmitter);
 
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
+    function I18n() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var callback = arguments[1];
+      classCallCheck(this, I18n);
+
+      var _this = possibleConstructorReturn(this, _EventEmitter.call(this));
+
+      _this.options = transformOptions(options);
+      _this.services = {};
+      _this.logger = baseLogger;
+      _this.modules = { external: [] };
+
+      if (callback && !_this.isInitialized && !options.isClone) {
+        // https://github.com/i18next/i18next/issues/879
+        if (!_this.options.initImmediate) {
+          var _ret;
+
+          _this.init(options, callback);
+          return (_ret = _this), possibleConstructorReturn(_this, _ret);
+        }
+        setTimeout(function() {
+          _this.init(options, callback);
+        }, 0);
+      }
+      return _this;
     }
-    this.options = _extends({}, get$1(), this.options, transformOptions(options));
 
-    this.format = this.options.interpolation.format;
-    if (!callback) callback = noop;
+    I18n.prototype.init = function init() {
+      var _this2 = this;
 
-    function createClassOnDemand(ClassOrObject) {
-      if (!ClassOrObject) return null;
-      if (typeof ClassOrObject === 'function') return new ClassOrObject();
-      return ClassOrObject;
-    }
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var callback = arguments[1];
 
-    // init services
-    if (!this.options.isClone) {
-      if (this.modules.logger) {
-        baseLogger.init(createClassOnDemand(this.modules.logger), this.options);
-      } else {
-        baseLogger.init(null, this.options);
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      this.options = _extends({}, get$1(), this.options, transformOptions(options));
+
+      this.format = this.options.interpolation.format;
+      if (!callback) callback = noop;
+
+      function createClassOnDemand(ClassOrObject) {
+        if (!ClassOrObject) return null;
+        if (typeof ClassOrObject === 'function') return new ClassOrObject();
+        return ClassOrObject;
       }
 
-      var lu = new LanguageUtil(this.options);
-      this.store = new ResourceStore(this.options.resources, this.options);
-
-      var s = this.services;
-      s.logger = baseLogger;
-      s.resourceStore = this.store;
-      s.languageUtils = lu;
-      s.pluralResolver = new PluralResolver(lu, { prepend: this.options.pluralSeparator, compatibilityJSON: this.options.compatibilityJSON, simplifyPluralSuffix: this.options.simplifyPluralSuffix });
-      s.interpolator = new Interpolator(this.options);
-
-      s.backendConnector = new Connector(createClassOnDemand(this.modules.backend), s.resourceStore, s, this.options);
-      // pipe events from backendConnector
-      s.backendConnector.on('*', function (event) {
-        for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-          args[_key - 1] = arguments[_key];
+      // init services
+      if (!this.options.isClone) {
+        if (this.modules.logger) {
+          baseLogger.init(createClassOnDemand(this.modules.logger), this.options);
+        } else {
+          baseLogger.init(null, this.options);
         }
 
-        _this2.emit.apply(_this2, [event].concat(args));
-      });
+        var lu = new LanguageUtil(this.options);
+        this.store = new ResourceStore(this.options.resources, this.options);
 
-      if (this.modules.languageDetector) {
-        s.languageDetector = createClassOnDemand(this.modules.languageDetector);
-        s.languageDetector.init(s, this.options.detection, this.options);
-      }
+        var s = this.services;
+        s.logger = baseLogger;
+        s.resourceStore = this.store;
+        s.languageUtils = lu;
+        s.pluralResolver = new PluralResolver(lu, {
+          prepend: this.options.pluralSeparator,
+          compatibilityJSON: this.options.compatibilityJSON,
+          simplifyPluralSuffix: this.options.simplifyPluralSuffix,
+        });
+        s.interpolator = new Interpolator(this.options);
 
-      if (this.modules.i18nFormat) {
-        s.i18nFormat = createClassOnDemand(this.modules.i18nFormat);
-        if (s.i18nFormat.init) s.i18nFormat.init(this);
-      }
+        s.backendConnector = new Connector(
+          createClassOnDemand(this.modules.backend),
+          s.resourceStore,
+          s,
+          this.options,
+        );
+        // pipe events from backendConnector
+        s.backendConnector.on('*', function(event) {
+          for (
+            var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1;
+            _key < _len;
+            _key++
+          ) {
+            args[_key - 1] = arguments[_key];
+          }
 
-      this.translator = new Translator(this.services, this.options);
-      // pipe events from translator
-      this.translator.on('*', function (event) {
-        for (var _len2 = arguments.length, args = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
-          args[_key2 - 1] = arguments[_key2];
+          _this2.emit.apply(_this2, [event].concat(args));
+        });
+
+        if (this.modules.languageDetector) {
+          s.languageDetector = createClassOnDemand(this.modules.languageDetector);
+          s.languageDetector.init(s, this.options.detection, this.options);
         }
 
-        _this2.emit.apply(_this2, [event].concat(args));
+        if (this.modules.i18nFormat) {
+          s.i18nFormat = createClassOnDemand(this.modules.i18nFormat);
+          if (s.i18nFormat.init) s.i18nFormat.init(this);
+        }
+
+        this.translator = new Translator(this.services, this.options);
+        // pipe events from translator
+        this.translator.on('*', function(event) {
+          for (
+            var _len2 = arguments.length, args = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1;
+            _key2 < _len2;
+            _key2++
+          ) {
+            args[_key2 - 1] = arguments[_key2];
+          }
+
+          _this2.emit.apply(_this2, [event].concat(args));
+        });
+
+        this.modules.external.forEach(function(m) {
+          if (m.init) m.init(_this2);
+        });
+      }
+
+      // append api
+      var storeApi = [
+        'getResource',
+        'addResource',
+        'addResources',
+        'addResourceBundle',
+        'removeResourceBundle',
+        'hasResourceBundle',
+        'getResourceBundle',
+        'getDataByLanguage',
+      ];
+      storeApi.forEach(function(fcName) {
+        _this2[fcName] = function() {
+          var _store;
+
+          return (_store = _this2.store)[fcName].apply(_store, arguments);
+        };
       });
 
-      this.modules.external.forEach(function (m) {
-        if (m.init) m.init(_this2);
-      });
-    }
+      var deferred = defer();
 
-    // append api
-    var storeApi = ['getResource', 'addResource', 'addResources', 'addResourceBundle', 'removeResourceBundle', 'hasResourceBundle', 'getResourceBundle', 'getDataByLanguage'];
-    storeApi.forEach(function (fcName) {
-      _this2[fcName] = function () {
-        var _store;
+      var load = function load() {
+        _this2.changeLanguage(_this2.options.lng, function(err, t) {
+          _this2.isInitialized = true;
+          _this2.logger.log('initialized', _this2.options);
+          _this2.emit('initialized', _this2.options);
 
-        return (_store = _this2.store)[fcName].apply(_store, arguments);
-      };
-    });
-
-    var deferred = defer();
-
-    var load = function load() {
-      _this2.changeLanguage(_this2.options.lng, function (err, t) {
-        _this2.isInitialized = true;
-        _this2.logger.log('initialized', _this2.options);
-        _this2.emit('initialized', _this2.options);
-
-        deferred.resolve(t); // not rejecting on err (as err is only a loading translation failed warning)
-        callback(err, t);
-      });
-    };
-
-    if (this.options.resources || !this.options.initImmediate) {
-      load();
-    } else {
-      setTimeout(load, 0);
-    }
-
-    return deferred;
-  };
-
-  /* eslint consistent-return: 0 */
-
-
-  I18n.prototype.loadResources = function loadResources() {
-    var _this3 = this;
-
-    var callback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : noop;
-
-    if (!this.options.resources || this.options.partialBundledLanguages) {
-      if (this.language && this.language.toLowerCase() === 'cimode') return callback(); // avoid loading resources for cimode
-
-      var toLoad = [];
-
-      var append = function append(lng) {
-        if (!lng) return;
-        var lngs = _this3.services.languageUtils.toResolveHierarchy(lng);
-        lngs.forEach(function (l) {
-          if (toLoad.indexOf(l) < 0) toLoad.push(l);
+          deferred.resolve(t); // not rejecting on err (as err is only a loading translation failed warning)
+          callback(err, t);
         });
       };
 
-      if (!this.language) {
-        // at least load fallbacks in this case
-        var fallbacks = this.services.languageUtils.getFallbackCodes(this.options.fallbackLng);
-        fallbacks.forEach(function (l) {
-          return append(l);
-        });
+      if (this.options.resources || !this.options.initImmediate) {
+        load();
       } else {
-        append(this.language);
+        setTimeout(load, 0);
       }
 
-      if (this.options.preload) {
-        this.options.preload.forEach(function (l) {
-          return append(l);
+      return deferred;
+    };
+
+    /* eslint consistent-return: 0 */
+
+    I18n.prototype.loadResources = function loadResources() {
+      var _this3 = this;
+
+      var callback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : noop;
+
+      if (!this.options.resources || this.options.partialBundledLanguages) {
+        if (this.language && this.language.toLowerCase() === 'cimode') return callback(); // avoid loading resources for cimode
+
+        var toLoad = [];
+
+        var append = function append(lng) {
+          if (!lng) return;
+          var lngs = _this3.services.languageUtils.toResolveHierarchy(lng);
+          lngs.forEach(function(l) {
+            if (toLoad.indexOf(l) < 0) toLoad.push(l);
+          });
+        };
+
+        if (!this.language) {
+          // at least load fallbacks in this case
+          var fallbacks = this.services.languageUtils.getFallbackCodes(this.options.fallbackLng);
+          fallbacks.forEach(function(l) {
+            return append(l);
+          });
+        } else {
+          append(this.language);
+        }
+
+        if (this.options.preload) {
+          this.options.preload.forEach(function(l) {
+            return append(l);
+          });
+        }
+
+        this.services.backendConnector.load(toLoad, this.options.ns, callback);
+      } else {
+        callback(null);
+      }
+    };
+
+    I18n.prototype.reloadResources = function reloadResources(lngs, ns, callback) {
+      var deferred = defer();
+      if (!lngs) lngs = this.languages;
+      if (!ns) ns = this.options.ns;
+      if (!callback) callback = noop;
+      this.services.backendConnector.reload(lngs, ns, function() {
+        deferred.resolve();
+        callback(null);
+      });
+      return deferred;
+    };
+
+    I18n.prototype.use = function use(module) {
+      if (module.type === 'backend') {
+        this.modules.backend = module;
+      }
+
+      if (module.type === 'logger' || (module.log && module.warn && module.error)) {
+        this.modules.logger = module;
+      }
+
+      if (module.type === 'languageDetector') {
+        this.modules.languageDetector = module;
+      }
+
+      if (module.type === 'i18nFormat') {
+        this.modules.i18nFormat = module;
+      }
+
+      if (module.type === 'postProcessor') {
+        postProcessor.addPostProcessor(module);
+      }
+
+      if (module.type === '3rdParty') {
+        this.modules.external.push(module);
+      }
+
+      return this;
+    };
+
+    I18n.prototype.changeLanguage = function changeLanguage(lng, callback) {
+      var _this4 = this;
+
+      var deferred = defer();
+
+      var done = function done(err, l) {
+        _this4.translator.changeLanguage(l);
+
+        if (l) {
+          _this4.emit('languageChanged', l);
+          _this4.logger.log('languageChanged', l);
+        }
+
+        deferred.resolve(function() {
+          return _this4.t.apply(_this4, arguments);
         });
+        if (callback)
+          callback(err, function() {
+            return _this4.t.apply(_this4, arguments);
+          });
+      };
+
+      var setLng = function setLng(l) {
+        if (l) {
+          _this4.language = l;
+          _this4.languages = _this4.services.languageUtils.toResolveHierarchy(l);
+          if (!_this4.translator.language) _this4.translator.changeLanguage(l);
+
+          if (_this4.services.languageDetector)
+            _this4.services.languageDetector.cacheUserLanguage(l);
+        }
+
+        _this4.loadResources(function(err) {
+          done(err, l);
+        });
+      };
+
+      if (!lng && this.services.languageDetector && !this.services.languageDetector.async) {
+        setLng(this.services.languageDetector.detect());
+      } else if (!lng && this.services.languageDetector && this.services.languageDetector.async) {
+        this.services.languageDetector.detect(setLng);
+      } else {
+        setLng(lng);
       }
 
-      this.services.backendConnector.load(toLoad, this.options.ns, callback);
-    } else {
-      callback(null);
-    }
-  };
-
-  I18n.prototype.reloadResources = function reloadResources(lngs, ns, callback) {
-    var deferred = defer();
-    if (!lngs) lngs = this.languages;
-    if (!ns) ns = this.options.ns;
-    if (!callback) callback = noop;
-    this.services.backendConnector.reload(lngs, ns, function () {
-      deferred.resolve();
-      callback(null);
-    });
-    return deferred;
-  };
-
-  I18n.prototype.use = function use(module) {
-    if (module.type === 'backend') {
-      this.modules.backend = module;
-    }
-
-    if (module.type === 'logger' || module.log && module.warn && module.error) {
-      this.modules.logger = module;
-    }
-
-    if (module.type === 'languageDetector') {
-      this.modules.languageDetector = module;
-    }
-
-    if (module.type === 'i18nFormat') {
-      this.modules.i18nFormat = module;
-    }
-
-    if (module.type === 'postProcessor') {
-      postProcessor.addPostProcessor(module);
-    }
-
-    if (module.type === '3rdParty') {
-      this.modules.external.push(module);
-    }
-
-    return this;
-  };
-
-  I18n.prototype.changeLanguage = function changeLanguage(lng, callback) {
-    var _this4 = this;
-
-    var deferred = defer();
-
-    var done = function done(err, l) {
-      _this4.translator.changeLanguage(l);
-
-      if (l) {
-        _this4.emit('languageChanged', l);
-        _this4.logger.log('languageChanged', l);
-      }
-
-      deferred.resolve(function () {
-        return _this4.t.apply(_this4, arguments);
-      });
-      if (callback) callback(err, function () {
-        return _this4.t.apply(_this4, arguments);
-      });
+      return deferred;
     };
 
-    var setLng = function setLng(l) {
-      if (l) {
-        _this4.language = l;
-        _this4.languages = _this4.services.languageUtils.toResolveHierarchy(l);
-        if (!_this4.translator.language) _this4.translator.changeLanguage(l);
+    I18n.prototype.getFixedT = function getFixedT(lng, ns) {
+      var _this5 = this;
 
-        if (_this4.services.languageDetector) _this4.services.languageDetector.cacheUserLanguage(l);
+      var fixedT = function fixedT(key, opts) {
+        for (
+          var _len3 = arguments.length, rest = Array(_len3 > 2 ? _len3 - 2 : 0), _key3 = 2;
+          _key3 < _len3;
+          _key3++
+        ) {
+          rest[_key3 - 2] = arguments[_key3];
+        }
+
+        var options = _extends({}, opts);
+        if ((typeof opts === 'undefined' ? 'undefined' : _typeof(opts)) !== 'object') {
+          options = _this5.options.overloadTranslationOptionHandler([key, opts].concat(rest));
+        }
+
+        options.lng = options.lng || fixedT.lng;
+        options.lngs = options.lngs || fixedT.lngs;
+        options.ns = options.ns || fixedT.ns;
+        return _this5.t(key, options);
+      };
+      if (typeof lng === 'string') {
+        fixedT.lng = lng;
+      } else {
+        fixedT.lngs = lng;
       }
+      fixedT.ns = ns;
+      return fixedT;
+    };
 
-      _this4.loadResources(function (err) {
-        done(err, l);
+    I18n.prototype.t = function t() {
+      var _translator;
+
+      return (
+        this.translator && (_translator = this.translator).translate.apply(_translator, arguments)
+      );
+    };
+
+    I18n.prototype.exists = function exists() {
+      var _translator2;
+
+      return (
+        this.translator && (_translator2 = this.translator).exists.apply(_translator2, arguments)
+      );
+    };
+
+    I18n.prototype.setDefaultNamespace = function setDefaultNamespace(ns) {
+      this.options.defaultNS = ns;
+    };
+
+    I18n.prototype.loadNamespaces = function loadNamespaces(ns, callback) {
+      var _this6 = this;
+
+      var deferred = defer();
+
+      if (!this.options.ns) {
+        callback && callback();
+        return Promise.resolve();
+      }
+      if (typeof ns === 'string') ns = [ns];
+
+      ns.forEach(function(n) {
+        if (_this6.options.ns.indexOf(n) < 0) _this6.options.ns.push(n);
       });
+
+      this.loadResources(function(err) {
+        deferred.resolve();
+        if (callback) callback(err);
+      });
+
+      return deferred;
     };
 
-    if (!lng && this.services.languageDetector && !this.services.languageDetector.async) {
-      setLng(this.services.languageDetector.detect());
-    } else if (!lng && this.services.languageDetector && this.services.languageDetector.async) {
-      this.services.languageDetector.detect(setLng);
-    } else {
-      setLng(lng);
-    }
+    I18n.prototype.loadLanguages = function loadLanguages(lngs, callback) {
+      var deferred = defer();
 
-    return deferred;
-  };
+      if (typeof lngs === 'string') lngs = [lngs];
+      var preloaded = this.options.preload || [];
 
-  I18n.prototype.getFixedT = function getFixedT(lng, ns) {
-    var _this5 = this;
-
-    var fixedT = function fixedT(key, opts) {
-      for (var _len3 = arguments.length, rest = Array(_len3 > 2 ? _len3 - 2 : 0), _key3 = 2; _key3 < _len3; _key3++) {
-        rest[_key3 - 2] = arguments[_key3];
+      var newLngs = lngs.filter(function(lng) {
+        return preloaded.indexOf(lng) < 0;
+      });
+      // Exit early if all given languages are already preloaded
+      if (!newLngs.length) {
+        if (callback) callback();
+        return Promise.resolve();
       }
 
-      var options = _extends({}, opts);
-      if ((typeof opts === 'undefined' ? 'undefined' : _typeof(opts)) !== 'object') {
-        options = _this5.options.overloadTranslationOptionHandler([key, opts].concat(rest));
-      }
+      this.options.preload = preloaded.concat(newLngs);
+      this.loadResources(function(err) {
+        deferred.resolve();
+        if (callback) callback(err);
+      });
 
-      options.lng = options.lng || fixedT.lng;
-      options.lngs = options.lngs || fixedT.lngs;
-      options.ns = options.ns || fixedT.ns;
-      return _this5.t(key, options);
+      return deferred;
     };
-    if (typeof lng === 'string') {
-      fixedT.lng = lng;
-    } else {
-      fixedT.lngs = lng;
-    }
-    fixedT.ns = ns;
-    return fixedT;
-  };
 
-  I18n.prototype.t = function t() {
-    var _translator;
+    I18n.prototype.dir = function dir(lng) {
+      if (!lng)
+        lng = this.languages && this.languages.length > 0 ? this.languages[0] : this.language;
+      if (!lng) return 'rtl';
 
-    return this.translator && (_translator = this.translator).translate.apply(_translator, arguments);
-  };
+      var rtlLngs = [
+        'ar',
+        'shu',
+        'sqr',
+        'ssh',
+        'xaa',
+        'yhd',
+        'yud',
+        'aao',
+        'abh',
+        'abv',
+        'acm',
+        'acq',
+        'acw',
+        'acx',
+        'acy',
+        'adf',
+        'ads',
+        'aeb',
+        'aec',
+        'afb',
+        'ajp',
+        'apc',
+        'apd',
+        'arb',
+        'arq',
+        'ars',
+        'ary',
+        'arz',
+        'auz',
+        'avl',
+        'ayh',
+        'ayl',
+        'ayn',
+        'ayp',
+        'bbz',
+        'pga',
+        'he',
+        'iw',
+        'ps',
+        'pbt',
+        'pbu',
+        'pst',
+        'prp',
+        'prd',
+        'ur',
+        'ydd',
+        'yds',
+        'yih',
+        'ji',
+        'yi',
+        'hbo',
+        'men',
+        'xmn',
+        'fa',
+        'jpr',
+        'peo',
+        'pes',
+        'prs',
+        'dv',
+        'sam',
+      ];
 
-  I18n.prototype.exists = function exists() {
-    var _translator2;
+      return rtlLngs.indexOf(this.services.languageUtils.getLanguagePartFromCode(lng)) >= 0
+        ? 'rtl'
+        : 'ltr';
+    };
 
-    return this.translator && (_translator2 = this.translator).exists.apply(_translator2, arguments);
-  };
+    /* eslint class-methods-use-this: 0 */
 
-  I18n.prototype.setDefaultNamespace = function setDefaultNamespace(ns) {
-    this.options.defaultNS = ns;
-  };
+    I18n.prototype.createInstance = function createInstance() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var callback = arguments[1];
 
-  I18n.prototype.loadNamespaces = function loadNamespaces(ns, callback) {
-    var _this6 = this;
+      return new I18n(options, callback);
+    };
 
-    var deferred = defer();
+    I18n.prototype.cloneInstance = function cloneInstance() {
+      var _this7 = this;
 
-    if (!this.options.ns) {
-      callback && callback();
-      return Promise.resolve();
-    }
-    if (typeof ns === 'string') ns = [ns];
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var callback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : noop;
 
-    ns.forEach(function (n) {
-      if (_this6.options.ns.indexOf(n) < 0) _this6.options.ns.push(n);
-    });
+      var mergedOptions = _extends({}, this.options, options, { isClone: true });
+      var clone = new I18n(mergedOptions);
+      var membersToCopy = ['store', 'services', 'language'];
+      membersToCopy.forEach(function(m) {
+        clone[m] = _this7[m];
+      });
+      clone.translator = new Translator(clone.services, clone.options);
+      clone.translator.on('*', function(event) {
+        for (
+          var _len4 = arguments.length, args = Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1;
+          _key4 < _len4;
+          _key4++
+        ) {
+          args[_key4 - 1] = arguments[_key4];
+        }
 
-    this.loadResources(function (err) {
-      deferred.resolve();
-      if (callback) callback(err);
-    });
+        clone.emit.apply(clone, [event].concat(args));
+      });
+      clone.init(mergedOptions, callback);
+      clone.translator.options = clone.options; // sync options
 
-    return deferred;
-  };
+      return clone;
+    };
 
-  I18n.prototype.loadLanguages = function loadLanguages(lngs, callback) {
-    var deferred = defer();
+    return I18n;
+  })(EventEmitter);
 
-    if (typeof lngs === 'string') lngs = [lngs];
-    var preloaded = this.options.preload || [];
+  var i18next = new I18n();
 
-    var newLngs = lngs.filter(function (lng) {
-      return preloaded.indexOf(lng) < 0;
-    });
-    // Exit early if all given languages are already preloaded
-    if (!newLngs.length) {
-      if (callback) callback();
-      return Promise.resolve();
-    }
-
-    this.options.preload = preloaded.concat(newLngs);
-    this.loadResources(function (err) {
-      deferred.resolve();
-      if (callback) callback(err);
-    });
-
-    return deferred;
-  };
-
-  I18n.prototype.dir = function dir(lng) {
-    if (!lng) lng = this.languages && this.languages.length > 0 ? this.languages[0] : this.language;
-    if (!lng) return 'rtl';
-
-    var rtlLngs = ['ar', 'shu', 'sqr', 'ssh', 'xaa', 'yhd', 'yud', 'aao', 'abh', 'abv', 'acm', 'acq', 'acw', 'acx', 'acy', 'adf', 'ads', 'aeb', 'aec', 'afb', 'ajp', 'apc', 'apd', 'arb', 'arq', 'ars', 'ary', 'arz', 'auz', 'avl', 'ayh', 'ayl', 'ayn', 'ayp', 'bbz', 'pga', 'he', 'iw', 'ps', 'pbt', 'pbu', 'pst', 'prp', 'prd', 'ur', 'ydd', 'yds', 'yih', 'ji', 'yi', 'hbo', 'men', 'xmn', 'fa', 'jpr', 'peo', 'pes', 'prs', 'dv', 'sam'];
-
-    return rtlLngs.indexOf(this.services.languageUtils.getLanguagePartFromCode(lng)) >= 0 ? 'rtl' : 'ltr';
-  };
-
-  /* eslint class-methods-use-this: 0 */
-
-
-  I18n.prototype.createInstance = function createInstance() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var callback = arguments[1];
-
-    return new I18n(options, callback);
-  };
-
-  I18n.prototype.cloneInstance = function cloneInstance() {
-    var _this7 = this;
-
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var callback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : noop;
-
-    var mergedOptions = _extends({}, this.options, options, { isClone: true });
-    var clone = new I18n(mergedOptions);
-    var membersToCopy = ['store', 'services', 'language'];
-    membersToCopy.forEach(function (m) {
-      clone[m] = _this7[m];
-    });
-    clone.translator = new Translator(clone.services, clone.options);
-    clone.translator.on('*', function (event) {
-      for (var _len4 = arguments.length, args = Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
-        args[_key4 - 1] = arguments[_key4];
-      }
-
-      clone.emit.apply(clone, [event].concat(args));
-    });
-    clone.init(mergedOptions, callback);
-    clone.translator.options = clone.options; // sync options
-
-    return clone;
-  };
-
-  return I18n;
-}(EventEmitter);
-
-var i18next = new I18n();
-
-return i18next;
-
-})));
+  return i18next;
+});

--- a/i18next.min.js
+++ b/i18next.min.js
@@ -1,2 +1,1708 @@
-!function(t,e){"object"==typeof exports&&"undefined"!=typeof module?module.exports=e():"function"==typeof define&&define.amd?define(e):t.i18next=e()}(this,function(){"use strict";function t(){var t=void 0,e=void 0,n=new Promise(function(n,o){t=n,e=o});return n.resolve=t,n.reject=e,n}function e(t){return null==t?"":""+t}function n(t,e,n){t.forEach(function(t){e[t]&&(n[t]=e[t])})}function o(t,e,n){function o(t){return t&&t.indexOf("###")>-1?t.replace(/###/g,"."):t}function r(){return!t||"string"==typeof t}for(var i="string"!=typeof e?[].concat(e):e.split(".");i.length>1;){if(r())return{};var s=o(i.shift());!t[s]&&n&&(t[s]=new n),t=t[s]}return r()?{}:{obj:t,k:o(i.shift())}}function r(t,e,n){var r=o(t,e,Object);r.obj[r.k]=n}function i(t,e,n,r){var i=o(t,e,Object),s=i.obj,a=i.k;s[a]=s[a]||[],r&&(s[a]=s[a].concat(n)),r||s[a].push(n)}function s(t,e){var n=o(t,e),r=n.obj,i=n.k;if(r)return r[i]}function a(t,e,n){for(var o in e)o in t?"string"==typeof t[o]||t[o]instanceof String||"string"==typeof e[o]||e[o]instanceof String?n&&(t[o]=e[o]):a(t[o],e[o],n):t[o]=e[o];return t}function u(t){return t.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,"\\$&")}function l(t){return"string"==typeof t?t.replace(/[&<>"'\/]/g,function(t){return j[t]}):t}function p(t){return t.charAt(0).toUpperCase()+t.slice(1)}function c(){var t={};return F.forEach(function(e){e.lngs.forEach(function(n){t[n]={numbers:e.nr,plurals:A[e.fc]}})}),t}function f(t,e){for(var n=t.indexOf(e);-1!==n;)t.splice(n,1),n=t.indexOf(e)}function g(){return{debug:!1,initImmediate:!0,ns:["translation"],defaultNS:["translation"],fallbackLng:["dev"],fallbackNS:!1,whitelist:!1,nonExplicitWhitelist:!1,load:"all",preload:!1,simplifyPluralSuffix:!0,keySeparator:".",nsSeparator:":",pluralSeparator:"_",contextSeparator:"_",partialBundledLanguages:!1,saveMissing:!1,updateMissing:!1,saveMissingTo:"fallback",saveMissingPlurals:!0,missingKeyHandler:!1,missingInterpolationHandler:!1,postProcess:!1,returnNull:!0,returnEmptyString:!0,returnObjects:!1,joinArrays:!1,returnedObjectHandler:function(){},parseMissingKeyHandler:!1,appendNamespaceToMissingKey:!1,appendNamespaceToCIMode:!1,overloadTranslationOptionHandler:function(t){var e={};if("object"===v(t[1])&&(e=t[1]),"string"==typeof t[1]&&(e.defaultValue=t[1]),"string"==typeof t[2]&&(e.tDescription=t[2]),"object"===v(t[2])||"object"===v(t[3])){var n=t[3]||t[2];Object.keys(n).forEach(function(t){e[t]=n[t]})}return e},interpolation:{escapeValue:!0,format:function(t,e,n){return t},prefix:"{{",suffix:"}}",formatSeparator:",",unescapePrefix:"-",nestingPrefix:"$t(",nestingSuffix:")",maxReplaces:1e3}}}function h(t){return"string"==typeof t.ns&&(t.ns=[t.ns]),"string"==typeof t.fallbackLng&&(t.fallbackLng=[t.fallbackLng]),"string"==typeof t.fallbackNS&&(t.fallbackNS=[t.fallbackNS]),t.whitelist&&t.whitelist.indexOf("cimode")<0&&(t.whitelist=t.whitelist.concat(["cimode"])),t}function d(){}var v="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t},y=function(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")},m=Object.assign||function(t){for(var e=1;e<arguments.length;e++){var n=arguments[e];for(var o in n)Object.prototype.hasOwnProperty.call(n,o)&&(t[o]=n[o])}return t},b=function(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)},x=function(t,e){if(!t)throw new ReferenceError("this hasn't been initialised - super() hasn't been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e},S=function(){function t(t,e){var n=[],o=!0,r=!1,i=void 0;try{for(var s,a=t[Symbol.iterator]();!(o=(s=a.next()).done)&&(n.push(s.value),!e||n.length!==e);o=!0);}catch(t){r=!0,i=t}finally{try{!o&&a.return&&a.return()}finally{if(r)throw i}}return n}return function(e,n){if(Array.isArray(e))return e;if(Symbol.iterator in Object(e))return t(e,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),k=function(t){if(Array.isArray(t)){for(var e=0,n=Array(t.length);e<t.length;e++)n[e]=t[e];return n}return Array.from(t)},w={type:"logger",log:function(t){this.output("log",t)},warn:function(t){this.output("warn",t)},error:function(t){this.output("error",t)},output:function(t,e){var n;console&&console[t]&&(n=console)[t].apply(n,k(e))}},O=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};y(this,t),this.init(e,n)}return t.prototype.init=function(t){var e=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};this.prefix=e.prefix||"i18next:",this.logger=t||w,this.options=e,this.debug=e.debug},t.prototype.setDebug=function(t){this.debug=t},t.prototype.log=function(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];return this.forward(e,"log","",!0)},t.prototype.warn=function(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];return this.forward(e,"warn","",!0)},t.prototype.error=function(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];return this.forward(e,"error","")},t.prototype.deprecate=function(){for(var t=arguments.length,e=Array(t),n=0;n<t;n++)e[n]=arguments[n];return this.forward(e,"warn","WARNING DEPRECATED: ",!0)},t.prototype.forward=function(t,e,n,o){return o&&!this.debug?null:("string"==typeof t[0]&&(t[0]=""+n+this.prefix+" "+t[0]),this.logger[e](t))},t.prototype.create=function(e){return new t(this.logger,m({prefix:this.prefix+":"+e+":"},this.options))},t}(),R=new O,L=function(){function t(){y(this,t),this.observers={}}return t.prototype.on=function(t,e){var n=this;return t.split(" ").forEach(function(t){n.observers[t]=n.observers[t]||[],n.observers[t].push(e)}),this},t.prototype.off=function(t,e){var n=this;this.observers[t]&&this.observers[t].forEach(function(){if(e){var o=n.observers[t].indexOf(e);o>-1&&n.observers[t].splice(o,1)}else delete n.observers[t]})},t.prototype.emit=function(t){for(var e=arguments.length,n=Array(e>1?e-1:0),o=1;o<e;o++)n[o-1]=arguments[o];if(this.observers[t]){[].concat(this.observers[t]).forEach(function(t){t.apply(void 0,n)})}if(this.observers["*"]){[].concat(this.observers["*"]).forEach(function(e){e.apply(e,[t].concat(n))})}},t}(),j={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;"},N=function(t){function e(n){var o=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{ns:["translation"],defaultNS:"translation"};y(this,e);var r=x(this,t.call(this));return r.data=n||{},r.options=o,void 0===r.options.keySeparator&&(r.options.keySeparator="."),r}return b(e,t),e.prototype.addNamespaces=function(t){this.options.ns.indexOf(t)<0&&this.options.ns.push(t)},e.prototype.removeNamespaces=function(t){var e=this.options.ns.indexOf(t);e>-1&&this.options.ns.splice(e,1)},e.prototype.getResource=function(t,e,n){var o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:{},r=void 0!==o.keySeparator?o.keySeparator:this.options.keySeparator,i=[t,e];return n&&"string"!=typeof n&&(i=i.concat(n)),n&&"string"==typeof n&&(i=i.concat(r?n.split(r):n)),t.indexOf(".")>-1&&(i=t.split(".")),s(this.data,i)},e.prototype.addResource=function(t,e,n,o){var i=arguments.length>4&&void 0!==arguments[4]?arguments[4]:{silent:!1},s=this.options.keySeparator;void 0===s&&(s=".");var a=[t,e];n&&(a=a.concat(s?n.split(s):n)),t.indexOf(".")>-1&&(a=t.split("."),o=e,e=a[1]),this.addNamespaces(e),r(this.data,a,o),i.silent||this.emit("added",t,e,n,o)},e.prototype.addResources=function(t,e,n){var o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:{silent:!1};for(var r in n)"string"==typeof n[r]&&this.addResource(t,e,r,n[r],{silent:!0});o.silent||this.emit("added",t,e,n)},e.prototype.addResourceBundle=function(t,e,n,o,i){var u=arguments.length>5&&void 0!==arguments[5]?arguments[5]:{silent:!1},l=[t,e];t.indexOf(".")>-1&&(l=t.split("."),o=n,n=e,e=l[1]),this.addNamespaces(e);var p=s(this.data,l)||{};o?a(p,n,i):p=m({},p,n),r(this.data,l,p),u.silent||this.emit("added",t,e,n)},e.prototype.removeResourceBundle=function(t,e){this.hasResourceBundle(t,e)&&delete this.data[t][e],this.removeNamespaces(e),this.emit("removed",t,e)},e.prototype.hasResourceBundle=function(t,e){return void 0!==this.getResource(t,e)},e.prototype.getResourceBundle=function(t,e){return e||(e=this.options.defaultNS),"v1"===this.options.compatibilityAPI?m({},this.getResource(t,e)):this.getResource(t,e)},e.prototype.getDataByLanguage=function(t){return this.data[t]},e.prototype.toJSON=function(){return this.data},e}(L),C={processors:{},addPostProcessor:function(t){this.processors[t.name]=t},handle:function(t,e,n,o,r){var i=this;return t.forEach(function(t){i.processors[t]&&(e=i.processors[t].process(e,n,o,r))}),e}},E=function(t){function e(o){var r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};y(this,e);var i=x(this,t.call(this));return n(["resourceStore","languageUtils","pluralResolver","interpolator","backendConnector","i18nFormat"],o,i),i.options=r,void 0===i.options.keySeparator&&(i.options.keySeparator="."),i.logger=R.create("translator"),i}return b(e,t),e.prototype.changeLanguage=function(t){t&&(this.language=t)},e.prototype.exists=function(t){var e=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{interpolation:{}},n=this.resolve(t,e);return n&&void 0!==n.res},e.prototype.extractFromKey=function(t,e){var n=e.nsSeparator||this.options.nsSeparator;void 0===n&&(n=":");var o=void 0!==e.keySeparator?e.keySeparator:this.options.keySeparator,r=e.ns||this.options.defaultNS;if(n&&t.indexOf(n)>-1){var i=t.split(n);(n!==o||n===o&&this.options.ns.indexOf(i[0])>-1)&&(r=i.shift()),t=i.join(o)}return"string"==typeof r&&(r=[r]),{key:t,namespaces:r}},e.prototype.translate=function(t,e){var n=this;if("object"!==(void 0===e?"undefined":v(e))&&this.options.overloadTranslationOptionHandler&&(e=this.options.overloadTranslationOptionHandler(arguments)),e||(e={}),void 0===t||null===t)return"";Array.isArray(t)||(t=[String(t)]);var o=void 0!==e.keySeparator?e.keySeparator:this.options.keySeparator,r=this.extractFromKey(t[t.length-1],e),i=r.key,s=r.namespaces,a=s[s.length-1],u=e.lng||this.language,l=e.appendNamespaceToCIMode||this.options.appendNamespaceToCIMode;if(u&&"cimode"===u.toLowerCase()){if(l){var p=e.nsSeparator||this.options.nsSeparator;return a+p+i}return i}var c=this.resolve(t,e),f=c&&c.res,g=c&&c.usedKey||i,h=Object.prototype.toString.apply(f),d=["[object Number]","[object Function]","[object RegExp]"],y=void 0!==e.joinArrays?e.joinArrays:this.options.joinArrays,b=!this.i18nFormat||this.i18nFormat.handleAsObject,x="string"!=typeof f&&"boolean"!=typeof f&&"number"!=typeof f;if(b&&f&&x&&d.indexOf(h)<0&&(!y||"[object Array]"!==h)){if(!e.returnObjects&&!this.options.returnObjects)return this.logger.warn("accessing an object - but returnObjects options is not enabled!"),this.options.returnedObjectHandler?this.options.returnedObjectHandler(g,f,e):"key '"+i+" ("+this.language+")' returned an object instead of string.";if(o){var S="[object Array]"===h?[]:{};for(var k in f)if(Object.prototype.hasOwnProperty.call(f,k)){var w=""+g+o+k;S[k]=this.translate(w,m({},e,{joinArrays:!1,ns:s})),S[k]===w&&(S[k]=f[k])}f=S}}else if(b&&y&&"[object Array]"===h)(f=f.join(y))&&(f=this.extendTranslation(f,t,e));else{var O=!1,R=!1;if(!this.isValidLookup(f)&&void 0!==e.defaultValue){if(O=!0,void 0!==e.count){var L=this.pluralResolver.getSuffix(u,e.count);f=e["defaultValue"+L]}f||(f=e.defaultValue)}this.isValidLookup(f)||(R=!0,f=i);var j=e.defaultValue&&e.defaultValue!==f&&this.options.updateMissing;if(R||O||j){this.logger.log(j?"updateKey":"missingKey",u,a,i,j?e.defaultValue:f);var N=[],C=this.languageUtils.getFallbackCodes(this.options.fallbackLng,e.lng||this.language);if("fallback"===this.options.saveMissingTo&&C&&C[0])for(var E=0;E<C.length;E++)N.push(C[E]);else"all"===this.options.saveMissingTo?N=this.languageUtils.toResolveHierarchy(e.lng||this.language):N.push(e.lng||this.language);var P=function(t,o){n.options.missingKeyHandler?n.options.missingKeyHandler(t,a,o,j?e.defaultValue:f,j,e):n.backendConnector&&n.backendConnector.saveMissing&&n.backendConnector.saveMissing(t,a,o,j?e.defaultValue:f,j,e),n.emit("missingKey",t,a,o,f)};if(this.options.saveMissing){var F=void 0!==e.count&&"string"!=typeof e.count;this.options.saveMissingPlurals&&F?N.forEach(function(t){n.pluralResolver.getPluralFormsOfKey(t,i).forEach(function(e){return P([t],e)})}):P(N,i)}}f=this.extendTranslation(f,t,e,c),R&&f===i&&this.options.appendNamespaceToMissingKey&&(f=a+":"+i),R&&this.options.parseMissingKeyHandler&&(f=this.options.parseMissingKeyHandler(f))}return f},e.prototype.extendTranslation=function(t,e,n,o){var r=this;if(this.i18nFormat&&this.i18nFormat.parse)t=this.i18nFormat.parse(t,n,o.usedLng,o.usedNS,o.usedKey,{resolved:o});else if(!n.skipInterpolation){n.interpolation&&this.interpolator.init(m({},n,{interpolation:m({},this.options.interpolation,n.interpolation)}));var i=n.replace&&"string"!=typeof n.replace?n.replace:n;this.options.interpolation.defaultVariables&&(i=m({},this.options.interpolation.defaultVariables,i)),t=this.interpolator.interpolate(t,i,n.lng||this.language,n),!1!==n.nest&&(t=this.interpolator.nest(t,function(){return r.translate.apply(r,arguments)},n)),n.interpolation&&this.interpolator.reset()}var s=n.postProcess||this.options.postProcess,a="string"==typeof s?[s]:s;return void 0!==t&&null!==t&&a&&a.length&&!1!==n.applyPostProcessor&&(t=C.handle(a,t,e,n,this)),t},e.prototype.resolve=function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},o=void 0,r=void 0,i=void 0,s=void 0;return"string"==typeof t&&(t=[t]),t.forEach(function(t){if(!e.isValidLookup(o)){var a=e.extractFromKey(t,n),u=a.key;r=u;var l=a.namespaces;e.options.fallbackNS&&(l=l.concat(e.options.fallbackNS));var p=void 0!==n.count&&"string"!=typeof n.count,c=void 0!==n.context&&"string"==typeof n.context&&""!==n.context,f=n.lngs?n.lngs:e.languageUtils.toResolveHierarchy(n.lng||e.language,n.fallbackLng);l.forEach(function(t){e.isValidLookup(o)||(s=t,f.forEach(function(r){if(!e.isValidLookup(o)){i=r;var s=u,a=[s];if(e.i18nFormat&&e.i18nFormat.addLookupKeys)e.i18nFormat.addLookupKeys(a,u,r,t,n);else{var l=void 0;p&&(l=e.pluralResolver.getSuffix(r,n.count)),p&&c&&a.push(s+l),c&&a.push(s+=""+e.options.contextSeparator+n.context),p&&a.push(s+=l)}for(var f=void 0;f=a.pop();)e.isValidLookup(o)||(o=e.getResource(r,t,f,n))}}))})}}),{res:o,usedKey:r,usedLng:i,usedNS:s}},e.prototype.isValidLookup=function(t){return!(void 0===t||!this.options.returnNull&&null===t||!this.options.returnEmptyString&&""===t)},e.prototype.getResource=function(t,e,n){var o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:{};return this.i18nFormat&&this.i18nFormat.getResource?this.i18nFormat.getResource(t,e,n,o):this.resourceStore.getResource(t,e,n,o)},e}(L),P=function(){function t(e){y(this,t),this.options=e,this.whitelist=this.options.whitelist||!1,this.logger=R.create("languageUtils")}return t.prototype.getScriptPartFromCode=function(t){if(!t||t.indexOf("-")<0)return null;var e=t.split("-");return 2===e.length?null:(e.pop(),this.formatLanguageCode(e.join("-")))},t.prototype.getLanguagePartFromCode=function(t){if(!t||t.indexOf("-")<0)return t;var e=t.split("-");return this.formatLanguageCode(e[0])},t.prototype.formatLanguageCode=function(t){if("string"==typeof t&&t.indexOf("-")>-1){var e=["hans","hant","latn","cyrl","cans","mong","arab"],n=t.split("-");return this.options.lowerCaseLng?n=n.map(function(t){return t.toLowerCase()}):2===n.length?(n[0]=n[0].toLowerCase(),n[1]=n[1].toUpperCase(),e.indexOf(n[1].toLowerCase())>-1&&(n[1]=p(n[1].toLowerCase()))):3===n.length&&(n[0]=n[0].toLowerCase(),2===n[1].length&&(n[1]=n[1].toUpperCase()),"sgn"!==n[0]&&2===n[2].length&&(n[2]=n[2].toUpperCase()),e.indexOf(n[1].toLowerCase())>-1&&(n[1]=p(n[1].toLowerCase())),e.indexOf(n[2].toLowerCase())>-1&&(n[2]=p(n[2].toLowerCase()))),n.join("-")}return this.options.cleanCode||this.options.lowerCaseLng?t.toLowerCase():t},t.prototype.isWhitelisted=function(t){return("languageOnly"===this.options.load||this.options.nonExplicitWhitelist)&&(t=this.getLanguagePartFromCode(t)),!this.whitelist||!this.whitelist.length||this.whitelist.indexOf(t)>-1},t.prototype.getFallbackCodes=function(t,e){if(!t)return[];if("string"==typeof t&&(t=[t]),"[object Array]"===Object.prototype.toString.apply(t))return t;if(!e)return t.default||[];var n=t[e];return n||(n=t[this.getScriptPartFromCode(e)]),n||(n=t[this.formatLanguageCode(e)]),n||(n=t.default),n||[]},t.prototype.toResolveHierarchy=function(t,e){var n=this,o=this.getFallbackCodes(e||this.options.fallbackLng||[],t),r=[],i=function(t){t&&(n.isWhitelisted(t)?r.push(t):n.logger.warn("rejecting non-whitelisted language code: "+t))};return"string"==typeof t&&t.indexOf("-")>-1?("languageOnly"!==this.options.load&&i(this.formatLanguageCode(t)),"languageOnly"!==this.options.load&&"currentOnly"!==this.options.load&&i(this.getScriptPartFromCode(t)),"currentOnly"!==this.options.load&&i(this.getLanguagePartFromCode(t))):"string"==typeof t&&i(this.formatLanguageCode(t)),o.forEach(function(t){r.indexOf(t)<0&&i(n.formatLanguageCode(t))}),r},t}(),F=[{lngs:["ach","ak","am","arn","br","fil","gun","ln","mfe","mg","mi","oc","pt","pt-BR","tg","ti","tr","uz","wa"],nr:[1,2],fc:1},{lngs:["af","an","ast","az","bg","bn","ca","da","de","dev","el","en","eo","es","et","eu","fi","fo","fur","fy","gl","gu","ha","hi","hu","hy","ia","it","kn","ku","lb","mai","ml","mn","mr","nah","nap","nb","ne","nl","nn","no","nso","pa","pap","pms","ps","pt-PT","rm","sco","se","si","so","son","sq","sv","sw","ta","te","tk","ur","yo"],nr:[1,2],fc:2},{lngs:["ay","bo","cgg","fa","id","ja","jbo","ka","kk","km","ko","ky","lo","ms","sah","su","th","tt","ug","vi","wo","zh"],nr:[1],fc:3},{lngs:["be","bs","dz","hr","ru","sr","uk"],nr:[1,2,5],fc:4},{lngs:["ar"],nr:[0,1,2,3,11,100],fc:5},{lngs:["cs","sk"],nr:[1,2,5],fc:6},{lngs:["csb","pl"],nr:[1,2,5],fc:7},{lngs:["cy"],nr:[1,2,3,8],fc:8},{lngs:["fr"],nr:[1,2],fc:9},{lngs:["ga"],nr:[1,2,3,7,11],fc:10},{lngs:["gd"],nr:[1,2,3,20],fc:11},{lngs:["is"],nr:[1,2],fc:12},{lngs:["jv"],nr:[0,1],fc:13},{lngs:["kw"],nr:[1,2,3,4],fc:14},{lngs:["lt"],nr:[1,2,10],fc:15},{lngs:["lv"],nr:[1,2,0],fc:16},{lngs:["mk"],nr:[1,2],fc:17},{lngs:["mnk"],nr:[0,1,2],fc:18},{lngs:["mt"],nr:[1,2,11,20],fc:19},{lngs:["or"],nr:[2,1],fc:2},{lngs:["ro"],nr:[1,2,20],fc:20},{lngs:["sl"],nr:[5,1,2,3],fc:21},{lngs:["he"],nr:[1,2,20,21],fc:22}],A={1:function(t){return Number(t>1)},2:function(t){return Number(1!=t)},3:function(t){return 0},4:function(t){return Number(t%10==1&&t%100!=11?0:t%10>=2&&t%10<=4&&(t%100<10||t%100>=20)?1:2)},5:function(t){return Number(0===t?0:1==t?1:2==t?2:t%100>=3&&t%100<=10?3:t%100>=11?4:5)},6:function(t){return Number(1==t?0:t>=2&&t<=4?1:2)},7:function(t){return Number(1==t?0:t%10>=2&&t%10<=4&&(t%100<10||t%100>=20)?1:2)},8:function(t){return Number(1==t?0:2==t?1:8!=t&&11!=t?2:3)},9:function(t){return Number(t>=2)},10:function(t){return Number(1==t?0:2==t?1:t<7?2:t<11?3:4)},11:function(t){return Number(1==t||11==t?0:2==t||12==t?1:t>2&&t<20?2:3)},12:function(t){return Number(t%10!=1||t%100==11)},13:function(t){return Number(0!==t)},14:function(t){return Number(1==t?0:2==t?1:3==t?2:3)},15:function(t){return Number(t%10==1&&t%100!=11?0:t%10>=2&&(t%100<10||t%100>=20)?1:2)},16:function(t){return Number(t%10==1&&t%100!=11?0:0!==t?1:2)},17:function(t){return Number(1==t||t%10==1?0:1)},18:function(t){return Number(0==t?0:1==t?1:2)},19:function(t){return Number(1==t?0:0===t||t%100>1&&t%100<11?1:t%100>10&&t%100<20?2:3)},20:function(t){return Number(1==t?0:0===t||t%100>0&&t%100<20?1:2)},21:function(t){return Number(t%100==1?1:t%100==2?2:t%100==3||t%100==4?3:0)},22:function(t){return Number(1===t?0:2===t?1:(t<0||t>10)&&t%10==0?2:3)}},T=function(){function t(e){var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};y(this,t),this.languageUtils=e,this.options=n,this.logger=R.create("pluralResolver"),this.rules=c()}return t.prototype.addRule=function(t,e){this.rules[t]=e},t.prototype.getRule=function(t){return this.rules[t]||this.rules[this.languageUtils.getLanguagePartFromCode(t)]},t.prototype.needsPlural=function(t){var e=this.getRule(t);return e&&e.numbers.length>1},t.prototype.getPluralFormsOfKey=function(t,e){var n=this,o=[],r=this.getRule(t);return r?(r.numbers.forEach(function(r){var i=n.getSuffix(t,r);o.push(""+e+i)}),o):o},t.prototype.getSuffix=function(t,e){var n=this,o=this.getRule(t);if(o){var r=o.noAbs?o.plurals(e):o.plurals(Math.abs(e)),i=o.numbers[r];this.options.simplifyPluralSuffix&&2===o.numbers.length&&1===o.numbers[0]&&(2===i?i="plural":1===i&&(i=""));var s=function(){return n.options.prepend&&i.toString()?n.options.prepend+i.toString():i.toString()};return"v1"===this.options.compatibilityJSON?1===i?"":"number"==typeof i?"_plural_"+i.toString():s():"v2"===this.options.compatibilityJSON?s():this.options.simplifyPluralSuffix&&2===o.numbers.length&&1===o.numbers[0]?s():this.options.prepend&&r.toString()?this.options.prepend+r.toString():r.toString()}return this.logger.warn("no plural rule found for: "+t),""},t}(),V=function(){function t(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};y(this,t),this.logger=R.create("interpolator"),this.init(e,!0)}return t.prototype.init=function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};arguments[1]&&(this.options=t,this.format=t.interpolation&&t.interpolation.format||function(t){return t}),t.interpolation||(t.interpolation={escapeValue:!0});var e=t.interpolation;this.escape=void 0!==e.escape?e.escape:l,this.escapeValue=void 0===e.escapeValue||e.escapeValue,this.useRawValueToEscape=void 0!==e.useRawValueToEscape&&e.useRawValueToEscape,this.prefix=e.prefix?u(e.prefix):e.prefixEscaped||"{{",this.suffix=e.suffix?u(e.suffix):e.suffixEscaped||"}}",this.formatSeparator=e.formatSeparator?e.formatSeparator:e.formatSeparator||",",this.unescapePrefix=e.unescapeSuffix?"":e.unescapePrefix||"-",this.unescapeSuffix=this.unescapePrefix?"":e.unescapeSuffix||"",this.nestingPrefix=e.nestingPrefix?u(e.nestingPrefix):e.nestingPrefixEscaped||u("$t("),this.nestingSuffix=e.nestingSuffix?u(e.nestingSuffix):e.nestingSuffixEscaped||u(")"),this.maxReplaces=e.maxReplaces?e.maxReplaces:1e3,this.resetRegExp()},t.prototype.reset=function(){this.options&&this.init(this.options)},t.prototype.resetRegExp=function(){var t=this.prefix+"(.+?)"+this.suffix;this.regexp=new RegExp(t,"g");var e=""+this.prefix+this.unescapePrefix+"(.+?)"+this.unescapeSuffix+this.suffix;this.regexpUnescape=new RegExp(e,"g");var n=this.nestingPrefix+"(.+?)"+this.nestingSuffix;this.nestingRegexp=new RegExp(n,"g")},t.prototype.interpolate=function(t,n,o,r){function i(t){return t.replace(/\$/g,"$$$$")}var a=this,u=void 0,l=void 0,p=void 0,c=function(t){if(t.indexOf(a.formatSeparator)<0)return s(n,t);var e=t.split(a.formatSeparator),r=e.shift().trim(),i=e.join(a.formatSeparator).trim();return a.format(s(n,r),i,o)};this.resetRegExp();var f=r&&r.missingInterpolationHandler||this.options.missingInterpolationHandler;for(p=0;(u=this.regexpUnescape.exec(t))&&(l=c(u[1].trim()),t=t.replace(u[0],l),this.regexpUnescape.lastIndex=0,!(++p>=this.maxReplaces)););for(p=0;u=this.regexp.exec(t);){if(void 0===(l=c(u[1].trim())))if("function"==typeof f){var g=f(t,u,r);l="string"==typeof g?g:""}else this.logger.warn("missed to pass in variable "+u[1]+" for interpolating "+t),l="";else"string"==typeof l||this.useRawValueToEscape||(l=e(l));if(l=i(this.escapeValue?this.escape(l):l),t=t.replace(u[0],l),this.regexp.lastIndex=0,++p>=this.maxReplaces)break}return t},t.prototype.nest=function(t,n){function o(t,e){if(t.indexOf(",")<0)return t;var n=t.split(",");t=n.shift();var o=n.join(",");o=this.interpolate(o,a),o=o.replace(/'/g,'"');try{a=JSON.parse(o),e&&(a=m({},e,a))}catch(e){this.logger.error("failed parsing options string in nesting for key "+t,e)}return t}var r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},i=void 0,s=void 0,a=m({},r);for(a.applyPostProcessor=!1;i=this.nestingRegexp.exec(t);){if((s=n(o.call(this,i[1].trim(),a),a))&&i[0]===t&&"string"!=typeof s)return s;"string"!=typeof s&&(s=e(s)),s||(this.logger.warn("missed to resolve "+i[1]+" for nesting "+t),s=""),t=t.replace(i[0],s),this.regexp.lastIndex=0}return t},t}(),U=function(t){function e(n,o,r){var i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:{};y(this,e);var s=x(this,t.call(this));return s.backend=n,s.store=o,s.languageUtils=r.languageUtils,s.options=i,s.logger=R.create("backendConnector"),s.state={},s.queue=[],s.backend&&s.backend.init&&s.backend.init(r,i.backend,i),s}return b(e,t),e.prototype.queueLoad=function(t,e,n,o){var r=this,i=[],s=[],a=[],u=[];return t.forEach(function(t){var o=!0;e.forEach(function(e){var a=t+"|"+e;!n.reload&&r.store.hasResourceBundle(t,e)?r.state[a]=2:r.state[a]<0||(1===r.state[a]?s.indexOf(a)<0&&s.push(a):(r.state[a]=1,o=!1,s.indexOf(a)<0&&s.push(a),i.indexOf(a)<0&&i.push(a),u.indexOf(e)<0&&u.push(e)))}),o||a.push(t)}),(i.length||s.length)&&this.queue.push({pending:s,loaded:{},errors:[],callback:o}),{toLoad:i,pending:s,toLoadLanguages:a,toLoadNamespaces:u}},e.prototype.loaded=function(t,e,n){var o=t.split("|"),r=S(o,2),s=r[0],a=r[1];e&&this.emit("failedLoading",s,a,e),n&&this.store.addResourceBundle(s,a,n),this.state[t]=e?-1:2;var u={};this.queue.forEach(function(n){i(n.loaded,[s],a),f(n.pending,t),e&&n.errors.push(e),0!==n.pending.length||n.done||(Object.keys(n.loaded).forEach(function(t){u[t]||(u[t]=[]),n.loaded[t].length&&n.loaded[t].forEach(function(e){u[t].indexOf(e)<0&&u[t].push(e)})}),n.done=!0,n.errors.length?n.callback(n.errors):n.callback())}),this.emit("loaded",u),this.queue=this.queue.filter(function(t){return!t.done})},e.prototype.read=function(t,e,n){var o=arguments.length>3&&void 0!==arguments[3]?arguments[3]:0,r=this,i=arguments.length>4&&void 0!==arguments[4]?arguments[4]:250,s=arguments[5];return t.length?this.backend[n](t,e,function(a,u){if(a&&u&&o<5)return void setTimeout(function(){r.read.call(r,t,e,n,o+1,2*i,s)},i);s(a,u)}):s(null,{})},e.prototype.prepareLoading=function(t,e){var n=this,o=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},r=arguments[3];if(!this.backend)return this.logger.warn("No backend was added via i18next.use. Will not load resources."),r&&r();"string"==typeof t&&(t=this.languageUtils.toResolveHierarchy(t)),"string"==typeof e&&(e=[e]);var i=this.queueLoad(t,e,o,r);if(!i.toLoad.length)return i.pending.length||r(),null;i.toLoad.forEach(function(t){n.loadOne(t)})},e.prototype.load=function(t,e,n){this.prepareLoading(t,e,{},n)},e.prototype.reload=function(t,e,n){this.prepareLoading(t,e,{reload:!0},n)},e.prototype.loadOne=function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"",o=t.split("|"),r=S(o,2),i=r[0],s=r[1];this.read(i,s,"read",null,null,function(o,r){o&&e.logger.warn(n+"loading namespace "+s+" for language "+i+" failed",o),!o&&r&&e.logger.log(n+"loaded namespace "+s+" for language "+i,r),e.loaded(t,o,r)})},e.prototype.saveMissing=function(t,e,n,o,r){var i=arguments.length>5&&void 0!==arguments[5]?arguments[5]:{};this.backend&&this.backend.create&&this.backend.create(t,e,n,o,null,m({},i,{isUpdate:r})),t&&t[0]&&this.store.addResource(t[0],e,n,o)},e}(L);return new(function(e){function n(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},o=arguments[1];y(this,n);var r=x(this,e.call(this));if(r.options=h(t),r.services={},r.logger=R,r.modules={external:[]},o&&!r.isInitialized&&!t.isClone){if(!r.options.initImmediate){var i;return r.init(t,o),i=r,x(r,i)}setTimeout(function(){r.init(t,o)},0)}return r}return b(n,e),n.prototype.init=function(){function e(t){return t?"function"==typeof t?new t:t:null}var n=this,o=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},r=arguments[1];if("function"==typeof o&&(r=o,o={}),this.options=m({},g(),this.options,h(o)),this.format=this.options.interpolation.format,r||(r=d),!this.options.isClone){this.modules.logger?R.init(e(this.modules.logger),this.options):R.init(null,this.options);var i=new P(this.options);this.store=new N(this.options.resources,this.options);var s=this.services;s.logger=R,s.resourceStore=this.store,s.languageUtils=i,s.pluralResolver=new T(i,{prepend:this.options.pluralSeparator,compatibilityJSON:this.options.compatibilityJSON,simplifyPluralSuffix:this.options.simplifyPluralSuffix}),s.interpolator=new V(this.options),s.backendConnector=new U(e(this.modules.backend),s.resourceStore,s,this.options),s.backendConnector.on("*",function(t){for(var e=arguments.length,o=Array(e>1?e-1:0),r=1;r<e;r++)o[r-1]=arguments[r];n.emit.apply(n,[t].concat(o))}),this.modules.languageDetector&&(s.languageDetector=e(this.modules.languageDetector),s.languageDetector.init(s,this.options.detection,this.options)),this.modules.i18nFormat&&(s.i18nFormat=e(this.modules.i18nFormat),s.i18nFormat.init&&s.i18nFormat.init(this)),this.translator=new E(this.services,this.options),this.translator.on("*",function(t){for(var e=arguments.length,o=Array(e>1?e-1:0),r=1;r<e;r++)o[r-1]=arguments[r];n.emit.apply(n,[t].concat(o))}),this.modules.external.forEach(function(t){t.init&&t.init(n)})}["getResource","addResource","addResources","addResourceBundle","removeResourceBundle","hasResourceBundle","getResourceBundle","getDataByLanguage"].forEach(function(t){n[t]=function(){var e;return(e=n.store)[t].apply(e,arguments)}});var a=t(),u=function(){n.changeLanguage(n.options.lng,function(t,e){n.isInitialized=!0,n.logger.log("initialized",n.options),n.emit("initialized",n.options),a.resolve(e),r(t,e)})};return this.options.resources||!this.options.initImmediate?u():setTimeout(u,0),a},n.prototype.loadResources=function(){var t=this,e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:d;if(!this.options.resources||this.options.partialBundledLanguages){if(this.language&&"cimode"===this.language.toLowerCase())return e();var n=[],o=function(e){if(e){t.services.languageUtils.toResolveHierarchy(e).forEach(function(t){n.indexOf(t)<0&&n.push(t)})}};if(this.language)o(this.language);else{this.services.languageUtils.getFallbackCodes(this.options.fallbackLng).forEach(function(t){return o(t)})}this.options.preload&&this.options.preload.forEach(function(t){return o(t)}),this.services.backendConnector.load(n,this.options.ns,e)}else e(null)},n.prototype.reloadResources=function(e,n,o){var r=t();return e||(e=this.languages),n||(n=this.options.ns),o||(o=d),this.services.backendConnector.reload(e,n,function(){r.resolve(),o(null)}),r},n.prototype.use=function(t){return"backend"===t.type&&(this.modules.backend=t),("logger"===t.type||t.log&&t.warn&&t.error)&&(this.modules.logger=t),"languageDetector"===t.type&&(this.modules.languageDetector=t),"i18nFormat"===t.type&&(this.modules.i18nFormat=t),"postProcessor"===t.type&&C.addPostProcessor(t),"3rdParty"===t.type&&this.modules.external.push(t),this},n.prototype.changeLanguage=function(e,n){var o=this,r=t(),i=function(t,e){o.translator.changeLanguage(e),e&&(o.emit("languageChanged",e),o.logger.log("languageChanged",e)),r.resolve(function(){return o.t.apply(o,arguments)}),n&&n(t,function(){return o.t.apply(o,arguments)})},s=function(t){t&&(o.language=t,o.languages=o.services.languageUtils.toResolveHierarchy(t),o.translator.language||o.translator.changeLanguage(t),o.services.languageDetector&&o.services.languageDetector.cacheUserLanguage(t)),o.loadResources(function(e){i(e,t)})};return e||!this.services.languageDetector||this.services.languageDetector.async?!e&&this.services.languageDetector&&this.services.languageDetector.async?this.services.languageDetector.detect(s):s(e):s(this.services.languageDetector.detect()),r},n.prototype.getFixedT=function(t,e){var n=this,o=function t(e,o){
-for(var r=arguments.length,i=Array(r>2?r-2:0),s=2;s<r;s++)i[s-2]=arguments[s];var a=m({},o);return"object"!==(void 0===o?"undefined":v(o))&&(a=n.options.overloadTranslationOptionHandler([e,o].concat(i))),a.lng=a.lng||t.lng,a.lngs=a.lngs||t.lngs,a.ns=a.ns||t.ns,n.t(e,a)};return"string"==typeof t?o.lng=t:o.lngs=t,o.ns=e,o},n.prototype.t=function(){var t;return this.translator&&(t=this.translator).translate.apply(t,arguments)},n.prototype.exists=function(){var t;return this.translator&&(t=this.translator).exists.apply(t,arguments)},n.prototype.setDefaultNamespace=function(t){this.options.defaultNS=t},n.prototype.loadNamespaces=function(e,n){var o=this,r=t();return this.options.ns?("string"==typeof e&&(e=[e]),e.forEach(function(t){o.options.ns.indexOf(t)<0&&o.options.ns.push(t)}),this.loadResources(function(t){r.resolve(),n&&n(t)}),r):(n&&n(),Promise.resolve())},n.prototype.loadLanguages=function(e,n){var o=t();"string"==typeof e&&(e=[e]);var r=this.options.preload||[],i=e.filter(function(t){return r.indexOf(t)<0});return i.length?(this.options.preload=r.concat(i),this.loadResources(function(t){o.resolve(),n&&n(t)}),o):(n&&n(),Promise.resolve())},n.prototype.dir=function(t){return t||(t=this.languages&&this.languages.length>0?this.languages[0]:this.language),t?["ar","shu","sqr","ssh","xaa","yhd","yud","aao","abh","abv","acm","acq","acw","acx","acy","adf","ads","aeb","aec","afb","ajp","apc","apd","arb","arq","ars","ary","arz","auz","avl","ayh","ayl","ayn","ayp","bbz","pga","he","iw","ps","pbt","pbu","pst","prp","prd","ur","ydd","yds","yih","ji","yi","hbo","men","xmn","fa","jpr","peo","pes","prs","dv","sam"].indexOf(this.services.languageUtils.getLanguagePartFromCode(t))>=0?"rtl":"ltr":"rtl"},n.prototype.createInstance=function(){return new n(arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},arguments[1])},n.prototype.cloneInstance=function(){var t=this,e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},o=arguments.length>1&&void 0!==arguments[1]?arguments[1]:d,r=m({},this.options,e,{isClone:!0}),i=new n(r);return["store","services","language"].forEach(function(e){i[e]=t[e]}),i.translator=new E(i.services,i.options),i.translator.on("*",function(t){for(var e=arguments.length,n=Array(e>1?e-1:0),o=1;o<e;o++)n[o-1]=arguments[o];i.emit.apply(i,[t].concat(n))}),i.init(r,o),i.translator.options=i.options,i},n}(L))});
+!(function(t, e) {
+  'object' == typeof exports && 'undefined' != typeof module
+    ? (module.exports = e())
+    : 'function' == typeof define && define.amd
+    ? define(e)
+    : (t.i18next = e());
+})(this, function() {
+  'use strict';
+  function t() {
+    var t = void 0,
+      e = void 0,
+      n = new Promise(function(n, o) {
+        (t = n), (e = o);
+      });
+    return (n.resolve = t), (n.reject = e), n;
+  }
+  function e(t) {
+    return null == t ? '' : '' + t;
+  }
+  function n(t, e, n) {
+    t.forEach(function(t) {
+      e[t] && (n[t] = e[t]);
+    });
+  }
+  function o(t, e, n) {
+    function o(t) {
+      return t && t.indexOf('###') > -1 ? t.replace(/###/g, '.') : t;
+    }
+    function r() {
+      return !t || 'string' == typeof t;
+    }
+    for (var i = 'string' != typeof e ? [].concat(e) : e.split('.'); i.length > 1; ) {
+      if (r()) return {};
+      var s = o(i.shift());
+      !t[s] && n && (t[s] = new n()), (t = t[s]);
+    }
+    return r() ? {} : { obj: t, k: o(i.shift()) };
+  }
+  function r(t, e, n) {
+    var r = o(t, e, Object);
+    r.obj[r.k] = n;
+  }
+  function i(t, e, n, r) {
+    var i = o(t, e, Object),
+      s = i.obj,
+      a = i.k;
+    (s[a] = s[a] || []), r && (s[a] = s[a].concat(n)), r || s[a].push(n);
+  }
+  function s(t, e) {
+    var n = o(t, e),
+      r = n.obj,
+      i = n.k;
+    if (r) return r[i];
+  }
+  function a(t, e, n) {
+    for (var o in e)
+      o in t
+        ? 'string' == typeof t[o] ||
+          t[o] instanceof String ||
+          'string' == typeof e[o] ||
+          e[o] instanceof String
+          ? n && (t[o] = e[o])
+          : a(t[o], e[o], n)
+        : (t[o] = e[o]);
+    return t;
+  }
+  function u(t) {
+    return t.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+  }
+  function l(t) {
+    return 'string' == typeof t
+      ? t.replace(/[&<>"'\/]/g, function(t) {
+          return j[t];
+        })
+      : t;
+  }
+  function p(t) {
+    return t.charAt(0).toUpperCase() + t.slice(1);
+  }
+  function c() {
+    var t = {};
+    return (
+      F.forEach(function(e) {
+        e.lngs.forEach(function(n) {
+          t[n] = { numbers: e.nr, plurals: A[e.fc] };
+        });
+      }),
+      t
+    );
+  }
+  function f(t, e) {
+    for (var n = t.indexOf(e); -1 !== n; ) t.splice(n, 1), (n = t.indexOf(e));
+  }
+  function g() {
+    return {
+      debug: !1,
+      initImmediate: !0,
+      ns: ['translation'],
+      defaultNS: ['translation'],
+      fallbackLng: ['dev'],
+      fallbackNS: !1,
+      whitelist: !1,
+      nonExplicitWhitelist: !1,
+      load: 'all',
+      preload: !1,
+      simplifyPluralSuffix: !0,
+      keySeparator: '.',
+      nsSeparator: ':',
+      pluralSeparator: '_',
+      contextSeparator: '_',
+      partialBundledLanguages: !1,
+      saveMissing: !1,
+      updateMissing: !1,
+      saveMissingTo: 'fallback',
+      saveMissingPlurals: !0,
+      missingKeyHandler: !1,
+      missingInterpolationHandler: !1,
+      postProcess: !1,
+      returnNull: !0,
+      returnEmptyString: !0,
+      returnObjects: !1,
+      joinArrays: !1,
+      returnedObjectHandler: function() {},
+      parseMissingKeyHandler: !1,
+      appendNamespaceToMissingKey: !1,
+      appendNamespaceToCIMode: !1,
+      overloadTranslationOptionHandler: function(t) {
+        var e = {};
+        if (
+          ('object' === v(t[1]) && (e = t[1]),
+          'string' == typeof t[1] && (e.defaultValue = t[1]),
+          'string' == typeof t[2] && (e.tDescription = t[2]),
+          'object' === v(t[2]) || 'object' === v(t[3]))
+        ) {
+          var n = t[3] || t[2];
+          Object.keys(n).forEach(function(t) {
+            e[t] = n[t];
+          });
+        }
+        return e;
+      },
+      interpolation: {
+        escapeValue: !0,
+        format: function(t, e, n) {
+          return t;
+        },
+        prefix: '{{',
+        suffix: '}}',
+        formatSeparator: ',',
+        unescapePrefix: '-',
+        nestingPrefix: '$t(',
+        nestingSuffix: ')',
+        maxReplaces: 1e3,
+      },
+    };
+  }
+  function h(t) {
+    return (
+      'string' == typeof t.ns && (t.ns = [t.ns]),
+      'string' == typeof t.fallbackLng && (t.fallbackLng = [t.fallbackLng]),
+      'string' == typeof t.fallbackNS && (t.fallbackNS = [t.fallbackNS]),
+      t.whitelist &&
+        t.whitelist.indexOf('cimode') < 0 &&
+        (t.whitelist = t.whitelist.concat(['cimode'])),
+      t
+    );
+  }
+  function d() {}
+  var v =
+      'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+        ? function(t) {
+            return typeof t;
+          }
+        : function(t) {
+            return t &&
+              'function' == typeof Symbol &&
+              t.constructor === Symbol &&
+              t !== Symbol.prototype
+              ? 'symbol'
+              : typeof t;
+          },
+    y = function(t, e) {
+      if (!(t instanceof e)) throw new TypeError('Cannot call a class as a function');
+    },
+    m =
+      Object.assign ||
+      function(t) {
+        for (var e = 1; e < arguments.length; e++) {
+          var n = arguments[e];
+          for (var o in n) Object.prototype.hasOwnProperty.call(n, o) && (t[o] = n[o]);
+        }
+        return t;
+      },
+    b = function(t, e) {
+      if ('function' != typeof e && null !== e)
+        throw new TypeError('Super expression must either be null or a function, not ' + typeof e);
+      (t.prototype = Object.create(e && e.prototype, {
+        constructor: { value: t, enumerable: !1, writable: !0, configurable: !0 },
+      })),
+        e && (Object.setPrototypeOf ? Object.setPrototypeOf(t, e) : (t.__proto__ = e));
+    },
+    x = function(t, e) {
+      if (!t) throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+      return !e || ('object' != typeof e && 'function' != typeof e) ? t : e;
+    },
+    S = (function() {
+      function t(t, e) {
+        var n = [],
+          o = !0,
+          r = !1,
+          i = void 0;
+        try {
+          for (
+            var s, a = t[Symbol.iterator]();
+            !(o = (s = a.next()).done) && (n.push(s.value), !e || n.length !== e);
+            o = !0
+          );
+        } catch (t) {
+          (r = !0), (i = t);
+        } finally {
+          try {
+            !o && a.return && a.return();
+          } finally {
+            if (r) throw i;
+          }
+        }
+        return n;
+      }
+      return function(e, n) {
+        if (Array.isArray(e)) return e;
+        if (Symbol.iterator in Object(e)) return t(e, n);
+        throw new TypeError('Invalid attempt to destructure non-iterable instance');
+      };
+    })(),
+    k = function(t) {
+      if (Array.isArray(t)) {
+        for (var e = 0, n = Array(t.length); e < t.length; e++) n[e] = t[e];
+        return n;
+      }
+      return Array.from(t);
+    },
+    w = {
+      type: 'logger',
+      log: function(t) {
+        this.output('log', t);
+      },
+      warn: function(t) {
+        this.output('warn', t);
+      },
+      error: function(t) {
+        this.output('error', t);
+      },
+      output: function(t, e) {
+        var n;
+        console && console[t] && (n = console)[t].apply(n, k(e));
+      },
+    },
+    O = (function() {
+      function t(e) {
+        var n = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {};
+        y(this, t), this.init(e, n);
+      }
+      return (
+        (t.prototype.init = function(t) {
+          var e = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {};
+          (this.prefix = e.prefix || 'i18next:'),
+            (this.logger = t || w),
+            (this.options = e),
+            (this.debug = e.debug);
+        }),
+        (t.prototype.setDebug = function(t) {
+          this.debug = t;
+        }),
+        (t.prototype.log = function() {
+          for (var t = arguments.length, e = Array(t), n = 0; n < t; n++) e[n] = arguments[n];
+          return this.forward(e, 'log', '', !0);
+        }),
+        (t.prototype.warn = function() {
+          for (var t = arguments.length, e = Array(t), n = 0; n < t; n++) e[n] = arguments[n];
+          return this.forward(e, 'warn', '', !0);
+        }),
+        (t.prototype.error = function() {
+          for (var t = arguments.length, e = Array(t), n = 0; n < t; n++) e[n] = arguments[n];
+          return this.forward(e, 'error', '');
+        }),
+        (t.prototype.deprecate = function() {
+          for (var t = arguments.length, e = Array(t), n = 0; n < t; n++) e[n] = arguments[n];
+          return this.forward(e, 'warn', 'WARNING DEPRECATED: ', !0);
+        }),
+        (t.prototype.forward = function(t, e, n, o) {
+          return o && !this.debug
+            ? null
+            : ('string' == typeof t[0] && (t[0] = '' + n + this.prefix + ' ' + t[0]),
+              this.logger[e](t));
+        }),
+        (t.prototype.create = function(e) {
+          return new t(this.logger, m({ prefix: this.prefix + ':' + e + ':' }, this.options));
+        }),
+        t
+      );
+    })(),
+    R = new O(),
+    L = (function() {
+      function t() {
+        y(this, t), (this.observers = {});
+      }
+      return (
+        (t.prototype.on = function(t, e) {
+          var n = this;
+          return (
+            t.split(' ').forEach(function(t) {
+              (n.observers[t] = n.observers[t] || []), n.observers[t].push(e);
+            }),
+            this
+          );
+        }),
+        (t.prototype.off = function(t, e) {
+          var n = this;
+          this.observers[t] &&
+            this.observers[t].forEach(function() {
+              if (e) {
+                var o = n.observers[t].indexOf(e);
+                o > -1 && n.observers[t].splice(o, 1);
+              } else delete n.observers[t];
+            });
+        }),
+        (t.prototype.emit = function(t) {
+          for (var e = arguments.length, n = Array(e > 1 ? e - 1 : 0), o = 1; o < e; o++)
+            n[o - 1] = arguments[o];
+          if (this.observers[t]) {
+            [].concat(this.observers[t]).forEach(function(t) {
+              t.apply(void 0, n);
+            });
+          }
+          if (this.observers['*']) {
+            [].concat(this.observers['*']).forEach(function(e) {
+              e.apply(e, [t].concat(n));
+            });
+          }
+        }),
+        t
+      );
+    })(),
+    j = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;', '/': '&#x2F;' },
+    N = (function(t) {
+      function e(n) {
+        var o =
+          arguments.length > 1 && void 0 !== arguments[1]
+            ? arguments[1]
+            : { ns: ['translation'], defaultNS: 'translation' };
+        y(this, e);
+        var r = x(this, t.call(this));
+        return (
+          (r.data = n || {}),
+          (r.options = o),
+          void 0 === r.options.keySeparator && (r.options.keySeparator = '.'),
+          r
+        );
+      }
+      return (
+        b(e, t),
+        (e.prototype.addNamespaces = function(t) {
+          this.options.ns.indexOf(t) < 0 && this.options.ns.push(t);
+        }),
+        (e.prototype.removeNamespaces = function(t) {
+          var e = this.options.ns.indexOf(t);
+          e > -1 && this.options.ns.splice(e, 1);
+        }),
+        (e.prototype.getResource = function(t, e, n) {
+          var o = arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : {},
+            r = void 0 !== o.keySeparator ? o.keySeparator : this.options.keySeparator,
+            i = [t, e];
+          return (
+            n && 'string' != typeof n && (i = i.concat(n)),
+            n && 'string' == typeof n && (i = i.concat(r ? n.split(r) : n)),
+            t.indexOf('.') > -1 && (i = t.split('.')),
+            s(this.data, i)
+          );
+        }),
+        (e.prototype.addResource = function(t, e, n, o) {
+          var i = arguments.length > 4 && void 0 !== arguments[4] ? arguments[4] : { silent: !1 },
+            s = this.options.keySeparator;
+          void 0 === s && (s = '.');
+          var a = [t, e];
+          n && (a = a.concat(s ? n.split(s) : n)),
+            t.indexOf('.') > -1 && ((a = t.split('.')), (o = e), (e = a[1])),
+            this.addNamespaces(e),
+            r(this.data, a, o),
+            i.silent || this.emit('added', t, e, n, o);
+        }),
+        (e.prototype.addResources = function(t, e, n) {
+          var o = arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : { silent: !1 };
+          for (var r in n)
+            'string' == typeof n[r] && this.addResource(t, e, r, n[r], { silent: !0 });
+          o.silent || this.emit('added', t, e, n);
+        }),
+        (e.prototype.addResourceBundle = function(t, e, n, o, i) {
+          var u = arguments.length > 5 && void 0 !== arguments[5] ? arguments[5] : { silent: !1 },
+            l = [t, e];
+          t.indexOf('.') > -1 && ((l = t.split('.')), (o = n), (n = e), (e = l[1])),
+            this.addNamespaces(e);
+          var p = s(this.data, l) || {};
+          o ? a(p, n, i) : (p = m({}, p, n)),
+            r(this.data, l, p),
+            u.silent || this.emit('added', t, e, n);
+        }),
+        (e.prototype.removeResourceBundle = function(t, e) {
+          this.hasResourceBundle(t, e) && delete this.data[t][e],
+            this.removeNamespaces(e),
+            this.emit('removed', t, e);
+        }),
+        (e.prototype.hasResourceBundle = function(t, e) {
+          return void 0 !== this.getResource(t, e);
+        }),
+        (e.prototype.getResourceBundle = function(t, e) {
+          return (
+            e || (e = this.options.defaultNS),
+            'v1' === this.options.compatibilityAPI
+              ? m({}, this.getResource(t, e))
+              : this.getResource(t, e)
+          );
+        }),
+        (e.prototype.getDataByLanguage = function(t) {
+          return this.data[t];
+        }),
+        (e.prototype.toJSON = function() {
+          return this.data;
+        }),
+        e
+      );
+    })(L),
+    C = {
+      processors: {},
+      addPostProcessor: function(t) {
+        this.processors[t.name] = t;
+      },
+      handle: function(t, e, n, o, r) {
+        var i = this;
+        return (
+          t.forEach(function(t) {
+            i.processors[t] && (e = i.processors[t].process(e, n, o, r));
+          }),
+          e
+        );
+      },
+    },
+    E = (function(t) {
+      function e(o) {
+        var r = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {};
+        y(this, e);
+        var i = x(this, t.call(this));
+        return (
+          n(
+            [
+              'resourceStore',
+              'languageUtils',
+              'pluralResolver',
+              'interpolator',
+              'backendConnector',
+              'i18nFormat',
+            ],
+            o,
+            i,
+          ),
+          (i.options = r),
+          void 0 === i.options.keySeparator && (i.options.keySeparator = '.'),
+          (i.logger = R.create('translator')),
+          i
+        );
+      }
+      return (
+        b(e, t),
+        (e.prototype.changeLanguage = function(t) {
+          t && (this.language = t);
+        }),
+        (e.prototype.exists = function(t) {
+          var e =
+              arguments.length > 1 && void 0 !== arguments[1]
+                ? arguments[1]
+                : { interpolation: {} },
+            n = this.resolve(t, e);
+          return n && void 0 !== n.res;
+        }),
+        (e.prototype.extractFromKey = function(t, e) {
+          var n = e.nsSeparator || this.options.nsSeparator;
+          void 0 === n && (n = ':');
+          var o = void 0 !== e.keySeparator ? e.keySeparator : this.options.keySeparator,
+            r = e.ns || this.options.defaultNS;
+          if (n && t.indexOf(n) > -1) {
+            var i = t.split(n);
+            (n !== o || (n === o && this.options.ns.indexOf(i[0]) > -1)) && (r = i.shift()),
+              (t = i.join(o));
+          }
+          return 'string' == typeof r && (r = [r]), { key: t, namespaces: r };
+        }),
+        (e.prototype.translate = function(t, e) {
+          var n = this;
+          if (
+            ('object' !== (void 0 === e ? 'undefined' : v(e)) &&
+              this.options.overloadTranslationOptionHandler &&
+              (e = this.options.overloadTranslationOptionHandler(arguments)),
+            e || (e = {}),
+            void 0 === t || null === t)
+          )
+            return '';
+          Array.isArray(t) || (t = [String(t)]);
+          var o = void 0 !== e.keySeparator ? e.keySeparator : this.options.keySeparator,
+            r = this.extractFromKey(t[t.length - 1], e),
+            i = r.key,
+            s = r.namespaces,
+            a = s[s.length - 1],
+            u = e.lng || this.language,
+            l = e.appendNamespaceToCIMode || this.options.appendNamespaceToCIMode;
+          if (u && 'cimode' === u.toLowerCase()) {
+            if (l) {
+              var p = e.nsSeparator || this.options.nsSeparator;
+              return a + p + i;
+            }
+            return i;
+          }
+          var c = this.resolve(t, e),
+            f = c && c.res,
+            g = (c && c.usedKey) || i,
+            h = Object.prototype.toString.apply(f),
+            d = ['[object Number]', '[object Function]', '[object RegExp]'],
+            y = void 0 !== e.joinArrays ? e.joinArrays : this.options.joinArrays,
+            b = !this.i18nFormat || this.i18nFormat.handleAsObject,
+            x = 'string' != typeof f && 'boolean' != typeof f && 'number' != typeof f;
+          if (b && f && x && d.indexOf(h) < 0 && (!y || '[object Array]' !== h)) {
+            if (!e.returnObjects && !this.options.returnObjects)
+              return (
+                this.logger.warn('accessing an object - but returnObjects options is not enabled!'),
+                this.options.returnedObjectHandler
+                  ? this.options.returnedObjectHandler(g, f, e)
+                  : "key '" + i + ' (' + this.language + ")' returned an object instead of string."
+              );
+            if (o) {
+              var S = '[object Array]' === h ? [] : {};
+              for (var k in f)
+                if (Object.prototype.hasOwnProperty.call(f, k)) {
+                  var w = '' + g + o + k;
+                  (S[k] = this.translate(w, m({}, e, { joinArrays: !1, ns: s }))),
+                    S[k] === w && (S[k] = f[k]);
+                }
+              f = S;
+            }
+          } else if (b && y && '[object Array]' === h)
+            (f = f.join(y)) && (f = this.extendTranslation(f, t, e));
+          else {
+            var O = !1,
+              R = !1;
+            if (!this.isValidLookup(f) && void 0 !== e.defaultValue) {
+              if (((O = !0), void 0 !== e.count)) {
+                var L = this.pluralResolver.getSuffix(u, e.count);
+                f = e['defaultValue' + L];
+              }
+              f || (f = e.defaultValue);
+            }
+            this.isValidLookup(f) || ((R = !0), (f = i));
+            var j = e.defaultValue && e.defaultValue !== f && this.options.updateMissing;
+            if (R || O || j) {
+              this.logger.log(j ? 'updateKey' : 'missingKey', u, a, i, j ? e.defaultValue : f);
+              var N = [],
+                C = this.languageUtils.getFallbackCodes(
+                  this.options.fallbackLng,
+                  e.lng || this.language,
+                );
+              if ('fallback' === this.options.saveMissingTo && C && C[0])
+                for (var E = 0; E < C.length; E++) N.push(C[E]);
+              else
+                'all' === this.options.saveMissingTo
+                  ? (N = this.languageUtils.toResolveHierarchy(e.lng || this.language))
+                  : N.push(e.lng || this.language);
+              var P = function(t, o) {
+                n.options.missingKeyHandler
+                  ? n.options.missingKeyHandler(t, a, o, j ? e.defaultValue : f, j, e)
+                  : n.backendConnector &&
+                    n.backendConnector.saveMissing &&
+                    n.backendConnector.saveMissing(t, a, o, j ? e.defaultValue : f, j, e),
+                  n.emit('missingKey', t, a, o, f);
+              };
+              if (this.options.saveMissing) {
+                var F = void 0 !== e.count && 'string' != typeof e.count;
+                this.options.saveMissingPlurals && F
+                  ? N.forEach(function(t) {
+                      n.pluralResolver.getPluralFormsOfKey(t, i).forEach(function(e) {
+                        return P([t], e);
+                      });
+                    })
+                  : P(N, i);
+              }
+            }
+            (f = this.extendTranslation(f, t, e, c)),
+              R && f === i && this.options.appendNamespaceToMissingKey && (f = a + ':' + i),
+              R &&
+                this.options.parseMissingKeyHandler &&
+                (f = this.options.parseMissingKeyHandler(f));
+          }
+          return f;
+        }),
+        (e.prototype.extendTranslation = function(t, e, n, o) {
+          var r = this;
+          if (this.i18nFormat && this.i18nFormat.parse)
+            t = this.i18nFormat.parse(t, n, o.usedLng, o.usedNS, o.usedKey, { resolved: o });
+          else if (!n.skipInterpolation) {
+            n.interpolation &&
+              this.interpolator.init(
+                m({}, n, { interpolation: m({}, this.options.interpolation, n.interpolation) }),
+              );
+            var i = n.replace && 'string' != typeof n.replace ? n.replace : n;
+            this.options.interpolation.defaultVariables &&
+              (i = m({}, this.options.interpolation.defaultVariables, i)),
+              (t = this.interpolator.interpolate(t, i, n.lng || this.language, n)),
+              !1 !== n.nest &&
+                (t = this.interpolator.nest(
+                  t,
+                  function() {
+                    return r.translate.apply(r, arguments);
+                  },
+                  n,
+                )),
+              n.interpolation && this.interpolator.reset();
+          }
+          var s = n.postProcess || this.options.postProcess,
+            a = 'string' == typeof s ? [s] : s;
+          return (
+            void 0 !== t &&
+              null !== t &&
+              a &&
+              a.length &&
+              !1 !== n.applyPostProcessor &&
+              (t = C.handle(a, t, e, n, this)),
+            t
+          );
+        }),
+        (e.prototype.resolve = function(t) {
+          var e = this,
+            n = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {},
+            o = void 0,
+            r = void 0,
+            i = void 0,
+            s = void 0;
+          return (
+            'string' == typeof t && (t = [t]),
+            t.forEach(function(t) {
+              if (!e.isValidLookup(o)) {
+                var a = e.extractFromKey(t, n),
+                  u = a.key;
+                r = u;
+                var l = a.namespaces;
+                e.options.fallbackNS && (l = l.concat(e.options.fallbackNS));
+                var p = void 0 !== n.count && 'string' != typeof n.count,
+                  c = void 0 !== n.context && 'string' == typeof n.context && '' !== n.context,
+                  f = n.lngs
+                    ? n.lngs
+                    : e.languageUtils.toResolveHierarchy(n.lng || e.language, n.fallbackLng);
+                l.forEach(function(t) {
+                  e.isValidLookup(o) ||
+                    ((s = t),
+                    f.forEach(function(r) {
+                      if (!e.isValidLookup(o)) {
+                        i = r;
+                        var s = u,
+                          a = [s];
+                        if (e.i18nFormat && e.i18nFormat.addLookupKeys)
+                          e.i18nFormat.addLookupKeys(a, u, r, t, n);
+                        else {
+                          var l = void 0;
+                          p && (l = e.pluralResolver.getSuffix(r, n.count)),
+                            p && c && a.push(s + l),
+                            c && a.push((s += '' + e.options.contextSeparator + n.context)),
+                            p && a.push((s += l));
+                        }
+                        for (var f = void 0; (f = a.pop()); )
+                          e.isValidLookup(o) || (o = e.getResource(r, t, f, n));
+                      }
+                    }));
+                });
+              }
+            }),
+            { res: o, usedKey: r, usedLng: i, usedNS: s }
+          );
+        }),
+        (e.prototype.isValidLookup = function(t) {
+          return !(
+            void 0 === t ||
+            (!this.options.returnNull && null === t) ||
+            (!this.options.returnEmptyString && '' === t)
+          );
+        }),
+        (e.prototype.getResource = function(t, e, n) {
+          var o = arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : {};
+          return this.i18nFormat && this.i18nFormat.getResource
+            ? this.i18nFormat.getResource(t, e, n, o)
+            : this.resourceStore.getResource(t, e, n, o);
+        }),
+        e
+      );
+    })(L),
+    P = (function() {
+      function t(e) {
+        y(this, t),
+          (this.options = e),
+          (this.whitelist = this.options.whitelist || !1),
+          (this.logger = R.create('languageUtils'));
+      }
+      return (
+        (t.prototype.getScriptPartFromCode = function(t) {
+          if (!t || t.indexOf('-') < 0) return null;
+          var e = t.split('-');
+          return 2 === e.length ? null : (e.pop(), this.formatLanguageCode(e.join('-')));
+        }),
+        (t.prototype.getLanguagePartFromCode = function(t) {
+          if (!t || t.indexOf('-') < 0) return t;
+          var e = t.split('-');
+          return this.formatLanguageCode(e[0]);
+        }),
+        (t.prototype.formatLanguageCode = function(t) {
+          if ('string' == typeof t && t.indexOf('-') > -1) {
+            var e = ['hans', 'hant', 'latn', 'cyrl', 'cans', 'mong', 'arab'],
+              n = t.split('-');
+            return (
+              this.options.lowerCaseLng
+                ? (n = n.map(function(t) {
+                    return t.toLowerCase();
+                  }))
+                : 2 === n.length
+                ? ((n[0] = n[0].toLowerCase()),
+                  (n[1] = n[1].toUpperCase()),
+                  e.indexOf(n[1].toLowerCase()) > -1 && (n[1] = p(n[1].toLowerCase())))
+                : 3 === n.length &&
+                  ((n[0] = n[0].toLowerCase()),
+                  2 === n[1].length && (n[1] = n[1].toUpperCase()),
+                  'sgn' !== n[0] && 2 === n[2].length && (n[2] = n[2].toUpperCase()),
+                  e.indexOf(n[1].toLowerCase()) > -1 && (n[1] = p(n[1].toLowerCase())),
+                  e.indexOf(n[2].toLowerCase()) > -1 && (n[2] = p(n[2].toLowerCase()))),
+              n.join('-')
+            );
+          }
+          return this.options.cleanCode || this.options.lowerCaseLng ? t.toLowerCase() : t;
+        }),
+        (t.prototype.isWhitelisted = function(t) {
+          return (
+            ('languageOnly' === this.options.load || this.options.nonExplicitWhitelist) &&
+              (t = this.getLanguagePartFromCode(t)),
+            !this.whitelist || !this.whitelist.length || this.whitelist.indexOf(t) > -1
+          );
+        }),
+        (t.prototype.getFallbackCodes = function(t, e) {
+          if (!t) return [];
+          if (
+            ('string' == typeof t && (t = [t]),
+            '[object Array]' === Object.prototype.toString.apply(t))
+          )
+            return t;
+          if (!e) return t.default || [];
+          var n = t[e];
+          return (
+            n || (n = t[this.getScriptPartFromCode(e)]),
+            n || (n = t[this.formatLanguageCode(e)]),
+            n || (n = t.default),
+            n || []
+          );
+        }),
+        (t.prototype.toResolveHierarchy = function(t, e) {
+          var n = this,
+            o = this.getFallbackCodes(e || this.options.fallbackLng || [], t),
+            r = [],
+            i = function(t) {
+              t &&
+                (n.isWhitelisted(t)
+                  ? r.push(t)
+                  : n.logger.warn('rejecting non-whitelisted language code: ' + t));
+            };
+          return (
+            'string' == typeof t && t.indexOf('-') > -1
+              ? ('languageOnly' !== this.options.load && i(this.formatLanguageCode(t)),
+                'languageOnly' !== this.options.load &&
+                  'currentOnly' !== this.options.load &&
+                  i(this.getScriptPartFromCode(t)),
+                'currentOnly' !== this.options.load && i(this.getLanguagePartFromCode(t)))
+              : 'string' == typeof t && i(this.formatLanguageCode(t)),
+            o.forEach(function(t) {
+              r.indexOf(t) < 0 && i(n.formatLanguageCode(t));
+            }),
+            r
+          );
+        }),
+        t
+      );
+    })(),
+    F = [
+      {
+        lngs: [
+          'ach',
+          'ak',
+          'am',
+          'arn',
+          'br',
+          'fil',
+          'gun',
+          'ln',
+          'mfe',
+          'mg',
+          'mi',
+          'oc',
+          'pt',
+          'pt-BR',
+          'tg',
+          'ti',
+          'tr',
+          'uz',
+          'wa',
+        ],
+        nr: [1, 2],
+        fc: 1,
+      },
+      {
+        lngs: [
+          'af',
+          'an',
+          'ast',
+          'az',
+          'bg',
+          'bn',
+          'ca',
+          'da',
+          'de',
+          'dev',
+          'el',
+          'en',
+          'eo',
+          'es',
+          'et',
+          'eu',
+          'fi',
+          'fo',
+          'fur',
+          'fy',
+          'gl',
+          'gu',
+          'ha',
+          'hi',
+          'hu',
+          'hy',
+          'ia',
+          'it',
+          'kn',
+          'ku',
+          'lb',
+          'mai',
+          'ml',
+          'mn',
+          'mr',
+          'nah',
+          'nap',
+          'nb',
+          'ne',
+          'nl',
+          'nn',
+          'no',
+          'nso',
+          'pa',
+          'pap',
+          'pms',
+          'ps',
+          'pt-PT',
+          'rm',
+          'sco',
+          'se',
+          'si',
+          'so',
+          'son',
+          'sq',
+          'sv',
+          'sw',
+          'ta',
+          'te',
+          'tk',
+          'ur',
+          'yo',
+        ],
+        nr: [1, 2],
+        fc: 2,
+      },
+      {
+        lngs: [
+          'ay',
+          'bo',
+          'cgg',
+          'fa',
+          'id',
+          'ja',
+          'jbo',
+          'ka',
+          'kk',
+          'km',
+          'ko',
+          'ky',
+          'lo',
+          'ms',
+          'sah',
+          'su',
+          'th',
+          'tt',
+          'ug',
+          'vi',
+          'wo',
+          'zh',
+        ],
+        nr: [1],
+        fc: 3,
+      },
+      { lngs: ['be', 'bs', 'dz', 'hr', 'ru', 'sr', 'uk'], nr: [1, 2, 5], fc: 4 },
+      { lngs: ['ar'], nr: [0, 1, 2, 3, 11, 100], fc: 5 },
+      { lngs: ['cs', 'sk'], nr: [1, 2, 5], fc: 6 },
+      { lngs: ['csb', 'pl'], nr: [1, 2, 5], fc: 7 },
+      { lngs: ['cy'], nr: [1, 2, 3, 8], fc: 8 },
+      { lngs: ['fr'], nr: [1, 2], fc: 9 },
+      { lngs: ['ga'], nr: [1, 2, 3, 7, 11], fc: 10 },
+      { lngs: ['gd'], nr: [1, 2, 3, 20], fc: 11 },
+      { lngs: ['is'], nr: [1, 2], fc: 12 },
+      { lngs: ['jv'], nr: [0, 1], fc: 13 },
+      { lngs: ['kw'], nr: [1, 2, 3, 4], fc: 14 },
+      { lngs: ['lt'], nr: [1, 2, 10], fc: 15 },
+      { lngs: ['lv'], nr: [1, 2, 0], fc: 16 },
+      { lngs: ['mk'], nr: [1, 2], fc: 17 },
+      { lngs: ['mnk'], nr: [0, 1, 2], fc: 18 },
+      { lngs: ['mt'], nr: [1, 2, 11, 20], fc: 19 },
+      { lngs: ['or'], nr: [2, 1], fc: 2 },
+      { lngs: ['ro'], nr: [1, 2, 20], fc: 20 },
+      { lngs: ['sl'], nr: [5, 1, 2, 3], fc: 21 },
+      { lngs: ['he'], nr: [1, 2, 20, 21], fc: 22 },
+    ],
+    A = {
+      1: function(t) {
+        return Number(t > 1);
+      },
+      2: function(t) {
+        return Number(1 != t);
+      },
+      3: function(t) {
+        return 0;
+      },
+      4: function(t) {
+        return Number(
+          t % 10 == 1 && t % 100 != 11
+            ? 0
+            : t % 10 >= 2 && t % 10 <= 4 && (t % 100 < 10 || t % 100 >= 20)
+            ? 1
+            : 2,
+        );
+      },
+      5: function(t) {
+        return Number(
+          0 === t
+            ? 0
+            : 1 == t
+            ? 1
+            : 2 == t
+            ? 2
+            : t % 100 >= 3 && t % 100 <= 10
+            ? 3
+            : t % 100 >= 11
+            ? 4
+            : 5,
+        );
+      },
+      6: function(t) {
+        return Number(1 == t ? 0 : t >= 2 && t <= 4 ? 1 : 2);
+      },
+      7: function(t) {
+        return Number(
+          1 == t ? 0 : t % 10 >= 2 && t % 10 <= 4 && (t % 100 < 10 || t % 100 >= 20) ? 1 : 2,
+        );
+      },
+      8: function(t) {
+        return Number(1 == t ? 0 : 2 == t ? 1 : 8 != t && 11 != t ? 2 : 3);
+      },
+      9: function(t) {
+        return Number(t >= 2);
+      },
+      10: function(t) {
+        return Number(1 == t ? 0 : 2 == t ? 1 : t < 7 ? 2 : t < 11 ? 3 : 4);
+      },
+      11: function(t) {
+        return Number(1 == t || 11 == t ? 0 : 2 == t || 12 == t ? 1 : t > 2 && t < 20 ? 2 : 3);
+      },
+      12: function(t) {
+        return Number(t % 10 != 1 || t % 100 == 11);
+      },
+      13: function(t) {
+        return Number(0 !== t);
+      },
+      14: function(t) {
+        return Number(1 == t ? 0 : 2 == t ? 1 : 3 == t ? 2 : 3);
+      },
+      15: function(t) {
+        return Number(
+          t % 10 == 1 && t % 100 != 11 ? 0 : t % 10 >= 2 && (t % 100 < 10 || t % 100 >= 20) ? 1 : 2,
+        );
+      },
+      16: function(t) {
+        return Number(t % 10 == 1 && t % 100 != 11 ? 0 : 0 !== t ? 1 : 2);
+      },
+      17: function(t) {
+        return Number(1 == t || t % 10 == 1 ? 0 : 1);
+      },
+      18: function(t) {
+        return Number(0 == t ? 0 : 1 == t ? 1 : 2);
+      },
+      19: function(t) {
+        return Number(
+          1 == t
+            ? 0
+            : 0 === t || (t % 100 > 1 && t % 100 < 11)
+            ? 1
+            : t % 100 > 10 && t % 100 < 20
+            ? 2
+            : 3,
+        );
+      },
+      20: function(t) {
+        return Number(1 == t ? 0 : 0 === t || (t % 100 > 0 && t % 100 < 20) ? 1 : 2);
+      },
+      21: function(t) {
+        return Number(t % 100 == 1 ? 1 : t % 100 == 2 ? 2 : t % 100 == 3 || t % 100 == 4 ? 3 : 0);
+      },
+      22: function(t) {
+        return Number(1 === t ? 0 : 2 === t ? 1 : (t < 0 || t > 10) && t % 10 == 0 ? 2 : 3);
+      },
+    },
+    T = (function() {
+      function t(e) {
+        var n = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {};
+        y(this, t),
+          (this.languageUtils = e),
+          (this.options = n),
+          (this.logger = R.create('pluralResolver')),
+          (this.rules = c());
+      }
+      return (
+        (t.prototype.addRule = function(t, e) {
+          this.rules[t] = e;
+        }),
+        (t.prototype.getRule = function(t) {
+          return this.rules[t] || this.rules[this.languageUtils.getLanguagePartFromCode(t)];
+        }),
+        (t.prototype.needsPlural = function(t) {
+          var e = this.getRule(t);
+          return e && e.numbers.length > 1;
+        }),
+        (t.prototype.getPluralFormsOfKey = function(t, e) {
+          var n = this,
+            o = [],
+            r = this.getRule(t);
+          return r
+            ? (r.numbers.forEach(function(r) {
+                var i = n.getSuffix(t, r);
+                o.push('' + e + i);
+              }),
+              o)
+            : o;
+        }),
+        (t.prototype.getSuffix = function(t, e) {
+          var n = this,
+            o = this.getRule(t);
+          if (o) {
+            var r = o.noAbs ? o.plurals(e) : o.plurals(Math.abs(e)),
+              i = o.numbers[r];
+            this.options.simplifyPluralSuffix &&
+              2 === o.numbers.length &&
+              1 === o.numbers[0] &&
+              (2 === i ? (i = 'plural') : 1 === i && (i = ''));
+            var s = function() {
+              return n.options.prepend && i.toString()
+                ? n.options.prepend + i.toString()
+                : i.toString();
+            };
+            return 'v1' === this.options.compatibilityJSON
+              ? 1 === i
+                ? ''
+                : 'number' == typeof i
+                ? '_plural_' + i.toString()
+                : s()
+              : 'v2' === this.options.compatibilityJSON
+              ? s()
+              : this.options.simplifyPluralSuffix && 2 === o.numbers.length && 1 === o.numbers[0]
+              ? s()
+              : this.options.prepend && r.toString()
+              ? this.options.prepend + r.toString()
+              : r.toString();
+          }
+          return this.logger.warn('no plural rule found for: ' + t), '';
+        }),
+        t
+      );
+    })(),
+    V = (function() {
+      function t() {
+        var e = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {};
+        y(this, t), (this.logger = R.create('interpolator')), this.init(e, !0);
+      }
+      return (
+        (t.prototype.init = function() {
+          var t = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {};
+          arguments[1] &&
+            ((this.options = t),
+            (this.format =
+              (t.interpolation && t.interpolation.format) ||
+              function(t) {
+                return t;
+              })),
+            t.interpolation || (t.interpolation = { escapeValue: !0 });
+          var e = t.interpolation;
+          (this.escape = void 0 !== e.escape ? e.escape : l),
+            (this.escapeValue = void 0 === e.escapeValue || e.escapeValue),
+            (this.useRawValueToEscape = void 0 !== e.useRawValueToEscape && e.useRawValueToEscape),
+            (this.prefix = e.prefix ? u(e.prefix) : e.prefixEscaped || '{{'),
+            (this.suffix = e.suffix ? u(e.suffix) : e.suffixEscaped || '}}'),
+            (this.formatSeparator = e.formatSeparator
+              ? e.formatSeparator
+              : e.formatSeparator || ','),
+            (this.unescapePrefix = e.unescapeSuffix ? '' : e.unescapePrefix || '-'),
+            (this.unescapeSuffix = this.unescapePrefix ? '' : e.unescapeSuffix || ''),
+            (this.nestingPrefix = e.nestingPrefix
+              ? u(e.nestingPrefix)
+              : e.nestingPrefixEscaped || u('$t(')),
+            (this.nestingSuffix = e.nestingSuffix
+              ? u(e.nestingSuffix)
+              : e.nestingSuffixEscaped || u(')')),
+            (this.maxReplaces = e.maxReplaces ? e.maxReplaces : 1e3),
+            this.resetRegExp();
+        }),
+        (t.prototype.reset = function() {
+          this.options && this.init(this.options);
+        }),
+        (t.prototype.resetRegExp = function() {
+          var t = this.prefix + '(.+?)' + this.suffix;
+          this.regexp = new RegExp(t, 'g');
+          var e =
+            '' + this.prefix + this.unescapePrefix + '(.+?)' + this.unescapeSuffix + this.suffix;
+          this.regexpUnescape = new RegExp(e, 'g');
+          var n = this.nestingPrefix + '(.+?)' + this.nestingSuffix;
+          this.nestingRegexp = new RegExp(n, 'g');
+        }),
+        (t.prototype.interpolate = function(t, n, o, r) {
+          function i(t) {
+            return t.replace(/\$/g, '$$$$');
+          }
+          var a = this,
+            u = void 0,
+            l = void 0,
+            p = void 0,
+            c = function(t) {
+              if (t.indexOf(a.formatSeparator) < 0) return s(n, t);
+              var e = t.split(a.formatSeparator),
+                r = e.shift().trim(),
+                i = e.join(a.formatSeparator).trim();
+              return a.format(s(n, r), i, o);
+            };
+          this.resetRegExp();
+          var f = (r && r.missingInterpolationHandler) || this.options.missingInterpolationHandler;
+          for (
+            p = 0;
+            (u = this.regexpUnescape.exec(t)) &&
+            ((l = c(u[1].trim())),
+            (t = t.replace(u[0], l)),
+            (this.regexpUnescape.lastIndex = 0),
+            !(++p >= this.maxReplaces));
+
+          );
+          for (p = 0; (u = this.regexp.exec(t)); ) {
+            if (void 0 === (l = c(u[1].trim())))
+              if ('function' == typeof f) {
+                var g = f(t, u, r);
+                l = 'string' == typeof g ? g : '';
+              } else
+                this.logger.warn('missed to pass in variable ' + u[1] + ' for interpolating ' + t),
+                  (l = '');
+            else 'string' == typeof l || this.useRawValueToEscape || (l = e(l));
+            if (
+              ((l = i(this.escapeValue ? this.escape(l) : l)),
+              (t = t.replace(u[0], l)),
+              (this.regexp.lastIndex = 0),
+              ++p >= this.maxReplaces)
+            )
+              break;
+          }
+          return t;
+        }),
+        (t.prototype.nest = function(t, n) {
+          function o(t, e) {
+            if (t.indexOf(',') < 0) return t;
+            var n = t.split(',');
+            t = n.shift();
+            var o = n.join(',');
+            (o = this.interpolate(o, a)), (o = o.replace(/'/g, '"'));
+            try {
+              (a = JSON.parse(o)), e && (a = m({}, e, a));
+            } catch (e) {
+              this.logger.error('failed parsing options string in nesting for key ' + t, e);
+            }
+            return t;
+          }
+          var r = arguments.length > 2 && void 0 !== arguments[2] ? arguments[2] : {},
+            i = void 0,
+            s = void 0,
+            a = m({}, r);
+          for (a.applyPostProcessor = !1; (i = this.nestingRegexp.exec(t)); ) {
+            if ((s = n(o.call(this, i[1].trim(), a), a)) && i[0] === t && 'string' != typeof s)
+              return s;
+            'string' != typeof s && (s = e(s)),
+              s || (this.logger.warn('missed to resolve ' + i[1] + ' for nesting ' + t), (s = '')),
+              (t = t.replace(i[0], s)),
+              (this.regexp.lastIndex = 0);
+          }
+          return t;
+        }),
+        t
+      );
+    })(),
+    U = (function(t) {
+      function e(n, o, r) {
+        var i = arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : {};
+        y(this, e);
+        var s = x(this, t.call(this));
+        return (
+          (s.backend = n),
+          (s.store = o),
+          (s.languageUtils = r.languageUtils),
+          (s.options = i),
+          (s.logger = R.create('backendConnector')),
+          (s.state = {}),
+          (s.queue = []),
+          s.backend && s.backend.init && s.backend.init(r, i.backend, i),
+          s
+        );
+      }
+      return (
+        b(e, t),
+        (e.prototype.queueLoad = function(t, e, n, o) {
+          var r = this,
+            i = [],
+            s = [],
+            a = [],
+            u = [];
+          return (
+            t.forEach(function(t) {
+              var o = !0;
+              e.forEach(function(e) {
+                var a = t + '|' + e;
+                !n.reload && r.store.hasResourceBundle(t, e)
+                  ? (r.state[a] = 2)
+                  : r.state[a] < 0 ||
+                    (1 === r.state[a]
+                      ? s.indexOf(a) < 0 && s.push(a)
+                      : ((r.state[a] = 1),
+                        (o = !1),
+                        s.indexOf(a) < 0 && s.push(a),
+                        i.indexOf(a) < 0 && i.push(a),
+                        u.indexOf(e) < 0 && u.push(e)));
+              }),
+                o || a.push(t);
+            }),
+            (i.length || s.length) &&
+              this.queue.push({ pending: s, loaded: {}, errors: [], callback: o }),
+            { toLoad: i, pending: s, toLoadLanguages: a, toLoadNamespaces: u }
+          );
+        }),
+        (e.prototype.loaded = function(t, e, n) {
+          var o = t.split('|'),
+            r = S(o, 2),
+            s = r[0],
+            a = r[1];
+          e && this.emit('failedLoading', s, a, e),
+            n && this.store.addResourceBundle(s, a, n),
+            (this.state[t] = e ? -1 : 2);
+          var u = {};
+          this.queue.forEach(function(n) {
+            i(n.loaded, [s], a),
+              f(n.pending, t),
+              e && n.errors.push(e),
+              0 !== n.pending.length ||
+                n.done ||
+                (Object.keys(n.loaded).forEach(function(t) {
+                  u[t] || (u[t] = []),
+                    n.loaded[t].length &&
+                      n.loaded[t].forEach(function(e) {
+                        u[t].indexOf(e) < 0 && u[t].push(e);
+                      });
+                }),
+                (n.done = !0),
+                n.errors.length ? n.callback(n.errors) : n.callback());
+          }),
+            this.emit('loaded', u),
+            (this.queue = this.queue.filter(function(t) {
+              return !t.done;
+            }));
+        }),
+        (e.prototype.read = function(t, e, n) {
+          var o = arguments.length > 3 && void 0 !== arguments[3] ? arguments[3] : 0,
+            r = this,
+            i = arguments.length > 4 && void 0 !== arguments[4] ? arguments[4] : 250,
+            s = arguments[5];
+          return t.length
+            ? this.backend[n](t, e, function(a, u) {
+                if (a && u && o < 5)
+                  return void setTimeout(function() {
+                    r.read.call(r, t, e, n, o + 1, 2 * i, s);
+                  }, i);
+                s(a, u);
+              })
+            : s(null, {});
+        }),
+        (e.prototype.prepareLoading = function(t, e) {
+          var n = this,
+            o = arguments.length > 2 && void 0 !== arguments[2] ? arguments[2] : {},
+            r = arguments[3];
+          if (!this.backend)
+            return (
+              this.logger.warn('No backend was added via i18next.use. Will not load resources.'),
+              r && r()
+            );
+          'string' == typeof t && (t = this.languageUtils.toResolveHierarchy(t)),
+            'string' == typeof e && (e = [e]);
+          var i = this.queueLoad(t, e, o, r);
+          if (!i.toLoad.length) return i.pending.length || r(), null;
+          i.toLoad.forEach(function(t) {
+            n.loadOne(t);
+          });
+        }),
+        (e.prototype.load = function(t, e, n) {
+          this.prepareLoading(t, e, {}, n);
+        }),
+        (e.prototype.reload = function(t, e, n) {
+          this.prepareLoading(t, e, { reload: !0 }, n);
+        }),
+        (e.prototype.loadOne = function(t) {
+          var e = this,
+            n = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : '',
+            o = t.split('|'),
+            r = S(o, 2),
+            i = r[0],
+            s = r[1];
+          this.read(i, s, 'read', null, null, function(o, r) {
+            o && e.logger.warn(n + 'loading namespace ' + s + ' for language ' + i + ' failed', o),
+              !o && r && e.logger.log(n + 'loaded namespace ' + s + ' for language ' + i, r),
+              e.loaded(t, o, r);
+          });
+        }),
+        (e.prototype.saveMissing = function(t, e, n, o, r) {
+          var i = arguments.length > 5 && void 0 !== arguments[5] ? arguments[5] : {};
+          this.backend &&
+            this.backend.create &&
+            this.backend.create(t, e, n, o, null, m({}, i, { isUpdate: r })),
+            t && t[0] && this.store.addResource(t[0], e, n, o);
+        }),
+        e
+      );
+    })(L);
+  return new ((function(e) {
+    function n() {
+      var t = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
+        o = arguments[1];
+      y(this, n);
+      var r = x(this, e.call(this));
+      if (
+        ((r.options = h(t)),
+        (r.services = {}),
+        (r.logger = R),
+        (r.modules = { external: [] }),
+        o && !r.isInitialized && !t.isClone)
+      ) {
+        if (!r.options.initImmediate) {
+          var i;
+          return r.init(t, o), (i = r), x(r, i);
+        }
+        setTimeout(function() {
+          r.init(t, o);
+        }, 0);
+      }
+      return r;
+    }
+    return (
+      b(n, e),
+      (n.prototype.init = function() {
+        function e(t) {
+          return t ? ('function' == typeof t ? new t() : t) : null;
+        }
+        var n = this,
+          o = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
+          r = arguments[1];
+        if (
+          ('function' == typeof o && ((r = o), (o = {})),
+          (this.options = m({}, g(), this.options, h(o))),
+          (this.format = this.options.interpolation.format),
+          r || (r = d),
+          !this.options.isClone)
+        ) {
+          this.modules.logger
+            ? R.init(e(this.modules.logger), this.options)
+            : R.init(null, this.options);
+          var i = new P(this.options);
+          this.store = new N(this.options.resources, this.options);
+          var s = this.services;
+          (s.logger = R),
+            (s.resourceStore = this.store),
+            (s.languageUtils = i),
+            (s.pluralResolver = new T(i, {
+              prepend: this.options.pluralSeparator,
+              compatibilityJSON: this.options.compatibilityJSON,
+              simplifyPluralSuffix: this.options.simplifyPluralSuffix,
+            })),
+            (s.interpolator = new V(this.options)),
+            (s.backendConnector = new U(e(this.modules.backend), s.resourceStore, s, this.options)),
+            s.backendConnector.on('*', function(t) {
+              for (var e = arguments.length, o = Array(e > 1 ? e - 1 : 0), r = 1; r < e; r++)
+                o[r - 1] = arguments[r];
+              n.emit.apply(n, [t].concat(o));
+            }),
+            this.modules.languageDetector &&
+              ((s.languageDetector = e(this.modules.languageDetector)),
+              s.languageDetector.init(s, this.options.detection, this.options)),
+            this.modules.i18nFormat &&
+              ((s.i18nFormat = e(this.modules.i18nFormat)),
+              s.i18nFormat.init && s.i18nFormat.init(this)),
+            (this.translator = new E(this.services, this.options)),
+            this.translator.on('*', function(t) {
+              for (var e = arguments.length, o = Array(e > 1 ? e - 1 : 0), r = 1; r < e; r++)
+                o[r - 1] = arguments[r];
+              n.emit.apply(n, [t].concat(o));
+            }),
+            this.modules.external.forEach(function(t) {
+              t.init && t.init(n);
+            });
+        }
+        [
+          'getResource',
+          'addResource',
+          'addResources',
+          'addResourceBundle',
+          'removeResourceBundle',
+          'hasResourceBundle',
+          'getResourceBundle',
+          'getDataByLanguage',
+        ].forEach(function(t) {
+          n[t] = function() {
+            var e;
+            return (e = n.store)[t].apply(e, arguments);
+          };
+        });
+        var a = t(),
+          u = function() {
+            n.changeLanguage(n.options.lng, function(t, e) {
+              (n.isInitialized = !0),
+                n.logger.log('initialized', n.options),
+                n.emit('initialized', n.options),
+                a.resolve(e),
+                r(t, e);
+            });
+          };
+        return this.options.resources || !this.options.initImmediate ? u() : setTimeout(u, 0), a;
+      }),
+      (n.prototype.loadResources = function() {
+        var t = this,
+          e = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : d;
+        if (!this.options.resources || this.options.partialBundledLanguages) {
+          if (this.language && 'cimode' === this.language.toLowerCase()) return e();
+          var n = [],
+            o = function(e) {
+              if (e) {
+                t.services.languageUtils.toResolveHierarchy(e).forEach(function(t) {
+                  n.indexOf(t) < 0 && n.push(t);
+                });
+              }
+            };
+          if (this.language) o(this.language);
+          else {
+            this.services.languageUtils
+              .getFallbackCodes(this.options.fallbackLng)
+              .forEach(function(t) {
+                return o(t);
+              });
+          }
+          this.options.preload &&
+            this.options.preload.forEach(function(t) {
+              return o(t);
+            }),
+            this.services.backendConnector.load(n, this.options.ns, e);
+        } else e(null);
+      }),
+      (n.prototype.reloadResources = function(e, n, o) {
+        var r = t();
+        return (
+          e || (e = this.languages),
+          n || (n = this.options.ns),
+          o || (o = d),
+          this.services.backendConnector.reload(e, n, function() {
+            r.resolve(), o(null);
+          }),
+          r
+        );
+      }),
+      (n.prototype.use = function(t) {
+        return (
+          'backend' === t.type && (this.modules.backend = t),
+          ('logger' === t.type || (t.log && t.warn && t.error)) && (this.modules.logger = t),
+          'languageDetector' === t.type && (this.modules.languageDetector = t),
+          'i18nFormat' === t.type && (this.modules.i18nFormat = t),
+          'postProcessor' === t.type && C.addPostProcessor(t),
+          '3rdParty' === t.type && this.modules.external.push(t),
+          this
+        );
+      }),
+      (n.prototype.changeLanguage = function(e, n) {
+        var o = this,
+          r = t(),
+          i = function(t, e) {
+            o.translator.changeLanguage(e),
+              e && (o.emit('languageChanged', e), o.logger.log('languageChanged', e)),
+              r.resolve(function() {
+                return o.t.apply(o, arguments);
+              }),
+              n &&
+                n(t, function() {
+                  return o.t.apply(o, arguments);
+                });
+          },
+          s = function(t) {
+            t &&
+              ((o.language = t),
+              (o.languages = o.services.languageUtils.toResolveHierarchy(t)),
+              o.translator.language || o.translator.changeLanguage(t),
+              o.services.languageDetector && o.services.languageDetector.cacheUserLanguage(t)),
+              o.loadResources(function(e) {
+                i(e, t);
+              });
+          };
+        return (
+          e || !this.services.languageDetector || this.services.languageDetector.async
+            ? !e && this.services.languageDetector && this.services.languageDetector.async
+              ? this.services.languageDetector.detect(s)
+              : s(e)
+            : s(this.services.languageDetector.detect()),
+          r
+        );
+      }),
+      (n.prototype.getFixedT = function(t, e) {
+        var n = this,
+          o = function t(e, o) {
+            for (var r = arguments.length, i = Array(r > 2 ? r - 2 : 0), s = 2; s < r; s++)
+              i[s - 2] = arguments[s];
+            var a = m({}, o);
+            return (
+              'object' !== (void 0 === o ? 'undefined' : v(o)) &&
+                (a = n.options.overloadTranslationOptionHandler([e, o].concat(i))),
+              (a.lng = a.lng || t.lng),
+              (a.lngs = a.lngs || t.lngs),
+              (a.ns = a.ns || t.ns),
+              n.t(e, a)
+            );
+          };
+        return 'string' == typeof t ? (o.lng = t) : (o.lngs = t), (o.ns = e), o;
+      }),
+      (n.prototype.t = function() {
+        var t;
+        return this.translator && (t = this.translator).translate.apply(t, arguments);
+      }),
+      (n.prototype.exists = function() {
+        var t;
+        return this.translator && (t = this.translator).exists.apply(t, arguments);
+      }),
+      (n.prototype.setDefaultNamespace = function(t) {
+        this.options.defaultNS = t;
+      }),
+      (n.prototype.loadNamespaces = function(e, n) {
+        var o = this,
+          r = t();
+        return this.options.ns
+          ? ('string' == typeof e && (e = [e]),
+            e.forEach(function(t) {
+              o.options.ns.indexOf(t) < 0 && o.options.ns.push(t);
+            }),
+            this.loadResources(function(t) {
+              r.resolve(), n && n(t);
+            }),
+            r)
+          : (n && n(), Promise.resolve());
+      }),
+      (n.prototype.loadLanguages = function(e, n) {
+        var o = t();
+        'string' == typeof e && (e = [e]);
+        var r = this.options.preload || [],
+          i = e.filter(function(t) {
+            return r.indexOf(t) < 0;
+          });
+        return i.length
+          ? ((this.options.preload = r.concat(i)),
+            this.loadResources(function(t) {
+              o.resolve(), n && n(t);
+            }),
+            o)
+          : (n && n(), Promise.resolve());
+      }),
+      (n.prototype.dir = function(t) {
+        return (
+          t ||
+            (t = this.languages && this.languages.length > 0 ? this.languages[0] : this.language),
+          t
+            ? [
+                'ar',
+                'shu',
+                'sqr',
+                'ssh',
+                'xaa',
+                'yhd',
+                'yud',
+                'aao',
+                'abh',
+                'abv',
+                'acm',
+                'acq',
+                'acw',
+                'acx',
+                'acy',
+                'adf',
+                'ads',
+                'aeb',
+                'aec',
+                'afb',
+                'ajp',
+                'apc',
+                'apd',
+                'arb',
+                'arq',
+                'ars',
+                'ary',
+                'arz',
+                'auz',
+                'avl',
+                'ayh',
+                'ayl',
+                'ayn',
+                'ayp',
+                'bbz',
+                'pga',
+                'he',
+                'iw',
+                'ps',
+                'pbt',
+                'pbu',
+                'pst',
+                'prp',
+                'prd',
+                'ur',
+                'ydd',
+                'yds',
+                'yih',
+                'ji',
+                'yi',
+                'hbo',
+                'men',
+                'xmn',
+                'fa',
+                'jpr',
+                'peo',
+                'pes',
+                'prs',
+                'dv',
+                'sam',
+              ].indexOf(this.services.languageUtils.getLanguagePartFromCode(t)) >= 0
+              ? 'rtl'
+              : 'ltr'
+            : 'rtl'
+        );
+      }),
+      (n.prototype.createInstance = function() {
+        return new n(
+          arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
+          arguments[1],
+        );
+      }),
+      (n.prototype.cloneInstance = function() {
+        var t = this,
+          e = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
+          o = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : d,
+          r = m({}, this.options, e, { isClone: !0 }),
+          i = new n(r);
+        return (
+          ['store', 'services', 'language'].forEach(function(e) {
+            i[e] = t[e];
+          }),
+          (i.translator = new E(i.services, i.options)),
+          i.translator.on('*', function(t) {
+            for (var e = arguments.length, n = Array(e > 1 ? e - 1 : 0), o = 1; o < e; o++)
+              n[o - 1] = arguments[o];
+            i.emit.apply(i, [t].concat(n));
+          }),
+          i.init(r, o),
+          (i.translator.options = i.options),
+          i
+        );
+      }),
+      n
+    );
+  })(L))();
+});

--- a/karma.backward.conf.js
+++ b/karma.backward.conf.js
@@ -1,32 +1,31 @@
 module.exports = function(karma) {
   karma.set({
-
-    frameworks: [ 'mocha', 'expect', 'sinon', 'browserify' ],
+    frameworks: ['mocha', 'expect', 'sinon', 'browserify'],
 
     files: [
       //'vendor/external.js',
       'test/backward/**/*.compat.js',
-      { pattern: 'test/backward/locales/**/*.json', watched: true, included: false, served: true},
+      { pattern: 'test/backward/locales/**/*.json', watched: true, included: false, served: true },
     ],
 
     proxies: {
-      '/locales': 'http://localhost:9877/base/test/backward/locales'
+      '/locales': 'http://localhost:9877/base/test/backward/locales',
     },
 
-    reporters: [ 'spec' ],
+    reporters: ['spec'],
 
     preprocessors: {
-      'test/backward/**/*.compat.js': [ 'browserify' ],
-      'test/backward/compatibility/**/*.js': [ 'browserify' ]
+      'test/backward/**/*.compat.js': ['browserify'],
+      'test/backward/compatibility/**/*.js': ['browserify'],
     },
 
-    browsers: [ 'HeadlessChrome' ],
-      customLaunchers: {
-        HeadlessChrome: {
-          base: 'ChromeHeadless',
-          flags: [ '—no-sandbox', ],
-         },
+    browsers: ['HeadlessChrome'],
+    customLaunchers: {
+      HeadlessChrome: {
+        base: 'ChromeHeadless',
+        flags: ['—no-sandbox'],
       },
+    },
 
     port: 9877,
 
@@ -45,7 +44,7 @@ module.exports = function(karma) {
     // browserify configuration
     browserify: {
       debug: true,
-      transform: [ 'babelify'/*, 'brfs' */]
-    }
+      transform: ['babelify' /*, 'brfs' */],
+    },
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,33 +2,32 @@
 
 module.exports = function(karma) {
   karma.set({
-
-    frameworks: [ 'mocha', 'chai', 'sinon', 'browserify' ],
+    frameworks: ['mocha', 'chai', 'sinon', 'browserify'],
 
     files: [
       //'vendor/external.js',
       'test/**/*.spec.js',
-      { pattern: 'test/locales/**/*.json', watched: true, included: false, served: true},
+      { pattern: 'test/locales/**/*.json', watched: true, included: false, served: true },
     ],
 
     proxies: {
-      '/locales': 'http://localhost:9876/base/test/locales'
+      '/locales': 'http://localhost:9876/base/test/locales',
     },
 
-    reporters: [ 'coverage', 'coveralls', 'spec' ],
+    reporters: ['coverage', 'coveralls', 'spec'],
 
     preprocessors: {
-      'test/**/*.spec.js': [ 'browserify' ],
-      'src/**/*.js': [ 'browserify', 'coverage' ]
+      'test/**/*.spec.js': ['browserify'],
+      'src/**/*.js': ['browserify', 'coverage'],
     },
 
-    browsers: [ 'HeadlessChrome' ],
-      customLaunchers: {
-        HeadlessChrome: {
-          base: 'ChromeHeadless',
-          flags: [ '—no-sandbox', ],
-         },
+    browsers: ['HeadlessChrome'],
+    customLaunchers: {
+      HeadlessChrome: {
+        base: 'ChromeHeadless',
+        flags: ['—no-sandbox'],
       },
+    },
 
     port: 9876,
 
@@ -47,14 +46,12 @@ module.exports = function(karma) {
     // browserify configuration
     browserify: {
       debug: true,
-      transform: [
-        'babelify', /*'brfs',*/ 'browserify-istanbul'
-      ]
+      transform: ['babelify', /*'brfs',*/ 'browserify-istanbul'],
     },
 
     coverageReporter: {
-      type : 'lcov', //'html', // disabled - erroring now, https://github.com/karma-runner/karma-coverage/issues/157
-      dir : 'coverage/'
-    }
+      type: 'lcov', //'html', // disabled - erroring now, https://github.com/karma-runner/karma-coverage/issues/157
+      dir: 'coverage/',
+    },
   });
 };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.9.0",
+    "husky": "^1.3.1",
     "i18next-browser-languagedetector": "1.0.1",
     "i18next-localstorage-cache": "0.3.0",
     "i18next-sprintf-postprocessor": "0.2.2",
@@ -60,6 +61,7 @@
     "karma-rollup-preprocessor": "3.0.3",
     "karma-sinon": "1.0.5",
     "karma-spec-reporter": "0.0.26",
+    "lint-staged": "^8.1.0",
     "mkdirp": "0.5.1",
     "mocha": "3.2.0",
     "prettier": "^1.15.3",
@@ -92,8 +94,19 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:umd && npm run copy",
     "preversion": "npm run test && npm run build && git push",
     "postversion": "git push && git push --tags",
-    "prettier:typescript": "prettier --write \"{,**/}*.{ts,tsx}\""
+    "prettier": "prettier --write \"{,**/}*.{ts,tsx,js,json,md}\""
   },
   "author": "Jan Mühlemann <jan.muehlemann@gmail.com> (https://github.com/jamuhl)",
-  "license": "MIT"
+  "license": "MIT",
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,json,md}": [
+      "prettier --write",
+      "git add"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dtslint": "^0.4.2",
     "eslint": "3.15.0",
     "eslint-config-airbnb": "14.1.0",
+    "eslint-config-prettier": "^3.6.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.9.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,24 +9,25 @@ const compress = argv.uglify;
 const babelOptions = {
   exclude: 'node_modules/**',
   presets: [['es2015', { modules: false }], 'stage-0'],
-  plugins: ['external-helpers', ['transform-es2015-classes', { loose: true }], 'transform-proto-to-assign'],
-  babelrc: false
+  plugins: [
+    'external-helpers',
+    ['transform-es2015-classes', { loose: true }],
+    'transform-proto-to-assign',
+  ],
+  babelrc: false,
 };
 
 const dest = {
   amd: `dist/amd/i18next${compress ? '.min' : ''}.js`,
   umd: `dist/umd/i18next${compress ? '.min' : ''}.js`,
-  iife: `dist/iife/i18next${compress ? '.min' : ''}.js`
+  iife: `dist/iife/i18next${compress ? '.min' : ''}.js`,
 }[format];
 
 export default {
   entry: 'src/i18next.js',
   format,
-  plugins: [
-    babel(babelOptions),
-    nodeResolve({ jsnext: true })
-  ].concat(compress ? uglify() : []),
+  plugins: [babel(babelOptions), nodeResolve({ jsnext: true })].concat(compress ? uglify() : []),
   moduleName: 'i18next',
   //moduleId: 'i18next',
-  dest
+  dest,
 };

--- a/src/BackendConnector.js
+++ b/src/BackendConnector.js
@@ -35,10 +35,10 @@ class Connector extends EventEmitter {
     const toLoadLanguages = [];
     const toLoadNamespaces = [];
 
-    languages.forEach((lng) => {
+    languages.forEach(lng => {
       let hasAllNamespaces = true;
 
-      namespaces.forEach((ns) => {
+      namespaces.forEach(ns => {
         const name = `${lng}|${ns}`;
 
         if (!options.reload && this.store.hasResourceBundle(lng, ns)) {
@@ -66,7 +66,7 @@ class Connector extends EventEmitter {
         pending,
         loaded: {},
         errors: [],
-        callback
+        callback,
       });
     }
 
@@ -74,7 +74,7 @@ class Connector extends EventEmitter {
       toLoad,
       pending,
       toLoadLanguages,
-      toLoadNamespaces
+      toLoadNamespaces,
     };
   }
 
@@ -94,7 +94,7 @@ class Connector extends EventEmitter {
     const loaded = {};
 
     // callback if ready
-    this.queue.forEach((q) => {
+    this.queue.forEach(q => {
       utils.pushPath(q.loaded, [lng], ns);
       remove(q.pending, name);
 
@@ -158,17 +158,17 @@ class Connector extends EventEmitter {
       return null; // pendings will trigger callback
     }
 
-    toLoad.toLoad.forEach((name) => {
+    toLoad.toLoad.forEach(name => {
       this.loadOne(name);
     });
   }
 
   load(languages, namespaces, callback) {
-    this.prepareLoading(languages, namespaces, {}, callback)
+    this.prepareLoading(languages, namespaces, {}, callback);
   }
 
   reload(languages, namespaces, callback) {
-    this.prepareLoading(languages, namespaces, { reload: true }, callback)
+    this.prepareLoading(languages, namespaces, { reload: true }, callback);
   }
 
   loadOne(name, prefix = '') {
@@ -176,7 +176,8 @@ class Connector extends EventEmitter {
 
     this.read(lng, ns, 'read', null, null, (err, data) => {
       if (err) this.logger.warn(`${prefix}loading namespace ${ns} for language ${lng} failed`, err);
-      if (!err && data) this.logger.log(`${prefix}loaded namespace ${ns} for language ${lng}`, data);
+      if (!err && data)
+        this.logger.log(`${prefix}loaded namespace ${ns} for language ${lng}`, data);
 
       this.loaded(name, err, data);
     });
@@ -184,7 +185,10 @@ class Connector extends EventEmitter {
 
   saveMissing(languages, namespace, key, fallbackValue, isUpdate, options = {}) {
     if (this.backend && this.backend.create) {
-      this.backend.create(languages, namespace, key, fallbackValue, null /* unused callback */, { ...options, isUpdate });
+      this.backend.create(languages, namespace, key, fallbackValue, null /* unused callback */, {
+        ...options,
+        isUpdate,
+      });
     }
 
     // write to store to avoid resending

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -4,7 +4,7 @@ class EventEmitter {
   }
 
   on(events, listener) {
-    events.split(' ').forEach((event) => {
+    events.split(' ').forEach(event => {
       this.observers[event] = this.observers[event] || [];
       this.observers[event].push(listener);
     });
@@ -31,14 +31,14 @@ class EventEmitter {
   emit(event, ...args) {
     if (this.observers[event]) {
       const cloned = [].concat(this.observers[event]);
-      cloned.forEach((observer) => {
+      cloned.forEach(observer => {
         observer(...args);
       });
     }
 
     if (this.observers['*']) {
       const cloned = [].concat(this.observers['*']);
-      cloned.forEach((observer) => {
+      cloned.forEach(observer => {
         observer.apply(observer, [event, ...args]);
       });
     }

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -20,18 +20,25 @@ class Interpolator {
 
     this.escape = iOpts.escape !== undefined ? iOpts.escape : utils.escape;
     this.escapeValue = iOpts.escapeValue !== undefined ? iOpts.escapeValue : true;
-    this.useRawValueToEscape = iOpts.useRawValueToEscape !== undefined ? iOpts.useRawValueToEscape : false;
+    this.useRawValueToEscape =
+      iOpts.useRawValueToEscape !== undefined ? iOpts.useRawValueToEscape : false;
 
     this.prefix = iOpts.prefix ? utils.regexEscape(iOpts.prefix) : iOpts.prefixEscaped || '{{';
     this.suffix = iOpts.suffix ? utils.regexEscape(iOpts.suffix) : iOpts.suffixEscaped || '}}';
 
-    this.formatSeparator = iOpts.formatSeparator ? iOpts.formatSeparator : iOpts.formatSeparator || ',';
+    this.formatSeparator = iOpts.formatSeparator
+      ? iOpts.formatSeparator
+      : iOpts.formatSeparator || ',';
 
     this.unescapePrefix = iOpts.unescapeSuffix ? '' : iOpts.unescapePrefix || '-';
     this.unescapeSuffix = this.unescapePrefix ? '' : iOpts.unescapeSuffix || '';
 
-    this.nestingPrefix = iOpts.nestingPrefix ? utils.regexEscape(iOpts.nestingPrefix) : iOpts.nestingPrefixEscaped || utils.regexEscape('$t(');
-    this.nestingSuffix = iOpts.nestingSuffix ? utils.regexEscape(iOpts.nestingSuffix) : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
+    this.nestingPrefix = iOpts.nestingPrefix
+      ? utils.regexEscape(iOpts.nestingPrefix)
+      : iOpts.nestingPrefixEscaped || utils.regexEscape('$t(');
+    this.nestingSuffix = iOpts.nestingSuffix
+      ? utils.regexEscape(iOpts.nestingSuffix)
+      : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
 
     this.maxReplaces = iOpts.maxReplaces ? iOpts.maxReplaces : 1000;
 
@@ -48,7 +55,9 @@ class Interpolator {
     const regexpStr = `${this.prefix}(.+?)${this.suffix}`;
     this.regexp = new RegExp(regexpStr, 'g');
 
-    const regexpUnescapeStr = `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${this.suffix}`;
+    const regexpUnescapeStr = `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${
+      this.suffix
+    }`;
     this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
 
     const nestingRegexpStr = `${this.nestingPrefix}(.+?)${this.nestingSuffix}`;
@@ -64,7 +73,7 @@ class Interpolator {
       return val.replace(/\$/g, '$$$$');
     }
 
-    const handleFormat = (key) => {
+    const handleFormat = key => {
       if (key.indexOf(this.formatSeparator) < 0) return utils.getPath(data, key);
 
       const p = key.split(this.formatSeparator);
@@ -76,13 +85,13 @@ class Interpolator {
 
     this.resetRegExp();
 
-    const missingInterpolationHandler = (options && options.missingInterpolationHandler) ||
-      this.options.missingInterpolationHandler;
+    const missingInterpolationHandler =
+      (options && options.missingInterpolationHandler) || this.options.missingInterpolationHandler;
 
     replaces = 0;
     // unescape if has unescapePrefix/Suffix
     /* eslint no-cond-assign: 0 */
-    while (match = this.regexpUnescape.exec(str)) {
+    while ((match = this.regexpUnescape.exec(str))) {
       value = handleFormat(match[1].trim());
       str = str.replace(match[0], value);
       this.regexpUnescape.lastIndex = 0;
@@ -94,7 +103,7 @@ class Interpolator {
 
     replaces = 0;
     // regular escape on demand
-    while (match = this.regexp.exec(str)) {
+    while ((match = this.regexp.exec(str))) {
       value = handleFormat(match[1].trim());
       if (value === undefined) {
         if (typeof missingInterpolationHandler === 'function') {
@@ -147,7 +156,7 @@ class Interpolator {
     }
 
     // regular escape on demand
-    while (match = this.nestingRegexp.exec(str)) {
+    while ((match = this.nestingRegexp.exec(str))) {
       value = fc(handleHasOptions.call(this, match[1].trim(), clonedOptions), clonedOptions);
 
       // is only the nesting key (key1 = '$(key2)') return the value without stringify
@@ -167,6 +176,5 @@ class Interpolator {
     return str;
   }
 }
-
 
 export default Interpolator;

--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -82,10 +82,13 @@ class LanguageUtil {
   }
 
   toResolveHierarchy(code, fallbackCode) {
-    const fallbackCodes = this.getFallbackCodes(fallbackCode || this.options.fallbackLng || [], code);
+    const fallbackCodes = this.getFallbackCodes(
+      fallbackCode || this.options.fallbackLng || [],
+      code,
+    );
 
     const codes = [];
-    const addCode = (c) => {
+    const addCode = c => {
       if (!c) return;
       if (this.isWhitelisted(c)) {
         codes.push(c);
@@ -96,13 +99,14 @@ class LanguageUtil {
 
     if (typeof code === 'string' && code.indexOf('-') > -1) {
       if (this.options.load !== 'languageOnly') addCode(this.formatLanguageCode(code));
-      if (this.options.load !== 'languageOnly' && this.options.load !== 'currentOnly') addCode(this.getScriptPartFromCode(code));
+      if (this.options.load !== 'languageOnly' && this.options.load !== 'currentOnly')
+        addCode(this.getScriptPartFromCode(code));
       if (this.options.load !== 'currentOnly') addCode(this.getLanguagePartFromCode(code));
     } else if (typeof code === 'string') {
       addCode(this.formatLanguageCode(code));
     }
 
-    fallbackCodes.forEach((fc) => {
+    fallbackCodes.forEach(fc => {
       if (codes.indexOf(fc) < 0) addCode(this.formatLanguageCode(fc));
     });
 

--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -3,260 +3,74 @@ import baseLogger from './logger.js';
 // definition http://translate.sourceforge.net/wiki/l10n/pluralforms
 /* eslint-disable */
 let sets = [
-  {
-    lngs: [
-      'ach',
-      'ak',
-      'am',
-      'arn',
-      'br',
-      'fil',
-      'gun',
-      'ln',
-      'mfe',
-      'mg',
-      'mi',
-      'oc',
-      'pt',
-      'pt-BR',
-      'tg',
-      'ti',
-      'tr',
-      'uz',
-      'wa',
-    ],
-    nr: [1, 2],
-    fc: 1,
-  },
+  { lngs: ['ach','ak','am','arn','br','fil','gun','ln','mfe','mg','mi','oc', 'pt', 'pt-BR',
+    'tg','ti','tr','uz','wa'], nr: [1,2], fc: 1 },
 
-  {
-    lngs: [
-      'af',
-      'an',
-      'ast',
-      'az',
-      'bg',
-      'bn',
-      'ca',
-      'da',
-      'de',
-      'dev',
-      'el',
-      'en',
-      'eo',
-      'es',
-      'et',
-      'eu',
-      'fi',
-      'fo',
-      'fur',
-      'fy',
-      'gl',
-      'gu',
-      'ha',
-      'hi',
-      'hu',
-      'hy',
-      'ia',
-      'it',
-      'kn',
-      'ku',
-      'lb',
-      'mai',
-      'ml',
-      'mn',
-      'mr',
-      'nah',
-      'nap',
-      'nb',
-      'ne',
-      'nl',
-      'nn',
-      'no',
-      'nso',
-      'pa',
-      'pap',
-      'pms',
-      'ps',
-      'pt-PT',
-      'rm',
-      'sco',
-      'se',
-      'si',
-      'so',
-      'son',
-      'sq',
-      'sv',
-      'sw',
-      'ta',
-      'te',
-      'tk',
-      'ur',
-      'yo',
-    ],
-    nr: [1, 2],
-    fc: 2,
-  },
+  { lngs: ['af','an','ast','az','bg','bn','ca','da','de','dev','el','en',
+    'eo','es','et','eu','fi','fo','fur','fy','gl','gu','ha','hi',
+    'hu','hy','ia','it','kn','ku','lb','mai','ml','mn','mr','nah','nap','nb',
+    'ne','nl','nn','no','nso','pa','pap','pms','ps','pt-PT','rm','sco',
+    'se','si','so','son','sq','sv','sw','ta','te','tk','ur','yo'], nr: [1,2], fc: 2 },
 
-  {
-    lngs: [
-      'ay',
-      'bo',
-      'cgg',
-      'fa',
-      'id',
-      'ja',
-      'jbo',
-      'ka',
-      'kk',
-      'km',
-      'ko',
-      'ky',
-      'lo',
-      'ms',
-      'sah',
-      'su',
-      'th',
-      'tt',
-      'ug',
-      'vi',
-      'wo',
-      'zh',
-    ],
-    nr: [1],
-    fc: 3,
-  },
+  { lngs: ['ay','bo','cgg','fa','id','ja','jbo','ka','kk','km','ko','ky','lo',
+    'ms','sah','su','th','tt','ug','vi','wo','zh'], nr: [1], fc: 3 },
 
-  { lngs: ['be', 'bs', 'dz', 'hr', 'ru', 'sr', 'uk'], nr: [1, 2, 5], fc: 4 },
+  { lngs: ['be','bs','dz','hr','ru','sr','uk'], nr: [1,2,5], fc: 4 },
 
-  { lngs: ['ar'], nr: [0, 1, 2, 3, 11, 100], fc: 5 },
-  { lngs: ['cs', 'sk'], nr: [1, 2, 5], fc: 6 },
-  { lngs: ['csb', 'pl'], nr: [1, 2, 5], fc: 7 },
-  { lngs: ['cy'], nr: [1, 2, 3, 8], fc: 8 },
-  { lngs: ['fr'], nr: [1, 2], fc: 9 },
-  { lngs: ['ga'], nr: [1, 2, 3, 7, 11], fc: 10 },
-  { lngs: ['gd'], nr: [1, 2, 3, 20], fc: 11 },
-  { lngs: ['is'], nr: [1, 2], fc: 12 },
-  { lngs: ['jv'], nr: [0, 1], fc: 13 },
-  { lngs: ['kw'], nr: [1, 2, 3, 4], fc: 14 },
-  { lngs: ['lt'], nr: [1, 2, 10], fc: 15 },
-  { lngs: ['lv'], nr: [1, 2, 0], fc: 16 },
-  { lngs: ['mk'], nr: [1, 2], fc: 17 },
-  { lngs: ['mnk'], nr: [0, 1, 2], fc: 18 },
-  { lngs: ['mt'], nr: [1, 2, 11, 20], fc: 19 },
-  { lngs: ['or'], nr: [2, 1], fc: 2 },
-  { lngs: ['ro'], nr: [1, 2, 20], fc: 20 },
-  { lngs: ['sl'], nr: [5, 1, 2, 3], fc: 21 },
-  { lngs: ['he'], nr: [1, 2, 20, 21], fc: 22 },
-];
+  { lngs: ['ar'], nr: [0,1,2,3,11,100], fc: 5 },
+  { lngs: ['cs','sk'], nr: [1,2,5], fc: 6 },
+  { lngs: ['csb','pl'], nr: [1,2,5], fc: 7 },
+  { lngs: ['cy'], nr: [1,2,3,8], fc: 8 },
+  { lngs: ['fr'], nr: [1,2], fc: 9 },
+  { lngs: ['ga'], nr: [1,2,3,7,11], fc: 10 },
+  { lngs: ['gd'], nr: [1,2,3,20], fc: 11 },
+  { lngs: ['is'], nr: [1,2], fc: 12 },
+  { lngs: ['jv'], nr: [0,1], fc: 13 },
+  { lngs: ['kw'], nr: [1,2,3,4], fc: 14 },
+  { lngs: ['lt'], nr: [1,2,10], fc: 15 },
+  { lngs: ['lv'], nr: [1,2,0], fc: 16 },
+  { lngs: ['mk'], nr: [1,2], fc: 17 },
+  { lngs: ['mnk'], nr: [0,1,2], fc: 18 },
+  { lngs: ['mt'], nr: [1,2,11,20], fc: 19 },
+  { lngs: ['or'], nr: [2,1], fc: 2 },
+  { lngs: ['ro'], nr: [1,2,20], fc: 20 },
+  { lngs: ['sl'], nr: [5,1,2,3], fc: 21 },
+  { lngs: ['he'], nr: [1,2,20,21], fc: 22 }
+]
 
 let _rulesPluralsTypes = {
-  1: function(n) {
-    return Number(n > 1);
-  },
-  2: function(n) {
-    return Number(n != 1);
-  },
-  3: function(n) {
-    return 0;
-  },
-  4: function(n) {
-    return Number(
-      n % 10 == 1 && n % 100 != 11
-        ? 0
-        : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)
-        ? 1
-        : 2,
-    );
-  },
-  5: function(n) {
-    return Number(
-      n === 0
-        ? 0
-        : n == 1
-        ? 1
-        : n == 2
-        ? 2
-        : n % 100 >= 3 && n % 100 <= 10
-        ? 3
-        : n % 100 >= 11
-        ? 4
-        : 5,
-    );
-  },
-  6: function(n) {
-    return Number(n == 1 ? 0 : n >= 2 && n <= 4 ? 1 : 2);
-  },
-  7: function(n) {
-    return Number(
-      n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
-    );
-  },
-  8: function(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n != 8 && n != 11 ? 2 : 3);
-  },
-  9: function(n) {
-    return Number(n >= 2);
-  },
-  10: function(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n < 7 ? 2 : n < 11 ? 3 : 4);
-  },
-  11: function(n) {
-    return Number(n == 1 || n == 11 ? 0 : n == 2 || n == 12 ? 1 : n > 2 && n < 20 ? 2 : 3);
-  },
-  12: function(n) {
-    return Number(n % 10 != 1 || n % 100 == 11);
-  },
-  13: function(n) {
-    return Number(n !== 0);
-  },
-  14: function(n) {
-    return Number(n == 1 ? 0 : n == 2 ? 1 : n == 3 ? 2 : 3);
-  },
-  15: function(n) {
-    return Number(
-      n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
-    );
-  },
-  16: function(n) {
-    return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n !== 0 ? 1 : 2);
-  },
-  17: function(n) {
-    return Number(n == 1 || n % 10 == 1 ? 0 : 1);
-  },
-  18: function(n) {
-    return Number(n == 0 ? 0 : n == 1 ? 1 : 2);
-  },
-  19: function(n) {
-    return Number(
-      n == 1
-        ? 0
-        : n === 0 || (n % 100 > 1 && n % 100 < 11)
-        ? 1
-        : n % 100 > 10 && n % 100 < 20
-        ? 2
-        : 3,
-    );
-  },
-  20: function(n) {
-    return Number(n == 1 ? 0 : n === 0 || (n % 100 > 0 && n % 100 < 20) ? 1 : 2);
-  },
-  21: function(n) {
-    return Number(n % 100 == 1 ? 1 : n % 100 == 2 ? 2 : n % 100 == 3 || n % 100 == 4 ? 3 : 0);
-  },
-  22: function(n) {
-    return Number(n === 1 ? 0 : n === 2 ? 1 : (n < 0 || n > 10) && n % 10 == 0 ? 2 : 3);
-  },
+  1: function(n) {return Number(n > 1);},
+  2: function(n) {return Number(n != 1);},
+  3: function(n) {return 0;},
+  4: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);},
+  5: function(n) {return Number(n===0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);},
+  6: function(n) {return Number((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);},
+  7: function(n) {return Number(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);},
+  8: function(n) {return Number((n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3);},
+  9: function(n) {return Number(n >= 2);},
+  10: function(n) {return Number(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4) ;},
+  11: function(n) {return Number((n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3);},
+  12: function(n) {return Number(n%10!=1 || n%100==11);},
+  13: function(n) {return Number(n !== 0);},
+  14: function(n) {return Number((n==1) ? 0 : (n==2) ? 1 : (n == 3) ? 2 : 3);},
+  15: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);},
+  16: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n !== 0 ? 1 : 2);},
+  17: function(n) {return Number(n==1 || n%10==1 ? 0 : 1);},
+  18: function(n) {return Number(n==0 ? 0 : n==1 ? 1 : 2);},
+  19: function(n) {return Number(n==1 ? 0 : n===0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);},
+  20: function(n) {return Number(n==1 ? 0 : (n===0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);},
+  21: function(n) {return Number(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0); },
+  22: function(n) {return Number(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 2 : 3); }
 };
 /* eslint-enable */
 
 function createRules() {
   const rules = {};
-  sets.forEach(set => {
-    set.lngs.forEach(l => {
+  sets.forEach((set) => {
+    set.lngs.forEach((l) => {
       rules[l] = {
         numbers: set.nr,
-        plurals: _rulesPluralsTypes[set.fc],
+        plurals: _rulesPluralsTypes[set.fc]
       };
     });
   });
@@ -294,7 +108,7 @@ class PluralResolver {
 
     if (!rule) return ret;
 
-    rule.numbers.forEach(n => {
+    rule.numbers.forEach((n) => {
       const suffix = this.getSuffix(code, n);
       ret.push(`${key}${suffix}`);
     });
@@ -320,10 +134,9 @@ class PluralResolver {
         }
       }
 
-      const returnSuffix = () =>
-        this.options.prepend && suffix.toString()
-          ? this.options.prepend + suffix.toString()
-          : suffix.toString();
+      const returnSuffix = () => (
+        this.options.prepend && suffix.toString() ? this.options.prepend + suffix.toString() : suffix.toString()
+      );
 
       // COMPATIBILITY JSON
       // v1
@@ -333,16 +146,10 @@ class PluralResolver {
         return returnSuffix();
       } else if (/* v2 */ this.options.compatibilityJSON === 'v2') {
         return returnSuffix();
-      } else if (
-        /* v3 - gettext index */ this.options.simplifyPluralSuffix &&
-        rule.numbers.length === 2 &&
-        rule.numbers[0] === 1
-      ) {
+      } else if (/* v3 - gettext index */ this.options.simplifyPluralSuffix && rule.numbers.length === 2 && rule.numbers[0] === 1) {
         return returnSuffix();
       }
-      return this.options.prepend && idx.toString()
-        ? this.options.prepend + idx.toString()
-        : idx.toString();
+      return this.options.prepend && idx.toString() ? this.options.prepend + idx.toString() : idx.toString();
     }
 
     this.logger.warn(`no plural rule found for: ${code}`);

--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -3,74 +3,260 @@ import baseLogger from './logger.js';
 // definition http://translate.sourceforge.net/wiki/l10n/pluralforms
 /* eslint-disable */
 let sets = [
-  { lngs: ['ach','ak','am','arn','br','fil','gun','ln','mfe','mg','mi','oc', 'pt', 'pt-BR',
-    'tg','ti','tr','uz','wa'], nr: [1,2], fc: 1 },
+  {
+    lngs: [
+      'ach',
+      'ak',
+      'am',
+      'arn',
+      'br',
+      'fil',
+      'gun',
+      'ln',
+      'mfe',
+      'mg',
+      'mi',
+      'oc',
+      'pt',
+      'pt-BR',
+      'tg',
+      'ti',
+      'tr',
+      'uz',
+      'wa',
+    ],
+    nr: [1, 2],
+    fc: 1,
+  },
 
-  { lngs: ['af','an','ast','az','bg','bn','ca','da','de','dev','el','en',
-    'eo','es','et','eu','fi','fo','fur','fy','gl','gu','ha','hi',
-    'hu','hy','ia','it','kn','ku','lb','mai','ml','mn','mr','nah','nap','nb',
-    'ne','nl','nn','no','nso','pa','pap','pms','ps','pt-PT','rm','sco',
-    'se','si','so','son','sq','sv','sw','ta','te','tk','ur','yo'], nr: [1,2], fc: 2 },
+  {
+    lngs: [
+      'af',
+      'an',
+      'ast',
+      'az',
+      'bg',
+      'bn',
+      'ca',
+      'da',
+      'de',
+      'dev',
+      'el',
+      'en',
+      'eo',
+      'es',
+      'et',
+      'eu',
+      'fi',
+      'fo',
+      'fur',
+      'fy',
+      'gl',
+      'gu',
+      'ha',
+      'hi',
+      'hu',
+      'hy',
+      'ia',
+      'it',
+      'kn',
+      'ku',
+      'lb',
+      'mai',
+      'ml',
+      'mn',
+      'mr',
+      'nah',
+      'nap',
+      'nb',
+      'ne',
+      'nl',
+      'nn',
+      'no',
+      'nso',
+      'pa',
+      'pap',
+      'pms',
+      'ps',
+      'pt-PT',
+      'rm',
+      'sco',
+      'se',
+      'si',
+      'so',
+      'son',
+      'sq',
+      'sv',
+      'sw',
+      'ta',
+      'te',
+      'tk',
+      'ur',
+      'yo',
+    ],
+    nr: [1, 2],
+    fc: 2,
+  },
 
-  { lngs: ['ay','bo','cgg','fa','id','ja','jbo','ka','kk','km','ko','ky','lo',
-    'ms','sah','su','th','tt','ug','vi','wo','zh'], nr: [1], fc: 3 },
+  {
+    lngs: [
+      'ay',
+      'bo',
+      'cgg',
+      'fa',
+      'id',
+      'ja',
+      'jbo',
+      'ka',
+      'kk',
+      'km',
+      'ko',
+      'ky',
+      'lo',
+      'ms',
+      'sah',
+      'su',
+      'th',
+      'tt',
+      'ug',
+      'vi',
+      'wo',
+      'zh',
+    ],
+    nr: [1],
+    fc: 3,
+  },
 
-  { lngs: ['be','bs','dz','hr','ru','sr','uk'], nr: [1,2,5], fc: 4 },
+  { lngs: ['be', 'bs', 'dz', 'hr', 'ru', 'sr', 'uk'], nr: [1, 2, 5], fc: 4 },
 
-  { lngs: ['ar'], nr: [0,1,2,3,11,100], fc: 5 },
-  { lngs: ['cs','sk'], nr: [1,2,5], fc: 6 },
-  { lngs: ['csb','pl'], nr: [1,2,5], fc: 7 },
-  { lngs: ['cy'], nr: [1,2,3,8], fc: 8 },
-  { lngs: ['fr'], nr: [1,2], fc: 9 },
-  { lngs: ['ga'], nr: [1,2,3,7,11], fc: 10 },
-  { lngs: ['gd'], nr: [1,2,3,20], fc: 11 },
-  { lngs: ['is'], nr: [1,2], fc: 12 },
-  { lngs: ['jv'], nr: [0,1], fc: 13 },
-  { lngs: ['kw'], nr: [1,2,3,4], fc: 14 },
-  { lngs: ['lt'], nr: [1,2,10], fc: 15 },
-  { lngs: ['lv'], nr: [1,2,0], fc: 16 },
-  { lngs: ['mk'], nr: [1,2], fc: 17 },
-  { lngs: ['mnk'], nr: [0,1,2], fc: 18 },
-  { lngs: ['mt'], nr: [1,2,11,20], fc: 19 },
-  { lngs: ['or'], nr: [2,1], fc: 2 },
-  { lngs: ['ro'], nr: [1,2,20], fc: 20 },
-  { lngs: ['sl'], nr: [5,1,2,3], fc: 21 },
-  { lngs: ['he'], nr: [1,2,20,21], fc: 22 }
-]
+  { lngs: ['ar'], nr: [0, 1, 2, 3, 11, 100], fc: 5 },
+  { lngs: ['cs', 'sk'], nr: [1, 2, 5], fc: 6 },
+  { lngs: ['csb', 'pl'], nr: [1, 2, 5], fc: 7 },
+  { lngs: ['cy'], nr: [1, 2, 3, 8], fc: 8 },
+  { lngs: ['fr'], nr: [1, 2], fc: 9 },
+  { lngs: ['ga'], nr: [1, 2, 3, 7, 11], fc: 10 },
+  { lngs: ['gd'], nr: [1, 2, 3, 20], fc: 11 },
+  { lngs: ['is'], nr: [1, 2], fc: 12 },
+  { lngs: ['jv'], nr: [0, 1], fc: 13 },
+  { lngs: ['kw'], nr: [1, 2, 3, 4], fc: 14 },
+  { lngs: ['lt'], nr: [1, 2, 10], fc: 15 },
+  { lngs: ['lv'], nr: [1, 2, 0], fc: 16 },
+  { lngs: ['mk'], nr: [1, 2], fc: 17 },
+  { lngs: ['mnk'], nr: [0, 1, 2], fc: 18 },
+  { lngs: ['mt'], nr: [1, 2, 11, 20], fc: 19 },
+  { lngs: ['or'], nr: [2, 1], fc: 2 },
+  { lngs: ['ro'], nr: [1, 2, 20], fc: 20 },
+  { lngs: ['sl'], nr: [5, 1, 2, 3], fc: 21 },
+  { lngs: ['he'], nr: [1, 2, 20, 21], fc: 22 },
+];
 
 let _rulesPluralsTypes = {
-  1: function(n) {return Number(n > 1);},
-  2: function(n) {return Number(n != 1);},
-  3: function(n) {return 0;},
-  4: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);},
-  5: function(n) {return Number(n===0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);},
-  6: function(n) {return Number((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);},
-  7: function(n) {return Number(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);},
-  8: function(n) {return Number((n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3);},
-  9: function(n) {return Number(n >= 2);},
-  10: function(n) {return Number(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4) ;},
-  11: function(n) {return Number((n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3);},
-  12: function(n) {return Number(n%10!=1 || n%100==11);},
-  13: function(n) {return Number(n !== 0);},
-  14: function(n) {return Number((n==1) ? 0 : (n==2) ? 1 : (n == 3) ? 2 : 3);},
-  15: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);},
-  16: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n !== 0 ? 1 : 2);},
-  17: function(n) {return Number(n==1 || n%10==1 ? 0 : 1);},
-  18: function(n) {return Number(n==0 ? 0 : n==1 ? 1 : 2);},
-  19: function(n) {return Number(n==1 ? 0 : n===0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);},
-  20: function(n) {return Number(n==1 ? 0 : (n===0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);},
-  21: function(n) {return Number(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0); },
-  22: function(n) {return Number(n===1 ? 0 : n===2 ? 1 : (n<0 || n>10) && n%10==0 ? 2 : 3); }
+  1: function(n) {
+    return Number(n > 1);
+  },
+  2: function(n) {
+    return Number(n != 1);
+  },
+  3: function(n) {
+    return 0;
+  },
+  4: function(n) {
+    return Number(
+      n % 10 == 1 && n % 100 != 11
+        ? 0
+        : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)
+        ? 1
+        : 2,
+    );
+  },
+  5: function(n) {
+    return Number(
+      n === 0
+        ? 0
+        : n == 1
+        ? 1
+        : n == 2
+        ? 2
+        : n % 100 >= 3 && n % 100 <= 10
+        ? 3
+        : n % 100 >= 11
+        ? 4
+        : 5,
+    );
+  },
+  6: function(n) {
+    return Number(n == 1 ? 0 : n >= 2 && n <= 4 ? 1 : 2);
+  },
+  7: function(n) {
+    return Number(
+      n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
+    );
+  },
+  8: function(n) {
+    return Number(n == 1 ? 0 : n == 2 ? 1 : n != 8 && n != 11 ? 2 : 3);
+  },
+  9: function(n) {
+    return Number(n >= 2);
+  },
+  10: function(n) {
+    return Number(n == 1 ? 0 : n == 2 ? 1 : n < 7 ? 2 : n < 11 ? 3 : 4);
+  },
+  11: function(n) {
+    return Number(n == 1 || n == 11 ? 0 : n == 2 || n == 12 ? 1 : n > 2 && n < 20 ? 2 : 3);
+  },
+  12: function(n) {
+    return Number(n % 10 != 1 || n % 100 == 11);
+  },
+  13: function(n) {
+    return Number(n !== 0);
+  },
+  14: function(n) {
+    return Number(n == 1 ? 0 : n == 2 ? 1 : n == 3 ? 2 : 3);
+  },
+  15: function(n) {
+    return Number(
+      n % 10 == 1 && n % 100 != 11 ? 0 : n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2,
+    );
+  },
+  16: function(n) {
+    return Number(n % 10 == 1 && n % 100 != 11 ? 0 : n !== 0 ? 1 : 2);
+  },
+  17: function(n) {
+    return Number(n == 1 || n % 10 == 1 ? 0 : 1);
+  },
+  18: function(n) {
+    return Number(n == 0 ? 0 : n == 1 ? 1 : 2);
+  },
+  19: function(n) {
+    return Number(
+      n == 1
+        ? 0
+        : n === 0 || (n % 100 > 1 && n % 100 < 11)
+        ? 1
+        : n % 100 > 10 && n % 100 < 20
+        ? 2
+        : 3,
+    );
+  },
+  20: function(n) {
+    return Number(n == 1 ? 0 : n === 0 || (n % 100 > 0 && n % 100 < 20) ? 1 : 2);
+  },
+  21: function(n) {
+    return Number(n % 100 == 1 ? 1 : n % 100 == 2 ? 2 : n % 100 == 3 || n % 100 == 4 ? 3 : 0);
+  },
+  22: function(n) {
+    return Number(n === 1 ? 0 : n === 2 ? 1 : (n < 0 || n > 10) && n % 10 == 0 ? 2 : 3);
+  },
 };
 /* eslint-enable */
 
 function createRules() {
   const rules = {};
-  sets.forEach((set) => {
-    set.lngs.forEach((l) => {
+  sets.forEach(set => {
+    set.lngs.forEach(l => {
       rules[l] = {
         numbers: set.nr,
-        plurals: _rulesPluralsTypes[set.fc]
+        plurals: _rulesPluralsTypes[set.fc],
       };
     });
   });
@@ -108,7 +294,7 @@ class PluralResolver {
 
     if (!rule) return ret;
 
-    rule.numbers.forEach((n) => {
+    rule.numbers.forEach(n => {
       const suffix = this.getSuffix(code, n);
       ret.push(`${key}${suffix}`);
     });
@@ -134,9 +320,10 @@ class PluralResolver {
         }
       }
 
-      const returnSuffix = () => (
-        this.options.prepend && suffix.toString() ? this.options.prepend + suffix.toString() : suffix.toString()
-      );
+      const returnSuffix = () =>
+        this.options.prepend && suffix.toString()
+          ? this.options.prepend + suffix.toString()
+          : suffix.toString();
 
       // COMPATIBILITY JSON
       // v1
@@ -146,10 +333,16 @@ class PluralResolver {
         return returnSuffix();
       } else if (/* v2 */ this.options.compatibilityJSON === 'v2') {
         return returnSuffix();
-      } else if (/* v3 - gettext index */ this.options.simplifyPluralSuffix && rule.numbers.length === 2 && rule.numbers[0] === 1) {
+      } else if (
+        /* v3 - gettext index */ this.options.simplifyPluralSuffix &&
+        rule.numbers.length === 2 &&
+        rule.numbers[0] === 1
+      ) {
         return returnSuffix();
       }
-      return this.options.prepend && idx.toString() ? this.options.prepend + idx.toString() : idx.toString();
+      return this.options.prepend && idx.toString()
+        ? this.options.prepend + idx.toString()
+        : idx.toString();
     }
 
     this.logger.warn(`no plural rule found for: ${code}`);

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -25,11 +25,13 @@ class ResourceStore extends EventEmitter {
   }
 
   getResource(lng, ns, key, options = {}) {
-    const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+    const keySeparator =
+      options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
 
     let path = [lng, ns];
     if (key && typeof key !== 'string') path = path.concat(key);
-    if (key && typeof key === 'string') path = path.concat(keySeparator ? key.split(keySeparator) : key);
+    if (key && typeof key === 'string')
+      path = path.concat(keySeparator ? key.split(keySeparator) : key);
 
     if (lng.indexOf('.') > -1) {
       path = lng.split('.');
@@ -61,7 +63,8 @@ class ResourceStore extends EventEmitter {
   addResources(lng, ns, resources, options = { silent: false }) {
     /* eslint no-restricted-syntax: 0 */
     for (const m in resources) {
-      if (typeof resources[m] === 'string') this.addResource(lng, ns, m, resources[m], { silent: true });
+      if (typeof resources[m] === 'string')
+        this.addResource(lng, ns, m, resources[m], { silent: true });
     }
     if (!options.silent) this.emit('added', lng, ns, resources);
   }

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -7,7 +7,18 @@ class Translator extends EventEmitter {
   constructor(services, options = {}) {
     super();
 
-    utils.copy(['resourceStore', 'languageUtils', 'pluralResolver', 'interpolator', 'backendConnector', 'i18nFormat'], services, this);
+    utils.copy(
+      [
+        'resourceStore',
+        'languageUtils',
+        'pluralResolver',
+        'interpolator',
+        'backendConnector',
+        'i18nFormat',
+      ],
+      services,
+      this,
+    );
 
     this.options = options;
     if (this.options.keySeparator === undefined) {
@@ -30,19 +41,24 @@ class Translator extends EventEmitter {
     let nsSeparator = options.nsSeparator || this.options.nsSeparator;
     if (nsSeparator === undefined) nsSeparator = ':';
 
-    const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+    const keySeparator =
+      options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
 
     let namespaces = options.ns || this.options.defaultNS;
     if (nsSeparator && key.indexOf(nsSeparator) > -1) {
       const parts = key.split(nsSeparator);
-      if (nsSeparator !== keySeparator || (nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1)) namespaces = parts.shift();
+      if (
+        nsSeparator !== keySeparator ||
+        (nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1)
+      )
+        namespaces = parts.shift();
       key = parts.join(keySeparator);
     }
     if (typeof namespaces === 'string') namespaces = [namespaces];
 
     return {
       key,
-      namespaces
+      namespaces,
     };
   }
 
@@ -58,7 +74,8 @@ class Translator extends EventEmitter {
     if (!Array.isArray(keys)) keys = [String(keys)];
 
     // separators
-    const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
+    const keySeparator =
+      options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
 
     // get namespace(s)
     const { key, namespaces } = this.extractFromKey(keys[keys.length - 1], options);
@@ -66,7 +83,8 @@ class Translator extends EventEmitter {
 
     // return key on CIMode
     const lng = options.lng || this.language;
-    const appendNamespaceToCIMode = options.appendNamespaceToCIMode || this.options.appendNamespaceToCIMode;
+    const appendNamespaceToCIMode =
+      options.appendNamespaceToCIMode || this.options.appendNamespaceToCIMode;
     if (lng && lng.toLowerCase() === 'cimode') {
       if (appendNamespaceToCIMode) {
         const nsSeparator = options.nsSeparator || this.options.nsSeparator;
@@ -83,27 +101,40 @@ class Translator extends EventEmitter {
 
     const resType = Object.prototype.toString.apply(res);
     const noObject = ['[object Number]', '[object Function]', '[object RegExp]'];
-    const joinArrays = options.joinArrays !== undefined ? options.joinArrays : this.options.joinArrays;
+    const joinArrays =
+      options.joinArrays !== undefined ? options.joinArrays : this.options.joinArrays;
 
     // object
     const handleAsObjectInI18nFormat = !this.i18nFormat || this.i18nFormat.handleAsObject;
-    const handleAsObject = typeof res !== 'string' && typeof res !== 'boolean' && typeof res !== 'number';
-    if (handleAsObjectInI18nFormat && res && handleAsObject && noObject.indexOf(resType) < 0 && !(joinArrays && resType === '[object Array]')) {
+    const handleAsObject =
+      typeof res !== 'string' && typeof res !== 'boolean' && typeof res !== 'number';
+    if (
+      handleAsObjectInI18nFormat &&
+      res &&
+      handleAsObject &&
+      noObject.indexOf(resType) < 0 &&
+      !(joinArrays && resType === '[object Array]')
+    ) {
       if (!options.returnObjects && !this.options.returnObjects) {
         this.logger.warn('accessing an object - but returnObjects options is not enabled!');
-        return this.options.returnedObjectHandler ? this.options.returnedObjectHandler(resUsedKey, res, options) : `key '${key} (${this.language})' returned an object instead of string.`;
+        return this.options.returnedObjectHandler
+          ? this.options.returnedObjectHandler(resUsedKey, res, options)
+          : `key '${key} (${this.language})' returned an object instead of string.`;
       }
 
       // if we got a separator we loop over children - else we just return object as is
       // as having it set to false means no hierarchy so no lookup for nested values
       if (keySeparator) {
-        const copy = (resType === '[object Array]') ? [] : {}; // apply child translation on a copy
+        const copy = resType === '[object Array]' ? [] : {}; // apply child translation on a copy
 
         /* eslint no-restricted-syntax: 0 */
         for (const m in res) {
           if (Object.prototype.hasOwnProperty.call(res, m)) {
             const deepKey = `${resUsedKey}${keySeparator}${m}`;
-            copy[m] = this.translate(deepKey, { ...options, ...{ joinArrays: false, ns: namespaces } });
+            copy[m] = this.translate(deepKey, {
+              ...options,
+              ...{ joinArrays: false, ns: namespaces },
+            });
             if (copy[m] === deepKey) copy[m] = res[m]; // if nothing found use orginal value as fallback
           }
         }
@@ -134,12 +165,22 @@ class Translator extends EventEmitter {
       }
 
       // save missing
-      const updateMissing = options.defaultValue && options.defaultValue !== res && this.options.updateMissing;
+      const updateMissing =
+        options.defaultValue && options.defaultValue !== res && this.options.updateMissing;
       if (usedKey || usedDefault || updateMissing) {
-        this.logger.log(updateMissing ? 'updateKey' : 'missingKey', lng, namespace, key, updateMissing ? options.defaultValue : res);
+        this.logger.log(
+          updateMissing ? 'updateKey' : 'missingKey',
+          lng,
+          namespace,
+          key,
+          updateMissing ? options.defaultValue : res,
+        );
 
         let lngs = [];
-        const fallbackLngs = this.languageUtils.getFallbackCodes(this.options.fallbackLng, options.lng || this.language);
+        const fallbackLngs = this.languageUtils.getFallbackCodes(
+          this.options.fallbackLng,
+          options.lng || this.language,
+        );
         if (this.options.saveMissingTo === 'fallback' && fallbackLngs && fallbackLngs[0]) {
           for (let i = 0; i < fallbackLngs.length; i++) {
             lngs.push(fallbackLngs[i]);
@@ -152,17 +193,32 @@ class Translator extends EventEmitter {
 
         const send = (l, k) => {
           if (this.options.missingKeyHandler) {
-            this.options.missingKeyHandler(l, namespace, k, updateMissing ? options.defaultValue : res, updateMissing, options);
+            this.options.missingKeyHandler(
+              l,
+              namespace,
+              k,
+              updateMissing ? options.defaultValue : res,
+              updateMissing,
+              options,
+            );
           } else if (this.backendConnector && this.backendConnector.saveMissing) {
-            this.backendConnector.saveMissing(l, namespace, k, updateMissing ? options.defaultValue : res, updateMissing, options);
+            this.backendConnector.saveMissing(
+              l,
+              namespace,
+              k,
+              updateMissing ? options.defaultValue : res,
+              updateMissing,
+              options,
+            );
           }
           this.emit('missingKey', l, namespace, k, res);
         };
 
         if (this.options.saveMissing) {
-          const needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
+          const needsPluralHandling =
+            options.count !== undefined && typeof options.count !== 'string';
           if (this.options.saveMissingPlurals && needsPluralHandling) {
-            lngs.forEach((l) => {
+            lngs.forEach(l => {
               const plurals = this.pluralResolver.getPluralFormsOfKey(l, key);
 
               plurals.forEach(p => send([l], p));
@@ -177,10 +233,12 @@ class Translator extends EventEmitter {
       res = this.extendTranslation(res, keys, options, resolved);
 
       // append namespace if still key
-      if (usedKey && res === key && this.options.appendNamespaceToMissingKey) res = `${namespace}:${key}`;
+      if (usedKey && res === key && this.options.appendNamespaceToMissingKey)
+        res = `${namespace}:${key}`;
 
       // parseMissingKeyHandler
-      if (usedKey && this.options.parseMissingKeyHandler) res = this.options.parseMissingKeyHandler(res);
+      if (usedKey && this.options.parseMissingKeyHandler)
+        res = this.options.parseMissingKeyHandler(res);
     }
 
     // return
@@ -189,17 +247,31 @@ class Translator extends EventEmitter {
 
   extendTranslation(res, key, options, resolved) {
     if (this.i18nFormat && this.i18nFormat.parse) {
-      res = this.i18nFormat.parse(res, options, resolved.usedLng, resolved.usedNS, resolved.usedKey, { resolved });
-    } else if (!options.skipInterpolation) { // i18next.parsing
-      if (options.interpolation) this.interpolator.init({ ...options, ...{ interpolation: { ...this.options.interpolation, ...options.interpolation } } });
+      res = this.i18nFormat.parse(
+        res,
+        options,
+        resolved.usedLng,
+        resolved.usedNS,
+        resolved.usedKey,
+        { resolved },
+      );
+    } else if (!options.skipInterpolation) {
+      // i18next.parsing
+      if (options.interpolation)
+        this.interpolator.init({
+          ...options,
+          ...{ interpolation: { ...this.options.interpolation, ...options.interpolation } },
+        });
 
       // interpolate
       let data = options.replace && typeof options.replace !== 'string' ? options.replace : options;
-      if (this.options.interpolation.defaultVariables) data = { ...this.options.interpolation.defaultVariables, ...data };
+      if (this.options.interpolation.defaultVariables)
+        data = { ...this.options.interpolation.defaultVariables, ...data };
       res = this.interpolator.interpolate(res, data, options.lng || this.language, options);
 
       // nesting
-      if (options.nest !== false) res = this.interpolator.nest(res, (...args) => this.translate(...args), options);
+      if (options.nest !== false)
+        res = this.interpolator.nest(res, (...args) => this.translate(...args), options);
 
       if (options.interpolation) this.interpolator.reset();
     }
@@ -208,11 +280,13 @@ class Translator extends EventEmitter {
     const postProcess = options.postProcess || this.options.postProcess;
     const postProcessorNames = typeof postProcess === 'string' ? [postProcess] : postProcess;
 
-    if (res !== undefined &&
+    if (
+      res !== undefined &&
       res !== null &&
       postProcessorNames &&
       postProcessorNames.length &&
-      options.applyPostProcessor !== false) {
+      options.applyPostProcessor !== false
+    ) {
       res = postProcessor.handle(postProcessorNames, res, key, options, this);
     }
 
@@ -228,7 +302,7 @@ class Translator extends EventEmitter {
     if (typeof keys === 'string') keys = [keys];
 
     // forEach possible key
-    keys.forEach((k) => {
+    keys.forEach(k => {
       if (this.isValidLookup(found)) return;
       const extracted = this.extractFromKey(k, options);
       const key = extracted.key;
@@ -237,15 +311,20 @@ class Translator extends EventEmitter {
       if (this.options.fallbackNS) namespaces = namespaces.concat(this.options.fallbackNS);
 
       const needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
-      const needsContextHandling = options.context !== undefined && typeof options.context === 'string' && options.context !== '';
+      const needsContextHandling =
+        options.context !== undefined &&
+        typeof options.context === 'string' &&
+        options.context !== '';
 
-      const codes = options.lngs ? options.lngs : this.languageUtils.toResolveHierarchy(options.lng || this.language, options.fallbackLng);
+      const codes = options.lngs
+        ? options.lngs
+        : this.languageUtils.toResolveHierarchy(options.lng || this.language, options.fallbackLng);
 
-      namespaces.forEach((ns) => {
+      namespaces.forEach(ns => {
         if (this.isValidLookup(found)) return;
         usedNS = ns;
 
-        codes.forEach((code) => {
+        codes.forEach(code => {
           if (this.isValidLookup(found)) return;
           usedLng = code;
 
@@ -256,22 +335,25 @@ class Translator extends EventEmitter {
             this.i18nFormat.addLookupKeys(finalKeys, key, code, ns, options);
           } else {
             let pluralSuffix;
-            if (needsPluralHandling) pluralSuffix = this.pluralResolver.getSuffix(code, options.count);
+            if (needsPluralHandling)
+              pluralSuffix = this.pluralResolver.getSuffix(code, options.count);
 
             // fallback for plural if context not found
-            if (needsPluralHandling && needsContextHandling) finalKeys.push(finalKey + pluralSuffix);
+            if (needsPluralHandling && needsContextHandling)
+              finalKeys.push(finalKey + pluralSuffix);
 
             // get key for context if needed
-            if (needsContextHandling) finalKeys.push(finalKey += `${this.options.contextSeparator}${options.context}`);
+            if (needsContextHandling)
+              finalKeys.push((finalKey += `${this.options.contextSeparator}${options.context}`));
 
             // get key for plural if needed
-            if (needsPluralHandling) finalKeys.push(finalKey += pluralSuffix);
+            if (needsPluralHandling) finalKeys.push((finalKey += pluralSuffix));
           }
 
           // iterate over finalKeys starting with most specific pluralkey (-> contextkey only) -> singularkey only
           let possibleKey;
           /* eslint no-cond-assign: 0 */
-          while (possibleKey = finalKeys.pop()) {
+          while ((possibleKey = finalKeys.pop())) {
             if (!this.isValidLookup(found)) {
               found = this.getResource(code, ns, possibleKey, options);
             }
@@ -284,13 +366,16 @@ class Translator extends EventEmitter {
   }
 
   isValidLookup(res) {
-    return res !== undefined &&
+    return (
+      res !== undefined &&
       !(!this.options.returnNull && res === null) &&
-      !(!this.options.returnEmptyString && res === '');
+      !(!this.options.returnEmptyString && res === '')
+    );
   }
 
   getResource(code, ns, key, options = {}) {
-    if (this.i18nFormat && this.i18nFormat.getResource) return this.i18nFormat.getResource(code, ns, key, options);
+    if (this.i18nFormat && this.i18nFormat.getResource)
+      return this.i18nFormat.getResource(code, ns, key, options);
     return this.resourceStore.getResource(code, ns, key, options);
   }
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -65,8 +65,8 @@ export function get() {
       // nestingPrefixEscaped: '$t(',
       // nestingSuffixEscaped: ')',
       // defaultVariables: undefined // object that can have values to interpolate on - extends passed in interpolation data
-      maxReplaces: 1000 // max replaces to prevent endless loop
-    }
+      maxReplaces: 1000, // max replaces to prevent endless loop
+    },
   };
 }
 

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -63,10 +63,19 @@ class I18n extends EventEmitter {
       s.logger = baseLogger;
       s.resourceStore = this.store;
       s.languageUtils = lu;
-      s.pluralResolver = new PluralResolver(lu, { prepend: this.options.pluralSeparator, compatibilityJSON: this.options.compatibilityJSON, simplifyPluralSuffix: this.options.simplifyPluralSuffix });
+      s.pluralResolver = new PluralResolver(lu, {
+        prepend: this.options.pluralSeparator,
+        compatibilityJSON: this.options.compatibilityJSON,
+        simplifyPluralSuffix: this.options.simplifyPluralSuffix,
+      });
       s.interpolator = new Interpolator(this.options);
 
-      s.backendConnector = new BackendConnector(createClassOnDemand(this.modules.backend), s.resourceStore, s, this.options);
+      s.backendConnector = new BackendConnector(
+        createClassOnDemand(this.modules.backend),
+        s.resourceStore,
+        s,
+        this.options,
+      );
       // pipe events from backendConnector
       s.backendConnector.on('*', (event, ...args) => {
         this.emit(event, ...args);
@@ -88,14 +97,23 @@ class I18n extends EventEmitter {
         this.emit(event, ...args);
       });
 
-      this.modules.external.forEach((m) => {
+      this.modules.external.forEach(m => {
         if (m.init) m.init(this);
       });
     }
 
     // append api
-    const storeApi = ['getResource', 'addResource', 'addResources', 'addResourceBundle', 'removeResourceBundle', 'hasResourceBundle', 'getResourceBundle', 'getDataByLanguage'];
-    storeApi.forEach((fcName) => {
+    const storeApi = [
+      'getResource',
+      'addResource',
+      'addResources',
+      'addResourceBundle',
+      'removeResourceBundle',
+      'hasResourceBundle',
+      'getResourceBundle',
+      'getDataByLanguage',
+    ];
+    storeApi.forEach(fcName => {
       this[fcName] = (...args) => this.store[fcName](...args);
     });
 
@@ -128,10 +146,10 @@ class I18n extends EventEmitter {
 
       const toLoad = [];
 
-      const append = (lng) => {
+      const append = lng => {
         if (!lng) return;
         const lngs = this.services.languageUtils.toResolveHierarchy(lng);
-        lngs.forEach((l) => {
+        lngs.forEach(l => {
           if (toLoad.indexOf(l) < 0) toLoad.push(l);
         });
       };
@@ -209,7 +227,7 @@ class I18n extends EventEmitter {
       if (callback) callback(err, (...args) => this.t(...args));
     };
 
-    const setLng = (l) => {
+    const setLng = l => {
       if (l) {
         this.language = l;
         this.languages = this.services.languageUtils.toResolveHierarchy(l);
@@ -218,7 +236,7 @@ class I18n extends EventEmitter {
         if (this.services.languageDetector) this.services.languageDetector.cacheUserLanguage(l);
       }
 
-      this.loadResources((err) => {
+      this.loadResources(err => {
         done(err, l);
       });
     };
@@ -276,11 +294,11 @@ class I18n extends EventEmitter {
     }
     if (typeof ns === 'string') ns = [ns];
 
-    ns.forEach((n) => {
+    ns.forEach(n => {
       if (this.options.ns.indexOf(n) < 0) this.options.ns.push(n);
     });
 
-    this.loadResources((err) => {
+    this.loadResources(err => {
       deferred.resolve();
       if (callback) callback(err);
     });
@@ -302,7 +320,7 @@ class I18n extends EventEmitter {
     }
 
     this.options.preload = preloaded.concat(newLngs);
-    this.loadResources((err) => {
+    this.loadResources(err => {
       deferred.resolve();
       if (callback) callback(err);
     });
@@ -314,14 +332,72 @@ class I18n extends EventEmitter {
     if (!lng) lng = this.languages && this.languages.length > 0 ? this.languages[0] : this.language;
     if (!lng) return 'rtl';
 
-    const rtlLngs = ['ar', 'shu', 'sqr', 'ssh', 'xaa', 'yhd', 'yud', 'aao', 'abh', 'abv', 'acm',
-      'acq', 'acw', 'acx', 'acy', 'adf', 'ads', 'aeb', 'aec', 'afb', 'ajp', 'apc', 'apd', 'arb',
-      'arq', 'ars', 'ary', 'arz', 'auz', 'avl', 'ayh', 'ayl', 'ayn', 'ayp', 'bbz', 'pga', 'he',
-      'iw', 'ps', 'pbt', 'pbu', 'pst', 'prp', 'prd', 'ur', 'ydd', 'yds', 'yih', 'ji', 'yi', 'hbo',
-      'men', 'xmn', 'fa', 'jpr', 'peo', 'pes', 'prs', 'dv', 'sam'
+    const rtlLngs = [
+      'ar',
+      'shu',
+      'sqr',
+      'ssh',
+      'xaa',
+      'yhd',
+      'yud',
+      'aao',
+      'abh',
+      'abv',
+      'acm',
+      'acq',
+      'acw',
+      'acx',
+      'acy',
+      'adf',
+      'ads',
+      'aeb',
+      'aec',
+      'afb',
+      'ajp',
+      'apc',
+      'apd',
+      'arb',
+      'arq',
+      'ars',
+      'ary',
+      'arz',
+      'auz',
+      'avl',
+      'ayh',
+      'ayl',
+      'ayn',
+      'ayp',
+      'bbz',
+      'pga',
+      'he',
+      'iw',
+      'ps',
+      'pbt',
+      'pbu',
+      'pst',
+      'prp',
+      'prd',
+      'ur',
+      'ydd',
+      'yds',
+      'yih',
+      'ji',
+      'yi',
+      'hbo',
+      'men',
+      'xmn',
+      'fa',
+      'jpr',
+      'peo',
+      'pes',
+      'prs',
+      'dv',
+      'sam',
     ];
 
-    return rtlLngs.indexOf(this.services.languageUtils.getLanguagePartFromCode(lng)) >= 0 ? 'rtl' : 'ltr';
+    return rtlLngs.indexOf(this.services.languageUtils.getLanguagePartFromCode(lng)) >= 0
+      ? 'rtl'
+      : 'ltr';
   }
 
   /* eslint class-methods-use-this: 0 */
@@ -333,7 +409,7 @@ class I18n extends EventEmitter {
     const mergedOptions = { ...this.options, ...options, ...{ isClone: true } };
     const clone = new I18n(mergedOptions);
     const membersToCopy = ['store', 'services', 'language'];
-    membersToCopy.forEach((m) => {
+    membersToCopy.forEach(m => {
       clone[m] = this[m];
     });
     clone.translator = new Translator(clone.services, clone.options);

--- a/src/logger.js
+++ b/src/logger.js
@@ -16,9 +16,8 @@ const consoleLogger = {
   output(type, args) {
     /* eslint no-console: 0 */
     if (console && console[type]) console[type](...args);
-  }
+  },
 };
-
 
 class Logger {
   constructor(concreteLogger, options = {}) {
@@ -59,7 +58,10 @@ class Logger {
   }
 
   create(moduleName) {
-    return new Logger(this.logger, { ...{ prefix: `${this.prefix}:${moduleName}:` }, ...this.options });
+    return new Logger(this.logger, {
+      ...{ prefix: `${this.prefix}:${moduleName}:` },
+      ...this.options,
+    });
   }
 }
 

--- a/src/postProcessor.js
+++ b/src/postProcessor.js
@@ -1,5 +1,4 @@
 export default {
-
   processors: {},
 
   addPostProcessor(module) {
@@ -7,11 +6,11 @@ export default {
   },
 
   handle(processors, value, key, options, translator) {
-    processors.forEach((processor) => {
-      if (this.processors[processor]) value = this.processors[processor].process(value, key, options, translator);
+    processors.forEach(processor => {
+      if (this.processors[processor])
+        value = this.processors[processor].process(value, key, options, translator);
     });
 
     return value;
-  }
-
+  },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,21 +21,21 @@ export function makeString(object) {
 }
 
 export function copy(a, s, t) {
-  a.forEach((m) => {
+  a.forEach(m => {
     if (s[m]) t[m] = s[m];
   });
 }
 
 function getLastOfPath(object, path, Empty) {
   function cleanKey(key) {
-    return (key && key.indexOf('###') > -1) ? key.replace(/###/g, '.') : key;
+    return key && key.indexOf('###') > -1 ? key.replace(/###/g, '.') : key;
   }
 
   function canNotTraverseDeeper() {
     return !object || typeof object === 'string';
   }
 
-  const stack = (typeof path !== 'string') ? [].concat(path) : path.split('.');
+  const stack = typeof path !== 'string' ? [].concat(path) : path.split('.');
   while (stack.length > 1) {
     if (canNotTraverseDeeper()) return {};
 
@@ -47,7 +47,7 @@ function getLastOfPath(object, path, Empty) {
   if (canNotTraverseDeeper()) return {};
   return {
     obj: object,
-    k: cleanKey(stack.shift())
+    k: cleanKey(stack.shift()),
   };
 }
 
@@ -77,7 +77,12 @@ export function deepExtend(target, source, overwrite) {
   for (const prop in source) {
     if (prop in target) {
       // If we reached a leaf string in target or source then replace with source or skip depending on the 'overwrite' switch
-      if (typeof target[prop] === 'string' || target[prop] instanceof String || typeof source[prop] === 'string' || source[prop] instanceof String) {
+      if (
+        typeof target[prop] === 'string' ||
+        target[prop] instanceof String ||
+        typeof source[prop] === 'string' ||
+        source[prop] instanceof String
+      ) {
         if (overwrite) target[prop] = source[prop];
       } else {
         deepExtend(target[prop], source[prop], overwrite);
@@ -96,12 +101,12 @@ export function regexEscape(str) {
 
 /* eslint-disable */
 var _entityMap = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
   '"': '&quot;',
   "'": '&#39;',
-  "/": '&#x2F;'
+  '/': '&#x2F;',
 };
 /* eslint-enable */
 

--- a/test/backend/backendConnector.load.retry.spec.js
+++ b/test/backend/backendConnector.load.retry.spec.js
@@ -7,18 +7,26 @@ describe('BackendConnector load retry', () => {
   let connector;
 
   before(() => {
-    connector = new BackendConnector(new BackendMock(), new ResourceStore(), {
-      interpolator: new Interpolator()
-    }, {
-      backend: { loadPath: 'http://localhost:9876/locales/{{lng}}/{{ns}}.json' }
-    });
+    connector = new BackendConnector(
+      new BackendMock(),
+      new ResourceStore(),
+      {
+        interpolator: new Interpolator(),
+      },
+      {
+        backend: { loadPath: 'http://localhost:9876/locales/{{lng}}/{{ns}}.json' },
+      },
+    );
   });
 
   describe('#load', () => {
-    it('should load data', (done) => {
+    it('should load data', done => {
       connector.load(['en'], ['retry'], function(err) {
         expect(err).to.be.not.ok;
-        expect(connector.store.getResourceBundle('en', 'retry')).to.eql({status: 'nok', retries: 2});
+        expect(connector.store.getResourceBundle('en', 'retry')).to.eql({
+          status: 'nok',
+          retries: 2,
+        });
         done();
       });
     });
@@ -29,17 +37,25 @@ describe('BackendConnector reload retry', () => {
   let connector;
 
   before(() => {
-    connector = new BackendConnector(new BackendMock(), new ResourceStore(), {
-      interpolator: new Interpolator()
-    }, {
-      backend: { loadPath: 'http://localhost:9876/locales/{{lng}}/{{ns}}.json' }
-    });
+    connector = new BackendConnector(
+      new BackendMock(),
+      new ResourceStore(),
+      {
+        interpolator: new Interpolator(),
+      },
+      {
+        backend: { loadPath: 'http://localhost:9876/locales/{{lng}}/{{ns}}.json' },
+      },
+    );
   });
 
   describe('#reload', () => {
     it('should reload data', () => {
       connector.reload(['es'], ['noretry'], () => {});
-      expect(connector.store.getResourceBundle('es', 'noretry')).to.eql({status: 'nok', retries: 0});
+      expect(connector.store.getResourceBundle('es', 'noretry')).to.eql({
+        status: 'nok',
+        retries: 0,
+      });
     });
   });
 });

--- a/test/backend/backendMock.js
+++ b/test/backend/backendMock.js
@@ -16,7 +16,7 @@ class Backend {
       this.retries[language]++;
       return callback('failed loading', true);
     } else {
-      callback(null, {status: 'nok', retries: this.retries[language]});
+      callback(null, { status: 'nok', retries: this.retries[language] });
       delete this.retries[language];
       return;
     }
@@ -32,12 +32,13 @@ class Backend {
       this.retries[language]++;
       return callback('failed loading', true);
     } else {
-      callback(null, {[language]: { [namespace]: {status: 'nok', retries: this.retries[language]}}});
+      callback(null, {
+        [language]: { [namespace]: { status: 'nok', retries: this.retries[language] } },
+      });
       delete this.retries[language];
       return;
     }
   }
 }
-
 
 export default Backend;

--- a/test/backward/compatibility/v1.js
+++ b/test/backward/compatibility/v1.js
@@ -2,9 +2,8 @@
 //import logger from '../logger';
 
 function convertInterpolation(options) {
-
   options.interpolation = {
-    unescapeSuffix: 'HTML'
+    unescapeSuffix: 'HTML',
   };
 
   options.interpolation.prefix = options.interpolationPrefix || '__';
@@ -53,7 +52,7 @@ export function convertAPIOptions(options) {
 
       return {
         postProcess: 'sprintf',
-        sprintf: values
+        sprintf: values,
       };
     };
   }
@@ -98,7 +97,11 @@ export function convertJSONOptions(options) {
 }
 
 export function convertTOptions(options) {
-  if (options.interpolationPrefix || options.interpolationSuffix || options.escapeInterpolation !== undefined) {
+  if (
+    options.interpolationPrefix ||
+    options.interpolationSuffix ||
+    options.escapeInterpolation !== undefined
+  ) {
     options = convertInterpolation(options);
   }
 
@@ -141,7 +144,7 @@ export function appendBackwardsAPI(i18n) {
     i18n.use({
       type: 'postProcessor',
       name,
-      process: fc
+      process: fc,
     });
   };
 }

--- a/test/backward/locales/de/translation.json
+++ b/test/backward/locales/de/translation.json
@@ -1,11 +1,11 @@
 {
-	"simple_de": "ok_from_de",
-	"xhr_simple_de": "xhr_ok_from_de",
-	"test": {
-		"simple_de": "ok_from_de"
-	},
-	"route": {
-		"key1": "key1_de",
-		"key2": "key2_de"
-	}
+  "simple_de": "ok_from_de",
+  "xhr_simple_de": "xhr_ok_from_de",
+  "test": {
+    "simple_de": "ok_from_de"
+  },
+  "route": {
+    "key1": "key1_de",
+    "key2": "key2_de"
+  }
 }

--- a/test/backward/locales/dev/ns.common.json
+++ b/test/backward/locales/dev/ns.common.json
@@ -1,7 +1,7 @@
 {
-	"simple_dev": "ok_from_common_dev",
-	"test": {
-		"simple_dev": "ok_from_common_dev",
-		"fallback_dev": "ok_from_common_dev-fallback"
-	}
+  "simple_dev": "ok_from_common_dev",
+  "test": {
+    "simple_dev": "ok_from_common_dev",
+    "fallback_dev": "ok_from_common_dev-fallback"
+  }
 }

--- a/test/backward/locales/dev/ns.special.json
+++ b/test/backward/locales/dev/ns.special.json
@@ -1,6 +1,6 @@
 {
-	"simple_dev": "ok_from_special_dev",
-	"test": {
-		"simple_dev": "ok_from_special_dev"
-	}
+  "simple_dev": "ok_from_special_dev",
+  "test": {
+    "simple_dev": "ok_from_special_dev"
+  }
 }

--- a/test/backward/locales/dev/translation.json
+++ b/test/backward/locales/dev/translation.json
@@ -1,7 +1,7 @@
 {
-	"simple_dev": "ok_from_dev",
-	"xhr_simple_dev": "xhr_ok_from_dev",
-	"test": {
-		"simple_dev": "ok_from_dev"
-	}
+  "simple_dev": "ok_from_dev",
+  "xhr_simple_dev": "xhr_ok_from_dev",
+  "test": {
+    "simple_dev": "ok_from_dev"
+  }
 }

--- a/test/backward/locales/en-US/ns.common.json
+++ b/test/backward/locales/en-US/ns.common.json
@@ -1,6 +1,6 @@
 {
-	"simple_en-US": "ok_from_common_en-US",
-	"test": {
-		"simple_en-US": "ok_from_common_en-US"
-	}
+  "simple_en-US": "ok_from_common_en-US",
+  "test": {
+    "simple_en-US": "ok_from_common_en-US"
+  }
 }

--- a/test/backward/locales/en-US/ns.special.json
+++ b/test/backward/locales/en-US/ns.special.json
@@ -1,6 +1,6 @@
 {
-	"simple_en-US": "ok_from_special_en-US",
-	"test": {
-		"simple_en-US": "ok_from_special_en-US"
-	}
+  "simple_en-US": "ok_from_special_en-US",
+  "test": {
+    "simple_en-US": "ok_from_special_en-US"
+  }
 }

--- a/test/backward/locales/en-US/translation.json
+++ b/test/backward/locales/en-US/translation.json
@@ -1,7 +1,7 @@
 {
-	"simple_en-US": "ok_from_en-US",
-	"xhr_simple_en-US": "xhr_ok_from_en-US",
-	"test": {
-		"simple_en-US": "ok_from_en-US"
-	}
+  "simple_en-US": "ok_from_en-US",
+  "xhr_simple_en-US": "xhr_ok_from_en-US",
+  "test": {
+    "simple_en-US": "ok_from_en-US"
+  }
 }

--- a/test/backward/locales/en/ns.common.json
+++ b/test/backward/locales/en/ns.common.json
@@ -1,7 +1,7 @@
 {
-	"simple_en": "ok_from_common_en",
-	"test": {
-		"simple_en": "ok_from_common_en",
-		"fallback_en": "ok_from_common_en-fallback"
-	}
+  "simple_en": "ok_from_common_en",
+  "test": {
+    "simple_en": "ok_from_common_en",
+    "fallback_en": "ok_from_common_en-fallback"
+  }
 }

--- a/test/backward/locales/en/ns.special.json
+++ b/test/backward/locales/en/ns.special.json
@@ -1,6 +1,6 @@
 {
-	"simple_en": "ok_from_special_en",
-	"test": {
-		"simple_en": "ok_from_special_en"
-	}
+  "simple_en": "ok_from_special_en",
+  "test": {
+    "simple_en": "ok_from_special_en"
+  }
 }

--- a/test/backward/locales/en/translation.json
+++ b/test/backward/locales/en/translation.json
@@ -1,11 +1,11 @@
 {
-	"simple_en": "ok_from_en",
-	"xhr_simple_en": "xhr_ok_from_en",
-	"test": {
-		"simple_en": "ok_from_en"
-	},
-	"route": {
-		"key1": "key1_en",
-		"key2": "key2_en"
-	}
+  "simple_en": "ok_from_en",
+  "xhr_simple_en": "xhr_ok_from_en",
+  "test": {
+    "simple_en": "ok_from_en"
+  },
+  "route": {
+    "key1": "key1_en",
+    "key2": "key2_en"
+  }
 }

--- a/test/backward/locales/fr/translation.json
+++ b/test/backward/locales/fr/translation.json
@@ -1,6 +1,6 @@
 {
-	"simple_fr": "ok_from_fr",
-	"test": {
-		"simple_fr": "ok_from_fr"
-	}
+  "simple_fr": "ok_from_fr",
+  "test": {
+    "simple_fr": "ok_from_fr"
+  }
 }

--- a/test/backward/v1.11.1.compat.js
+++ b/test/backward/v1.11.1.compat.js
@@ -27,14 +27,13 @@ export function extend(obj) {
 }
 
 i18n.functions = {
-  extend: extend
+  extend: extend,
 };
 
 let xhr = new XHR();
 
 let cache = new Cache();
 cache.debouncedStore = cache.store; // store without debounce
-
 
 i18n
   .use(xhr)
@@ -49,10 +48,9 @@ i18n.t = function(key, opts) {
   if (arguments.length > 2) return originalT.apply(i18n, arguments);
   if (typeof opts === 'object') opts = compat.convertTOptions(opts);
   return originalT.call(i18n, key, opts);
-}
+};
 
 describe('i18next', function() {
-
   var opts;
 
   beforeEach(function() {
@@ -86,49 +84,47 @@ describe('i18next', function() {
       shortcutFunction: 'sprintf',
       objectTreeKeyHandler: null,
       lngWhitelist: null,
-      resources: null
+      resources: null,
     });
   });
 
-
   describe('Initialisation', function() {
-
     describe('determining language directionality', function() {
-
       beforeEach(function(done) {
-        i18n.init(opts, function(t) { done(); });
+        i18n.init(opts, function(t) {
+          done();
+        });
       });
 
-      it('returns ltr for en-US', function(){
+      it('returns ltr for en-US', function() {
         i18n.setLng('en-US');
         expect(i18n.dir()).to.equal('ltr');
       });
 
-      it('returns ltr for unknown language', function(){
+      it('returns ltr for unknown language', function() {
         i18n.setLng('unknown');
         expect(i18n.dir()).to.equal('ltr');
       });
 
-      it('returns rtl for ar, ar-IR', function(){
+      it('returns rtl for ar, ar-IR', function() {
         i18n.setLng('ar');
         expect(i18n.dir()).to.equal('rtl');
         i18n.setLng('ar-IR');
         expect(i18n.dir()).to.equal('rtl');
       });
-
     });
 
     describe('with passed in resource set', function() {
-
       var resStore = {
-        dev: { translation: { 'simple_dev': 'ok_from_dev' } },
-        en: { translation: { 'simple_en': 'ok_from_en' } },
-        'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
+        dev: { translation: { simple_dev: 'ok_from_dev' } },
+        en: { translation: { simple_en: 'ok_from_en' } },
+        'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       it('it should provide passed in resources for translation', function() {
@@ -136,15 +132,14 @@ describe('i18next', function() {
         expect(i18n.t('simple_en')).to.be('ok_from_en');
         expect(i18n.t('simple_dev')).to.be('ok_from_dev');
       });
-
     });
 
     describe('loading from server', function() {
-
       describe('with static route', function() {
-
         beforeEach(function(done) {
-          i18n.init(opts, function(err, t) { done(); });
+          i18n.init(opts, function(err, t) {
+            done();
+          });
         });
 
         it('it should provide loaded resources for translation', function() {
@@ -156,24 +151,24 @@ describe('i18next', function() {
           expect(i18n.t('xhr_simple_en')).to.be('xhr_ok_from_en');
           expect(i18n.t('xhr_simple_dev')).to.be('xhr_ok_from_dev');
         });
-
       });
-
     });
 
     describe('advanced initialisation options', function() {
-
       describe('setting fallbackLng', function() {
-
         var resStore = {
-          dev1: { translation: { 'simple_dev1': 'ok_from_dev1' } },
-          en: { translation: { 'simple_en': 'ok_from_en' } },
-          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
+          dev1: { translation: { simple_dev1: 'ok_from_dev1' } },
+          en: { translation: { simple_en: 'ok_from_en' } },
+          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, fallbackLng: 'dev1' }),
-            function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, { resStore: resStore, fallbackLng: 'dev1' }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide passed in resources for translation', function() {
@@ -181,21 +176,23 @@ describe('i18next', function() {
           expect(i18n.t('simple_en')).to.be('ok_from_en');
           expect(i18n.t('simple_dev1')).to.be('ok_from_dev1');
         });
-
       });
 
       describe('multiple fallbackLng', function() {
-
         var resStore = {
-          dev1: { translation: { 'simple_dev1': 'ok_from_dev1', 'simple_dev': 'ok_from_dev1' } },
-          dev2: { translation: { 'simple_dev2': 'ok_from_dev2', 'simple_dev': 'ok_from_dev2' } },
-          en: { translation: { 'simple_en': 'ok_from_en' } },
-          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
+          dev1: { translation: { simple_dev1: 'ok_from_dev1', simple_dev: 'ok_from_dev1' } },
+          dev2: { translation: { simple_dev2: 'ok_from_dev2', simple_dev: 'ok_from_dev2' } },
+          en: { translation: { simple_en: 'ok_from_en' } },
+          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, fallbackLng: ['dev1', 'dev2'] }),
-            function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, { resStore: resStore, fallbackLng: ['dev1', 'dev2'] }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide passed in resources for translation', function() {
@@ -207,25 +204,21 @@ describe('i18next', function() {
           // in both
           expect(i18n.t('simple_dev')).to.be('ok_from_dev1');
         });
-
       });
 
       describe('adding resources after init', function() {
-
         var resStore = {
-          dev: { translation: { 'simple_dev': 'ok_from_dev' } },
-          en: { translation: { 'simple_en': 'ok_from_en' } }//,
+          dev: { translation: { simple_dev: 'ok_from_dev' } },
+          en: { translation: { simple_en: 'ok_from_en' } }, //,
           //'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
         };
 
         describe('resources', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-              function(t) {
-                i18n.addResource('en-US', 'translation', 'some.deep.thing', 'ok_from_en-US');
-                done();
-              });
+            i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+              i18n.addResource('en-US', 'translation', 'some.deep.thing', 'ok_from_en-US');
+              done();
+            });
           });
 
           it('it should provide passed in resources for translation', function() {
@@ -233,35 +226,29 @@ describe('i18next', function() {
           });
 
           describe('multiple resources', function() {
-
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) {
-                  i18n.addResources('en-US', 'translation', {
-                    'some.other.deep.thing': 'ok_from_en-US_1',
-                    'some.other.deep.deeper.thing': 'ok_from_en-US_2'
-                  });
-                  done();
+              i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+                i18n.addResources('en-US', 'translation', {
+                  'some.other.deep.thing': 'ok_from_en-US_1',
+                  'some.other.deep.deeper.thing': 'ok_from_en-US_2',
                 });
+                done();
+              });
             });
 
             it('it should add the new namespace to the namespace array', function() {
               expect(i18n.t('some.other.deep.thing')).to.be('ok_from_en-US_1');
               expect(i18n.t('some.other.deep.deeper.thing')).to.be('ok_from_en-US_2');
             });
-
           });
-
         });
 
         describe('bundles', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-              function(t) {
-                i18n.addResourceBundle('en-US', 'translation', { 'simple_en-US': 'ok_from_en-US' });
-                done();
-              });
+            i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+              i18n.addResourceBundle('en-US', 'translation', { 'simple_en-US': 'ok_from_en-US' });
+              done();
+            });
           });
 
           it('it should provide passed in resources for translation', function() {
@@ -271,32 +258,46 @@ describe('i18next', function() {
           });
 
           describe('with a additional namespace', function() {
-
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) {
-                  i18n.addResourceBundle('en-US', 'newNamespace', { 'simple_en-US': 'ok_from_en-US' });
-                  done();
+              i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+                i18n.addResourceBundle('en-US', 'newNamespace', {
+                  'simple_en-US': 'ok_from_en-US',
                 });
+                done();
+              });
             });
 
             it('it should add the new namespace to the namespace array', function() {
               expect(i18n.options.ns).to.contain('newNamespace');
             });
-
           });
 
           describe('with using deep switch', function() {
-
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) {
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_1': 'ok_from_en-US_1' }});
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_2': 'ok_from_en-US_2' }}, true);
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_3': 'ok_from_en-US_3' }}, true);
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_3': 'ok_from_en-US_3-overwrite' }}, true);
-                  done();
+              i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+                i18n.addResourceBundle('en-US', 'translation', {
+                  deep: { 'simple_en-US_1': 'ok_from_en-US_1' },
                 });
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_2': 'ok_from_en-US_2' } },
+                  true,
+                );
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_3': 'ok_from_en-US_3' } },
+                  true,
+                );
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_3': 'ok_from_en-US_3-overwrite' } },
+                  true,
+                );
+                done();
+              });
             });
 
             it('it should add the new namespace to the namespace array', function() {
@@ -307,20 +308,35 @@ describe('i18next', function() {
             it('it should not overwrite any existing entries if the overwrite switch is off', function() {
               expect(i18n.t('deep.simple_en-US_3')).to.be('ok_from_en-US_3');
             });
-
           });
 
           describe('with using deep switch and overwrite switch', function() {
-
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) {
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_1': 'ok_from_en-US_1' }});
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_2': 'ok_from_en-US_2' }}, true);
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_3': 'ok_from_en-US_3' }}, true);
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_3': 'ok_from_en-US_3-overwrite' }}, true, true);
-                  done();
+              i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+                i18n.addResourceBundle('en-US', 'translation', {
+                  deep: { 'simple_en-US_1': 'ok_from_en-US_1' },
                 });
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_2': 'ok_from_en-US_2' } },
+                  true,
+                );
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_3': 'ok_from_en-US_3' } },
+                  true,
+                );
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_3': 'ok_from_en-US_3-overwrite' } },
+                  true,
+                  true,
+                );
+                done();
+              });
             });
 
             it('it should add the new namespace to the namespace array', function() {
@@ -330,19 +346,23 @@ describe('i18next', function() {
 
             it('it should overwrite any existing entries if the overwrite switch is on', function() {
               expect(i18n.t('deep.simple_en-US_3')).to.be('ok_from_en-US_3-overwrite');
-            })
-
+            });
           });
 
           describe('check if exists', function() {
-
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) {
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_1': 'ok_from_en-US_1' }});
-                  i18n.addResourceBundle('en-US', 'translation', { 'deep': { 'simple_en-US_2': 'ok_from_en-US_2' }}, true);
-                  done();
+              i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+                i18n.addResourceBundle('en-US', 'translation', {
+                  deep: { 'simple_en-US_1': 'ok_from_en-US_1' },
                 });
+                i18n.addResourceBundle(
+                  'en-US',
+                  'translation',
+                  { deep: { 'simple_en-US_2': 'ok_from_en-US_2' } },
+                  true,
+                );
+                done();
+              });
             });
 
             it('it should return true for existing bundle', function() {
@@ -352,24 +372,20 @@ describe('i18next', function() {
             it('it should return false for non-existing bundle', function() {
               expect(i18n.hasResourceBundle('de-CH', 'translation')).to.not.be.ok();
             });
-
           });
-
         });
-
       });
 
       describe('getting resources after init', function() {
-
         var resStore = {
-          dev: { translation: { 'test': 'ok_from_dev' } },
-          en: { translation: { 'test': 'ok_from_en' } },
-          'en-US': { translation: { 'test': 'ok_from_en-US' } }
+          dev: { translation: { test: 'ok_from_dev' } },
+          en: { translation: { test: 'ok_from_en' } },
+          'en-US': { translation: { test: 'ok_from_en-US' } },
         };
 
         beforeEach(function(done) {
           i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function() {
-              done();
+            done();
           });
         });
 
@@ -398,42 +414,41 @@ describe('i18next', function() {
           expect(enTranslation.test).to.be('ok_from_en_changed');
           expect(resStore.en.translation.test).to.be('ok_from_en');
         });
-
       });
 
       describe('removing resources after init', function() {
-
         var resStore = {
-          dev: { translation: { 'test': 'ok_from_dev' } },
-          en: { translation: { 'test': 'ok_from_en' } },
-          'en-US': { translation: { 'test': 'ok_from_en-US' } }
+          dev: { translation: { test: 'ok_from_dev' } },
+          en: { translation: { test: 'ok_from_en' } },
+          'en-US': { translation: { test: 'ok_from_en-US' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) {
-              i18n.removeResourceBundle('en-US', 'translation');
-              done();
-            });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            i18n.removeResourceBundle('en-US', 'translation');
+            done();
+          });
         });
 
         it('it should remove resources', function() {
           expect(i18n.t('test')).to.be('ok_from_en');
         });
-
       });
 
       describe('setting load', function() {
-
         describe('to current', function() {
-
           var spy;
 
           beforeEach(function(done) {
             spy = sinon.spy(xhr, 'read');
-            i18n.init(i18n.functions.extend(opts, {
-                load: 'current' }),
-              function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                load: 'current',
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           afterEach(function() {
@@ -449,18 +464,21 @@ describe('i18next', function() {
             expect(i18n.t('simple_en')).not.to.be('ok_from_en');
             expect(i18n.t('simple_dev')).to.be('ok_from_dev');
           });
-
         });
 
         describe('to unspecific', function() {
-
           var spy;
 
           beforeEach(function(done) {
             spy = sinon.spy(xhr, 'read');
-            i18n.init(i18n.functions.extend(opts, {
-                load: 'unspecific' }),
-              function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                load: 'unspecific',
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           afterEach(function() {
@@ -480,20 +498,22 @@ describe('i18next', function() {
           it('it should return unspecific language', function() {
             expect(i18n.lng()).to.be('en');
           });
-
         });
-
       });
 
       describe('with fallback language set to false', function() {
-
         var spy;
 
         beforeEach(function(done) {
           spy = sinon.spy(xhr, 'read');
-          i18n.init(i18n.functions.extend(opts, {
-              fallbackLng: false }),
-            function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              fallbackLng: false,
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         afterEach(function() {
@@ -509,18 +529,21 @@ describe('i18next', function() {
           expect(i18n.t('simple_en')).to.be('ok_from_en');
           expect(i18n.t('simple_dev')).not.to.be('ok_from_dev');
         });
-
       });
 
       describe('preloading multiple languages', function() {
-
         var spy;
 
         beforeEach(function(done) {
           spy = sinon.spy(xhr, 'read');
-          i18n.init(i18n.functions.extend(opts, {
-              preload: ['fr', 'de-DE'] }),
-            function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              preload: ['fr', 'de-DE'],
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         afterEach(function() {
@@ -532,26 +555,23 @@ describe('i18next', function() {
         });
 
         describe('changing the language', function() {
-
           beforeEach(function(done) {
             spy.reset();
             //if (i18n.sync.resStore) i18n.sync.resStore = {}; // to reset for test on server!
-            i18n.setLng('de-DE',
-              function(t) { done(); });
+            i18n.setLng('de-DE', function(t) {
+              done();
+            });
           });
 
           it('it should not reload the preloaded languages', function() {
             expect(spy.callCount).to.be(0); // de-DE the missing one
           });
-
         });
-
       });
 
       describe.skip('[WONT FIX - HARD DEPRECATION]with synchronous flag', function() {
-
         beforeEach(function() {
-          i18n.init(i18n.functions.extend(opts, { getAsync: false }) );
+          i18n.init(i18n.functions.extend(opts, { getAsync: false }));
         });
 
         it('it should provide loaded resources for translation', function() {
@@ -559,16 +579,14 @@ describe('i18next', function() {
           expect(i18n.t('simple_en')).to.be('ok_from_en');
           expect(i18n.t('simple_dev')).to.be('ok_from_dev');
         });
-
       });
 
       describe('with namespace', function() {
-
         describe('with one namespace set', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, { ns: 'ns.special'} ),
-              function(t) { done(); });
+            i18n.init(i18n.functions.extend(opts, { ns: 'ns.special' }), function(t) {
+              done();
+            });
           });
 
           it('it should provide loaded resources for translation', function() {
@@ -576,14 +594,18 @@ describe('i18next', function() {
             expect(i18n.t('simple_en')).to.be('ok_from_special_en');
             expect(i18n.t('simple_dev')).to.be('ok_from_special_dev');
           });
-
         });
 
         describe('with more than one namespace set', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, { ns: { namespaces: ['ns.common', 'ns.special'], defaultNs: 'ns.special'} } ),
-              function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                ns: { namespaces: ['ns.common', 'ns.special'], defaultNs: 'ns.special' },
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should provide loaded resources for translation', function() {
@@ -605,17 +627,22 @@ describe('i18next', function() {
 
           describe('and fallbacking to default namespace', function() {
             var resStore = {
-              dev: { 'ns.special': { 'simple_dev': 'ok_from_dev' } },
-              en: { 'ns.special': { 'simple_en': 'ok_from_en' } },
-              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } }
+              dev: { 'ns.special': { simple_dev: 'ok_from_dev' } },
+              en: { 'ns.special': { simple_en: 'ok_from_en' } },
+              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } },
             };
 
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, {
-                fallbackToDefaultNS: true,
-                resStore: resStore,
-                ns: { namespaces: ['ns.common', 'ns.special'], defaultNs: 'ns.special'} } ),
-                function(t) { done(); });
+              i18n.init(
+                i18n.functions.extend(opts, {
+                  fallbackToDefaultNS: true,
+                  resStore: resStore,
+                  ns: { namespaces: ['ns.common', 'ns.special'], defaultNs: 'ns.special' },
+                }),
+                function(t) {
+                  done();
+                },
+              );
             });
 
             it('it should fallback to default ns', function() {
@@ -629,82 +656,103 @@ describe('i18next', function() {
               expect(i18n.t('simple_en', { ns: 'ns.common' })).to.be('ok_from_en');
               expect(i18n.t('simple_dev', { ns: 'ns.common' })).to.be('ok_from_dev');
             });
-
           });
 
           describe('and fallbacking to set namespace', function() {
             var resStore = {
               dev: {
-                'ns.special': { 'simple_dev': 'ok_from_dev' },
-                'ns.fallback': { 'simple_fallback': 'ok_from_fallback' }
+                'ns.special': { simple_dev: 'ok_from_dev' },
+                'ns.fallback': { simple_fallback: 'ok_from_fallback' },
               },
-              en: { 'ns.special': { 'simple_en': 'ok_from_en' } },
-              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } }
+              en: { 'ns.special': { simple_en: 'ok_from_en' } },
+              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } },
             };
 
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, {
-                fallbackNS: 'ns.fallback',
-                resStore: resStore,
-                ns: { namespaces: ['ns.common', 'ns.special', 'ns.fallback'], defaultNs: 'ns.special'} } ),
-                function(t) { done(); });
+              i18n.init(
+                i18n.functions.extend(opts, {
+                  fallbackNS: 'ns.fallback',
+                  resStore: resStore,
+                  ns: {
+                    namespaces: ['ns.common', 'ns.special', 'ns.fallback'],
+                    defaultNs: 'ns.special',
+                  },
+                }),
+                function(t) {
+                  done();
+                },
+              );
             });
 
             it('it should fallback to set fallback namespace', function() {
               expect(i18n.t('ns.common:simple_fallback')).to.be('ok_from_fallback');
             });
-
           });
 
           describe('and fallbacking to multiple set namespace', function() {
             var resStore = {
               dev: {
                 'ns.common': {},
-                'ns.special': { 'simple_dev': 'ok_from_dev' },
+                'ns.special': { simple_dev: 'ok_from_dev' },
                 'ns.fallback1': {
-                  'simple_fallback': 'ok_from_fallback1',
-                  'simple_fallback1': 'ok_from_fallback1'
-                }
+                  simple_fallback: 'ok_from_fallback1',
+                  simple_fallback1: 'ok_from_fallback1',
+                },
               },
               en: {
-                'ns.special': { 'simple_en': 'ok_from_en' },
+                'ns.special': { simple_en: 'ok_from_en' },
                 'ns.fallback2': {
-                  'simple_fallback': 'ok_from_fallback2',
-                  'simple_fallback2': 'ok_from_fallback2'
-                }
+                  simple_fallback: 'ok_from_fallback2',
+                  simple_fallback2: 'ok_from_fallback2',
+                },
               },
-              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } }
+              'en-US': { 'ns.special': { 'simple_en-US': 'ok_from_en-US' } },
             };
 
             beforeEach(function(done) {
-              i18n.init(i18n.functions.extend(opts, {
-                fallbackNS: ['ns.fallback1', 'ns.fallback2'],
-                resStore: resStore,
-                ns: { namespaces: ['ns.common', 'ns.special', 'ns.fallback'], defaultNs: 'ns.special'} } ),
-                function(t) { done(); });
+              i18n.init(
+                i18n.functions.extend(opts, {
+                  fallbackNS: ['ns.fallback1', 'ns.fallback2'],
+                  resStore: resStore,
+                  ns: {
+                    namespaces: ['ns.common', 'ns.special', 'ns.fallback'],
+                    defaultNs: 'ns.special',
+                  },
+                }),
+                function(t) {
+                  done();
+                },
+              );
             });
 
             it('it should fallback to set fallback namespace', function() {
-              expect(i18n.t('ns.common:simple_fallback')).to.be('ok_from_fallback1'); /* first wins */
+              expect(i18n.t('ns.common:simple_fallback')).to.be(
+                'ok_from_fallback1',
+              ); /* first wins */
               expect(i18n.t('ns.common:simple_fallback1')).to.be('ok_from_fallback1');
               expect(i18n.t('ns.common:simple_fallback2')).to.be('ok_from_fallback2');
             });
 
             describe('and post missing', function() {
-
               var spy;
 
               beforeEach(function(done) {
-                i18n.init(i18n.functions.extend(opts, {
-                  fallbackNS: ['ns.fallback1', 'ns.fallback2'],
-                  resStore: resStore,
-                  sendMissing: true, /* must be changed to saveMissing */
-                  ns: { namespaces: ['ns.common', 'ns.special', 'ns.fallback'], defaultNs: 'ns.special'} } ),
+                i18n.init(
+                  i18n.functions.extend(opts, {
+                    fallbackNS: ['ns.fallback1', 'ns.fallback2'],
+                    resStore: resStore,
+                    sendMissing: true /* must be changed to saveMissing */,
+                    ns: {
+                      namespaces: ['ns.common', 'ns.special', 'ns.fallback'],
+                      defaultNs: 'ns.special',
+                    },
+                  }),
                   function(err, t) {
                     spy = sinon.spy(xhr, 'create');
                     t('ns.common:notExisting');
                     done();
-                  });
+                  },
+                );
               });
 
               afterEach(function() {
@@ -718,22 +766,17 @@ describe('i18next', function() {
                 expect(spy.args[0][2]).to.be('notExisting');
                 expect(spy.args[0][3]).to.be('notExisting');
               });
-
             });
-
           });
-
         });
 
         describe('with reloading additional namespace', function() {
-
           describe('without using localStorage', function() {
             beforeEach(function(done) {
-              i18n.init(opts,
-                function(t) {
-                  i18n.setDefaultNamespace('ns.special');
-                  i18n.loadNamespaces(['ns.common', 'ns.special'], done);
-                });
+              i18n.init(opts, function(t) {
+                i18n.setDefaultNamespace('ns.special');
+                i18n.loadNamespaces(['ns.common', 'ns.special'], done);
+              });
             });
 
             it('it should provide loaded resources for translation', function() {
@@ -759,81 +802,79 @@ describe('i18next', function() {
             });
 
             describe('and fallbackToDefaultNS turned on', function() {
-
               beforeEach(function(done) {
-                i18n.init(i18n.functions.extend(opts, {
+                i18n.init(
+                  i18n.functions.extend(opts, {
                     ns: 'ns.common',
-                    fallbackToDefaultNS: true
+                    fallbackToDefaultNS: true,
                   }),
                   function(t) {
                     i18n.loadNamespaces(['ns.special'], done);
-                  });
+                  },
+                );
               });
 
               it('it should fallback to default namespace', function() {
                 expect(i18n.t('ns.special:test.fallback_en')).to.be('ok_from_common_en-fallback');
                 expect(i18n.t('ns.special:test.fallback_dev')).to.be('ok_from_common_dev-fallback');
               });
-
             });
-
           });
 
-        // cache was removed
+          // cache was removed
 
-        //   describe('with using localStorage', function() {
-        //
-        //     var spy;
-        //
-        //     before(function() {
-        //       if (typeof window !== 'undefined') { // safe use on server
-        //         window.localStorage.removeItem('res_en-US');
-        //         window.localStorage.removeItem('res_en');
-        //         window.localStorage.removeItem('res_dev');
-        //       }
-        //     });
-        //
-        //     beforeEach(function(done) {
-        //       spy = sinon.spy(xhr, 'read');
-        //       i18n.init(i18n.functions.extend(opts, {
-        //         useLocalStorage: true
-        //       }), function(t) {
-        //         i18n.setDefaultNamespace('ns.special');
-        //         i18n.loadNamespaces(['ns.common', 'ns.special'], done);
-        //       });
-        //     });
-        //
-        //     afterEach(function() {
-        //       spy.restore();
-        //     });
-        //
-        //     it('it should load language', function() {
-        //       expect(spy.callCount).to.be(9); // en-US, en, de-DE, de, fr, dev * 3 namespaces (translate, common, special)
-        //     });
-        //
-        //     describe('on later reload of namespaces', function() {
-        //
-        //       beforeEach(function(done) {
-        //         spy.reset();
-        //         i18n.init(i18n.functions.extend(opts, {
-        //           useLocalStorage: true,
-        //           ns: 'translation'
-        //         }), function(t) {
-        //           i18n.setDefaultNamespace('ns.special');
-        //           i18n.loadNamespaces(['ns.common', 'ns.special'], done);
-        //         });
-        //       });
-        //
-        //       it('it should not reload language', function() {
-        //         expect(spy.callCount).to.be(0);
-        //       });
-        //
-        //     });
-        //
-        //   });
-        //
+          //   describe('with using localStorage', function() {
+          //
+          //     var spy;
+          //
+          //     before(function() {
+          //       if (typeof window !== 'undefined') { // safe use on server
+          //         window.localStorage.removeItem('res_en-US');
+          //         window.localStorage.removeItem('res_en');
+          //         window.localStorage.removeItem('res_dev');
+          //       }
+          //     });
+          //
+          //     beforeEach(function(done) {
+          //       spy = sinon.spy(xhr, 'read');
+          //       i18n.init(i18n.functions.extend(opts, {
+          //         useLocalStorage: true
+          //       }), function(t) {
+          //         i18n.setDefaultNamespace('ns.special');
+          //         i18n.loadNamespaces(['ns.common', 'ns.special'], done);
+          //       });
+          //     });
+          //
+          //     afterEach(function() {
+          //       spy.restore();
+          //     });
+          //
+          //     it('it should load language', function() {
+          //       expect(spy.callCount).to.be(9); // en-US, en, de-DE, de, fr, dev * 3 namespaces (translate, common, special)
+          //     });
+          //
+          //     describe('on later reload of namespaces', function() {
+          //
+          //       beforeEach(function(done) {
+          //         spy.reset();
+          //         i18n.init(i18n.functions.extend(opts, {
+          //           useLocalStorage: true,
+          //           ns: 'translation'
+          //         }), function(t) {
+          //           i18n.setDefaultNamespace('ns.special');
+          //           i18n.loadNamespaces(['ns.common', 'ns.special'], done);
+          //         });
+          //       });
+          //
+          //       it('it should not reload language', function() {
+          //         expect(spy.callCount).to.be(0);
+          //       });
+          //
+          //     });
+          //
+          //   });
+          //
         });
-
       });
 
       // describe('using localStorage', function() {
@@ -896,18 +937,20 @@ describe('i18next', function() {
       //
       // });
 
-      describe('using function provided in callback\'s argument', function() {
-
+      describe("using function provided in callback's argument", function() {
         var cbT;
 
         var resStore = {
-          dev: { translation: { 'simple_dev': 'ok_from_dev' } },
-          en: { translation: { 'simple_en': 'ok_from_en' } },
-          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
+          dev: { translation: { simple_dev: 'ok_from_dev' } },
+          en: { translation: { simple_en: 'ok_from_en' } },
+          'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(err, t) { cbT = t; done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(err, t) {
+            cbT = t;
+            done();
+          });
         });
 
         it('it should provide loaded resources for translation', function() {
@@ -915,20 +958,22 @@ describe('i18next', function() {
           expect(cbT('simple_en')).to.be('ok_from_en');
           expect(cbT('simple_dev')).to.be('ok_from_dev');
         });
-
       });
 
       describe('with lowercase flag', function() {
-
         describe('default behaviour will uppercase specifc country part.', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              lng: 'en-us',
-              resStore: {
-                'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } }
-              }
-            }), function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                lng: 'en-us',
+                resStore: {
+                  'en-US': { translation: { 'simple_en-US': 'ok_from_en-US' } },
+                },
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should translate the uppercased lng value', function() {
@@ -938,19 +983,22 @@ describe('i18next', function() {
           it('it should get uppercased set language', function() {
             expect(i18n.lng()).to.be('en-US');
           });
-
         });
 
         describe('overridden behaviour will accept lowercased country part.', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              lng: 'en-us',
-              lowerCaseLng: true,
-              resStore: {
-                'en-us': { translation: { 'simple_en-us': 'ok_from_en-us' } }
-              }
-            }), function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                lng: 'en-us',
+                lowerCaseLng: true,
+                resStore: {
+                  'en-us': { translation: { 'simple_en-us': 'ok_from_en-us' } },
+                },
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should translate the lowercase lng value', function() {
@@ -960,112 +1008,124 @@ describe('i18next', function() {
           it('it should get lowercased set language', function() {
             expect(i18n.lng()).to.be('en-us');
           });
-
         });
-
       });
 
       describe('with language whitelist', function() {
-
         var resStore = {
-          'zh-CN':  { translation: { 'string_one': 'good_zh-CN' } },
-          en:       { translation: { 'string_one': 'good_en' } },
-          zh:       { translation: { 'string_one': 'BAD_zh' } },
-          'en-US':  { translation: { 'string_one': 'BAD_en-ZH' } }
+          'zh-CN': { translation: { string_one: 'good_zh-CN' } },
+          en: { translation: { string_one: 'good_en' } },
+          zh: { translation: { string_one: 'BAD_zh' } },
+          'en-US': { translation: { string_one: 'BAD_en-ZH' } },
         };
 
         it('should degrade UNwhitelisted 2-part lang code (en-US) to WHITELISTED 1-part (en)', function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lngWhitelist: ['en', 'zh-CN'], lng: 'en-US' }), function() {
-            expect(i18n.lng()).to.be('en');
-            expect(i18n.t('string_one')).to.be('good_en');
-            done();
-          });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              lngWhitelist: ['en', 'zh-CN'],
+              lng: 'en-US',
+            }),
+            function() {
+              expect(i18n.lng()).to.be('en');
+              expect(i18n.t('string_one')).to.be('good_en');
+              done();
+            },
+          );
         });
 
         it('should NOT degrade WHITELISTED 2-part lang code (zh-CN) to UNwhitelisted 1-part (en)', function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lngWhitelist: ['en', 'zh-CN'], lng: 'zh-CN' }), function() {
-            expect(i18n.lng()).to.be('zh-CN');
-            expect(i18n.t('string_one')).to.be('good_zh-CN');
-            done();
-          });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              lngWhitelist: ['en', 'zh-CN'],
+              lng: 'zh-CN',
+            }),
+            function() {
+              expect(i18n.lng()).to.be('zh-CN');
+              expect(i18n.t('string_one')).to.be('good_zh-CN');
+              done();
+            },
+          );
         });
-
       });
-
     });
-
   });
   describe('basic functionality', function() {
-
     describe('CI mode', function() {
-
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-          resStore: {
-            'en-US': { translation: { 'simpleTest': 'ok_from_en-US' } },
-            'de-DE': { translation: { 'simpleTest': 'ok_from_de-DE' } }
-          }
-        }), function(t) { done(); } );
+        i18n.init(
+          i18n.functions.extend(opts, {
+            resStore: {
+              'en-US': { translation: { simpleTest: 'ok_from_en-US' } },
+              'de-DE': { translation: { simpleTest: 'ok_from_de-DE' } },
+            },
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should provide resources for set language', function(done) {
         expect(i18n.t('simpleTest')).to.be('ok_from_en-US');
 
         i18n.setLng('CIMode', function(err, t) {
-            expect(t('simpleTest')).to.be('simpleTest');
-            done();
+          expect(t('simpleTest')).to.be('simpleTest');
+          done();
         });
-
       });
-
     });
 
     describe('setting language', function() {
-
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-          resStore: {
-            'en-US': { translation: { 'simpleTest': 'ok_from_en-US' } },
-            'de-DE': { translation: { 'simpleTest': 'ok_from_de-DE' } }
-          }
-        }), function(t) { done(); } );
+        i18n.init(
+          i18n.functions.extend(opts, {
+            resStore: {
+              'en-US': { translation: { simpleTest: 'ok_from_en-US' } },
+              'de-DE': { translation: { simpleTest: 'ok_from_de-DE' } },
+            },
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should provide resources for set language', function(done) {
         expect(i18n.t('simpleTest')).to.be('ok_from_en-US');
 
         i18n.setLng('de-DE', function(err, t) {
-            expect(t('simpleTest')).to.be('ok_from_de-DE');
-            done();
+          expect(t('simpleTest')).to.be('ok_from_de-DE');
+          done();
         });
-
       });
 
       it('should be possible to call setLng multiple times to get specialized callbacks', function(done) {
         i18n.setLng('de-DE', { fixLng: true }, function(err, deDE) {
+          expect(deDE.lng).to.be('de-DE');
+
+          i18n.setLng('en-US', { fixLng: true }, function(err, enUS) {
             expect(deDE.lng).to.be('de-DE');
+            expect(enUS.lng).to.be('en-US');
 
-            i18n.setLng('en-US', { fixLng: true }, function(err, enUS) {
-                expect(deDE.lng).to.be('de-DE');
-                expect(enUS.lng).to.be('en-US');
+            expect(deDE('simpleTest')).to.be('ok_from_de-DE');
+            expect(enUS('simpleTest')).to.be('ok_from_en-US');
 
-                expect(deDE('simpleTest')).to.be('ok_from_de-DE');
-                expect(enUS('simpleTest')).to.be('ok_from_en-US');
-
-                done();
-            });
+            done();
+          });
         });
-      })
-
+      });
     });
 
     describe('preloading multiple languages', function() {
-
       var spy;
 
       beforeEach(function(done) {
         spy = sinon.spy(xhr, 'read');
-        i18n.init(opts, function(t) { done(); });
+        i18n.init(opts, function(t) {
+          done();
+        });
       });
 
       afterEach(function() {
@@ -1079,78 +1139,87 @@ describe('i18next', function() {
           expect(spy.callCount).to.be(2); // de-DE, de
           done();
         });
-
       });
-
     });
 
     describe('postprocessing tranlation', function() {
-
       describe('having a postprocessor', function() {
-
-        before(function(){
+        before(function() {
           i18n.addPostProcessor('myProcessor', function(val, key, opts) {
             return 'ok_from_postprocessor';
           });
           i18n.addPostProcessor('myProcessor2', function(val, key, opts) {
-            return val + ' ok' ;
+            return val + ' ok';
           });
         });
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: {
-              'en-US': { translation: { 'simpleTest': 'ok_from_en-US' } },
-              'de-DE': { translation: { 'simpleTest': 'ok_from_de-DE' } }
-            }
-          }), function(t) { done(); } );
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: {
+                'en-US': { translation: { simpleTest: 'ok_from_en-US' } },
+                'de-DE': { translation: { simpleTest: 'ok_from_de-DE' } },
+              },
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should postprocess the translation by passing in postProcess name to t function', function() {
-          expect(i18n.t('simpleTest', {postProcess: 'myProcessor'})).to.be('ok_from_postprocessor');
+          expect(i18n.t('simpleTest', { postProcess: 'myProcessor' })).to.be(
+            'ok_from_postprocessor',
+          );
         });
 
         it('it should postprocess on default value', function() {
-          expect(i18n.t('notFound1', {defaultValue: 'defaultValue', postProcess: 'myProcessor2'})).to.be('defaultValue ok');
+          expect(
+            i18n.t('notFound1', { defaultValue: 'defaultValue', postProcess: 'myProcessor2' }),
+          ).to.be('defaultValue ok');
         });
 
         it('it should postprocess on missing value', function() {
-          expect(i18n.t('notFound2', {postProcess: 'myProcessor2'})).to.be('notFound2 ok');
+          expect(i18n.t('notFound2', { postProcess: 'myProcessor2' })).to.be('notFound2 ok');
         });
 
         it('it should postprocess with multiple post processors', function() {
-          expect(i18n.t('simpleTest', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
+          expect(i18n.t('simpleTest', { postProcess: ['myProcessor', 'myProcessor2'] })).to.be(
+            'ok_from_postprocessor ok',
+          );
         });
 
         it('it should postprocess on missing value with multiple post processes', function() {
-           expect(i18n.t('notFound2', {postProcess: ['myProcessor', 'myProcessor2']})).to.be('ok_from_postprocessor ok');
+          expect(i18n.t('notFound2', { postProcess: ['myProcessor', 'myProcessor2'] })).to.be(
+            'ok_from_postprocessor ok',
+          );
         });
 
         describe('or setting it as default on init', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              resStore: {
-                'en-US': { translation: { 'simpleTest': 'ok_from_en-US' } },
-                'de-DE': { translation: { 'simpleTest': 'ok_from_de-DE' } }
+            i18n.init(
+              i18n.functions.extend(opts, {
+                resStore: {
+                  'en-US': { translation: { simpleTest: 'ok_from_en-US' } },
+                  'de-DE': { translation: { simpleTest: 'ok_from_de-DE' } },
+                },
+                postProcess: 'myProcessor',
+                shortcutFunction: 'defaultValue',
+              }),
+              function(t) {
+                done();
               },
-              postProcess: 'myProcessor',
-              shortcutFunction: 'defaultValue',
-            }), function(t) { done(); } );
+            );
           });
 
           it('it should postprocess the translation by default', function() {
             expect(i18n.t('simpleTest')).to.be('ok_from_postprocessor');
           });
-
         });
-
       });
-
     });
 
     describe('post missing resources', function() {
-
       describe('to fallback', function() {
         var server, stub, spy;
 
@@ -1159,17 +1228,21 @@ describe('i18next', function() {
           spy = sinon.spy(xhr, 'create');
           //spy = sinon.spy(i18n.services.backendConnector, 'saveMissing');
 
+          server.respondWith([200, { 'Content-Type': 'text/html', 'Content-Length': 2 }, 'OK']);
 
-          server.respondWith([200, { "Content-Type": "text/html", "Content-Length": 2 }, "OK"]);
-
-          i18n.init(i18n.functions.extend(opts, {
-            sendMissing: true,
-            resStore: {
-              'en-US': { translation: {  } },
-              'en': { translation: {  } },
-              'dev': { translation: {  } }
-            }
-          }), function(t) { done(); } );
+          i18n.init(
+            i18n.functions.extend(opts, {
+              sendMissing: true,
+              resStore: {
+                'en-US': { translation: {} },
+                en: { translation: {} },
+                dev: { translation: {} },
+              },
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         afterEach(function() {
@@ -1199,19 +1272,23 @@ describe('i18next', function() {
         });
 
         describe('with fallbackLng set to false', function() {
-
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              lng: 'de',
-              sendMissing: true,
-              fallbackLng: false,
-              sendMissingTo: 'fallback',
-              resStore: {
-                'en-US': { translation: {  } },
-                'en': { translation: {  } },
-                'dev': { translation: {  } }
-              }
-            }), function(t) { done(); } );
+            i18n.init(
+              i18n.functions.extend(opts, {
+                lng: 'de',
+                sendMissing: true,
+                fallbackLng: false,
+                sendMissingTo: 'fallback',
+                resStore: {
+                  'en-US': { translation: {} },
+                  en: { translation: {} },
+                  dev: { translation: {} },
+                },
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should post missing resource to server', function() {
@@ -1232,9 +1309,7 @@ describe('i18next', function() {
             i18n.t('missing');
             expect(stub.args[0][0].url).to.be('locales/add/de/translation');
           });
-
         });
-
       });
 
       describe('to current', function() {
@@ -1244,18 +1319,23 @@ describe('i18next', function() {
           server = sinon.fakeServer.create();
           spy = sinon.stub(xhr, 'create');
 
-          server.respondWith([200, { "Content-Type": "text/html", "Content-Length": 2 }, "OK"]);
+          server.respondWith([200, { 'Content-Type': 'text/html', 'Content-Length': 2 }, 'OK']);
 
-          i18n.init(i18n.functions.extend(opts, {
-            sendMissing: true,
-            sendMissingTo: 'current',
-            //fallbackLng: false,
-            resStore: {
-              'en-US': { translation: {  } },
-              'en': { translation: {  } },
-              'dev': { translation: {  } }
-            }
-          }), function(t) { done(); } );
+          i18n.init(
+            i18n.functions.extend(opts, {
+              sendMissing: true,
+              sendMissingTo: 'current',
+              //fallbackLng: false,
+              resStore: {
+                'en-US': { translation: {} },
+                en: { translation: {} },
+                dev: { translation: {} },
+              },
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         afterEach(function() {
@@ -1276,7 +1356,6 @@ describe('i18next', function() {
           expect(spy.args[0][2]).to.be('missing2');
           expect(spy.args[0][3]).to.be('missing2');
         });
-
       });
 
       describe('to all', function() {
@@ -1286,17 +1365,22 @@ describe('i18next', function() {
           server = sinon.fakeServer.create();
           spy = sinon.spy(xhr, 'create');
 
-          server.respondWith([200, { "Content-Type": "text/html", "Content-Length": 2 }, "OK"]);
+          server.respondWith([200, { 'Content-Type': 'text/html', 'Content-Length': 2 }, 'OK']);
 
-          i18n.init(i18n.functions.extend(opts, {
-            sendMissing: true,
-            sendMissingTo: 'all',
-            resStore: {
-              'en-US': { translation: {  } },
-              'en': { translation: {  } },
-              'dev': { translation: {  } }
-            }
-          }), function(t) { done(); } );
+          i18n.init(
+            i18n.functions.extend(opts, {
+              sendMissing: true,
+              sendMissingTo: 'all',
+              resStore: {
+                'en-US': { translation: {} },
+                en: { translation: {} },
+                dev: { translation: {} },
+              },
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         afterEach(function() {
@@ -1312,69 +1396,68 @@ describe('i18next', function() {
 
         it('it should call post missing with right arguments', function() {
           i18n.t('missing2');
-          expect(spy.args[0][0]).to.eql([ 'en-US', 'en', 'dev' ]);
+          expect(spy.args[0][0]).to.eql(['en-US', 'en', 'dev']);
           expect(spy.args[0][1]).to.be('translation');
           expect(spy.args[0][2]).to.be('missing2');
           expect(spy.args[0][3]).to.be('missing2');
         });
-
       });
-
     });
 
     describe('using objectTreeKeyHandler', function() {
-
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-          objectTreeKeyHandler: function(key, value, lng, ns, opts) {
-            return i18n.t(key + '.a');
+        i18n.init(
+          i18n.functions.extend(opts, {
+            objectTreeKeyHandler: function(key, value, lng, ns, opts) {
+              return i18n.t(key + '.a');
+            },
+            resStore: {
+              'en-US': { translation: { simpleTest: { a: 'a value', b: 'b value' } } },
+            },
+            returnObjectTrees: false,
+          }),
+          function(t) {
+            done();
           },
-          resStore: {
-            'en-US': { translation: { 'simpleTest': { a: 'a value', b: 'b value' } } }
-          },
-          returnObjectTrees: false
-        }), function(t) { done(); } );
+        );
       });
 
       it('it should apply objectTreeKeyHandler', function() {
         expect(i18n.t('simpleTest')).to.be('a value');
       });
-
     });
 
-    describe.skip('[WONT BE EXPOSED AS I18N]Global variable conflict', function () {
+    describe.skip('[WONT BE EXPOSED AS I18N]Global variable conflict', function() {
+      it(
+        'it should rename global "window.i18n" to "window.i18next"' +
+          ' and restore window.i18n conflicting reference',
+        function() {
+          window.i18n.noConflict();
 
-      it('it should rename global "window.i18n" to "window.i18next"' +
-        ' and restore window.i18n conflicting reference', function () {
-
-        window.i18n.noConflict();
-
-        expect(window.i18n.isFakeConflictingLib).to.be(true);
-        expect(window.i18next).to.be.an(Object);
-        expect(window.i18next.t).to.be.a(Function);
-      });
+          expect(window.i18n.isFakeConflictingLib).to.be(true);
+          expect(window.i18next).to.be.an(Object);
+          expect(window.i18next.t).to.be.a(Function);
+        },
+      );
     });
-
   });
   describe('translation functionality', function() {
-
     describe('keys with non supported values', function() {
-
       var resStore = {
-        dev: { translation: {  } },
-        en: { translation: {  } },
+        dev: { translation: {} },
+        en: { translation: {} },
         'en-US': {
           translation: {
-            test: 'hi'
-          }
-        }
+            test: 'hi',
+          },
+        },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
-
 
       it('it should not break on null key', function() {
         expect(i18n.t(null)).to.be('');
@@ -1388,19 +1471,19 @@ describe('i18next', function() {
         expect(i18n.t(1)).to.be(i18n.t('1'));
         expect(i18n.t(1.1)).to.be(i18n.t('1.1'));
       });
-
     });
 
     describe('resource is missing', function() {
       var resStore = {
-        dev: { translation: { } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        dev: { translation: {} },
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       it('it should return key', function() {
@@ -1408,36 +1491,42 @@ describe('i18next', function() {
       });
 
       it('it should return default value if set', function() {
-        expect(i18n.t('missing', { defaultValue: 'defaultOfMissing'})).to.be('defaultOfMissing');
+        expect(i18n.t('missing', { defaultValue: 'defaultOfMissing' })).to.be('defaultOfMissing');
       });
 
       describe('with namespaces', function() {
-
         it('it should return key', function() {
           expect(i18n.t('translate:missing')).to.be('translate:missing');
         });
 
         it('it should return default value if set', function() {
-          expect(i18n.t('translate:missing', { defaultValue: 'defaultOfMissing'})).to.be('defaultOfMissing');
+          expect(i18n.t('translate:missing', { defaultValue: 'defaultOfMissing' })).to.be(
+            'defaultOfMissing',
+          );
         });
 
         describe('and function parseMissingKey set', function() {
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              parseMissingKey: function(key) {
-                var ret = key;
+            i18n.init(
+              i18n.functions.extend(opts, {
+                parseMissingKey: function(key) {
+                  var ret = key;
 
-                if (ret.indexOf(':')) {
-                   ret = ret.substring(ret.lastIndexOf(':')+1, ret.length);
-                }
+                  if (ret.indexOf(':')) {
+                    ret = ret.substring(ret.lastIndexOf(':') + 1, ret.length);
+                  }
 
-                if (ret.indexOf('.')) {
-                  ret = ret.substring(ret.lastIndexOf('.')+1, ret.length);
-                }
+                  if (ret.indexOf('.')) {
+                    ret = ret.substring(ret.lastIndexOf('.') + 1, ret.length);
+                  }
 
-                return ret;
-              }
-            }), function(t) { done(); });
+                  return ret;
+                },
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should parse key', function() {
@@ -1446,67 +1535,76 @@ describe('i18next', function() {
           });
 
           it('it should return default value if set', function() {
-            expect(i18n.t('translate:missing', { defaultValue: 'defaultOfMissing'})).to.be('defaultOfMissing');
+            expect(i18n.t('translate:missing', { defaultValue: 'defaultOfMissing' })).to.be(
+              'defaultOfMissing',
+            );
           });
-
         });
-
       });
-
     });
 
     describe('Check for existence of keys', function() {
+      var resStore = {
+        dev: { translation: { iExist: '' } },
+        en: { translation: {} },
+        'en-US': { translation: {} },
+      };
+
+      beforeEach(function(done) {
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
+      });
+
+      it('it should exist', function() {
+        expect(i18n.exists('iExist')).to.be(true);
+      });
+
+      it('it should not exist', function() {
+        expect(i18n.exists('iDontExist')).to.be(false);
+      });
+
+      describe('missing on unspecific', function() {
         var resStore = {
-            dev: { translation: { iExist: '' } },
-            en: { translation: { } },
-            'en-US': { translation: { } }
+          dev: { translation: { iExist: 'text' } },
+          en: { translation: {} },
+          'en-US': { translation: { empty: '' } },
         };
 
         beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-                function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lng: 'en' }), function(t) {
+            done();
+          });
         });
 
         it('it should exist', function() {
-            expect(i18n.exists('iExist')).to.be(true);
+          expect(i18n.exists('iExist')).to.be(true);
         });
 
         it('it should not exist', function() {
-            expect(i18n.exists('iDontExist')).to.be(false);
+          expect(i18n.exists('iDontExist')).to.be(false);
         });
-
-        describe('missing on unspecific', function() {
-            var resStore = {
-                dev: { translation: { iExist: 'text' } },
-                en: { translation: { } },
-                'en-US': { translation: { empty: '' } }
-            };
-
-            beforeEach(function(done) {
-                i18n.init(i18n.functions.extend(opts, { resStore: resStore, lng: 'en' }),
-                    function(t) { done(); });
-            });
-
-            it('it should exist', function() {
-                expect(i18n.exists('iExist')).to.be(true);
-            });
-
-            it('it should not exist', function() {
-                expect(i18n.exists('iDontExist')).to.be(false);
-            });
-        });
+      });
     });
 
     describe('resource string is null', function() {
       var resStore = {
         dev: { translation: { key1: null, key2: { key3: null } } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore, returnObjectTrees: true, fallbackOnNull: false }),
-          function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, {
+            resStore: resStore,
+            returnObjectTrees: true,
+            fallbackOnNull: false,
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should translate value', function() {
@@ -1517,35 +1615,37 @@ describe('i18next', function() {
       describe('with option fallbackOnNull = true', function() {
         var resStore = {
           dev: { translation: { key1: 'fallbackKey1', key2: { key3: 'fallbackKey3' } } },
-          en: { translation: { } },
-          'en-US': { translation: { key1: null, key2: { key3: null } } }
+          en: { translation: {} },
+          'en-US': { translation: { key1: null, key2: { key3: null } } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, fallbackOnNull: true}),
-            function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, { resStore: resStore, fallbackOnNull: true }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should translate to fallback value', function() {
           expect(i18n.t('key1')).to.be('fallbackKey1');
           expect(i18n.t('key2.key3')).to.eql('fallbackKey3');
         });
-
       });
-
-
     });
 
     describe('key with empty string value as valid option', function() {
       var resStore = {
         dev: { translation: { empty: '' } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       it('it should translate correctly', function() {
@@ -1555,13 +1655,14 @@ describe('i18next', function() {
       describe('missing on unspecific', function() {
         var resStore = {
           dev: { translation: { empty: 'text' } },
-          en: { translation: { } },
-          'en-US': { translation: { empty: '' } }
+          en: { translation: {} },
+          'en-US': { translation: { empty: '' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lng: 'en' }),
-              function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lng: 'en' }), function(t) {
+            done();
+          });
         });
 
         it('it should translate correctly', function() {
@@ -1572,13 +1673,14 @@ describe('i18next', function() {
       describe('on specific language', function() {
         var resStore = {
           dev: { translation: { empty: 'text' } },
-          en: { translation: { } },
-          'en-US': { translation: { empty: '' } }
+          en: { translation: {} },
+          'en-US': { translation: { empty: '' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-              function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should translate correctly', function() {
@@ -1590,13 +1692,17 @@ describe('i18next', function() {
     describe('key with empty string set to fallback if empty', function() {
       var resStore = {
         dev: { translation: { empty: '' } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore, fallbackOnEmpty: true }),
-            function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, { resStore: resStore, fallbackOnEmpty: true }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should translate correctly', function() {
@@ -1606,13 +1712,17 @@ describe('i18next', function() {
       describe('missing on unspecific', function() {
         var resStore = {
           dev: { translation: { empty: 'text' } },
-          en: { translation: { } },
-          'en-US': { translation: { empty: '' } }
+          en: { translation: {} },
+          'en-US': { translation: { empty: '' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, lng: 'en', fallbackOnEmpty: true }),
-              function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, { resStore: resStore, lng: 'en', fallbackOnEmpty: true }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should translate correctly', function() {
@@ -1623,13 +1733,17 @@ describe('i18next', function() {
       describe('on specific language', function() {
         var resStore = {
           dev: { translation: { empty: 'text' } },
-          en: { translation: { } },
-          'en-US': { translation: { empty: '' } }
+          en: { translation: {} },
+          'en-US': { translation: { empty: '' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore, fallbackOnEmpty: true }),
-              function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, { resStore: resStore, fallbackOnEmpty: true }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should translate correctly', function() {
@@ -1641,44 +1755,52 @@ describe('i18next', function() {
     describe('resource key as array', function() {
       var resStore = {
         dev: { translation: { existing1: 'hello _name_', existing2: 'howdy __name__' } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       describe('when none of the keys exist', function() {
         it('return the same value as translating the last non-existent key', function() {
-          expect(i18n.t(['nonexistent1', 'nonexistent2'], {name: "Joe"})).to.equal(i18n.t('nonexistent2', {name: "Joe"}));
+          expect(i18n.t(['nonexistent1', 'nonexistent2'], { name: 'Joe' })).to.equal(
+            i18n.t('nonexistent2', { name: 'Joe' }),
+          );
         });
       });
 
       describe('when one of the keys exist', function() {
         it('return the same value as translating the one existing key', function() {
-          expect(i18n.t(['nonexistent1', 'existing2'], {name: "Joe"})).to.equal(i18n.t('existing2', {name: "Joe"}));
+          expect(i18n.t(['nonexistent1', 'existing2'], { name: 'Joe' })).to.equal(
+            i18n.t('existing2', { name: 'Joe' }),
+          );
         });
       });
 
       describe('when two or more of the keys exist', function() {
         it('return the same value as translating the first existing key', function() {
-          expect(i18n.t(['nonexistent1', 'existing2', 'existing1'], {name: "Joe"})).to.equal(i18n.t('existing2', {name: "Joe"}));
+          expect(i18n.t(['nonexistent1', 'existing2', 'existing1'], { name: 'Joe' })).to.equal(
+            i18n.t('existing2', { name: 'Joe' }),
+          );
         });
       });
     });
 
     describe('resource string as array', function() {
       var resStore = {
-        dev: { translation: { testarray: ["title", "text"] } },
-        en: { translation: { } },
-        'en-US': { translation: { } }
+        dev: { translation: { testarray: ['title', 'text'] } },
+        en: { translation: {} },
+        'en-US': { translation: {} },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       it('it should translate nested value', function() {
@@ -1687,21 +1809,25 @@ describe('i18next', function() {
     });
 
     describe('accessing tree values', function() {
-
       var resStore = {
-        dev: { translation: {  } },
-        en: { translation: {  } },
+        dev: { translation: {} },
+        en: { translation: {} },
         'en-US': {
           translation: {
-            test: { 'simple_en-US': 'ok_from_en-US' }
-          }
-        }
+            test: { 'simple_en-US': 'ok_from_en-US' },
+          },
+        },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-          resStore: resStore }
-        ), function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, {
+            resStore: resStore,
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should return nested string as usual', function() {
@@ -1709,69 +1835,77 @@ describe('i18next', function() {
       });
 
       it('it should not fail silently on accessing an objectTree', function() {
-        expect(i18n.t('test')).to.be('key \'test (en-US)\' returned an object instead of string.');
+        expect(i18n.t('test')).to.be("key 'test (en-US)' returned an object instead of string.");
       });
 
       describe('optional return an objectTree for UI components,...', function() {
-
         describe('with init flag', function() {
-
           var resStore = {
-            dev: { translation: {
-                test_dev: { res_dev: 'added __replace__' }
-              }
+            dev: {
+              translation: {
+                test_dev: { res_dev: 'added __replace__' },
+              },
             },
-            en: { translation: {  } },
+            en: { translation: {} },
             'en-US': {
               translation: {
-                test_en_US: { res_en_US: 'added __replace__' }
-              }
-            }
+                test_en_US: { res_en_US: 'added __replace__' },
+              },
+            },
           };
 
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              returnObjectTrees: true,
-              resStore: resStore }
-              ), function(t) { done(); });
+            i18n.init(
+              i18n.functions.extend(opts, {
+                returnObjectTrees: true,
+                resStore: resStore,
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should return objectTree applying options', function() {
-            expect(i18n.t('test_en_US', { replace: 'two' })).to.eql({ 'res_en_US': 'added two' });
-            expect(i18n.t('test_en_US', { replace: 'three' })).to.eql({ 'res_en_US': 'added three' });
-            expect(i18n.t('test_en_US', { replace: 'four' })).to.eql({ 'res_en_US': 'added four' });
+            expect(i18n.t('test_en_US', { replace: 'two' })).to.eql({ res_en_US: 'added two' });
+            expect(i18n.t('test_en_US', { replace: 'three' })).to.eql({ res_en_US: 'added three' });
+            expect(i18n.t('test_en_US', { replace: 'four' })).to.eql({ res_en_US: 'added four' });
 
             // from fallback
-            expect(i18n.t('test_dev', { replace: 'two' })).to.eql({ 'res_dev': 'added two' });
+            expect(i18n.t('test_dev', { replace: 'two' })).to.eql({ res_dev: 'added two' });
           });
-
         });
 
         describe('with flag in options', function() {
-
           var resStore = {
-            dev: { translation: {  } },
-            en: { translation: {  } },
+            dev: { translation: {} },
+            en: { translation: {} },
             'en-US': {
               translation: {
-                test: { res: 'added __replace__',
-                        id: 0,
-                        regex: /test/,
-                        func: function () {},
-                        template: '4',
-                        title: 'About...',
-                        text: 'Site description',
-                        media: ['test']
-                }
-              }
-            }
+                test: {
+                  res: 'added __replace__',
+                  id: 0,
+                  regex: /test/,
+                  func: function() {},
+                  template: '4',
+                  title: 'About...',
+                  text: 'Site description',
+                  media: ['test'],
+                },
+              },
+            },
           };
 
           beforeEach(function(done) {
-            i18n.init(i18n.functions.extend(opts, {
-              returnObjectTrees: false,
-              resStore: resStore }),
-              function(t) { done(); } );
+            i18n.init(
+              i18n.functions.extend(opts, {
+                returnObjectTrees: false,
+                resStore: resStore,
+              }),
+              function(t) {
+                done();
+              },
+            );
           });
 
           it('it should return objectTree', function() {
@@ -1783,28 +1917,26 @@ describe('i18next', function() {
               template: '4',
               title: 'About...',
               text: 'Site description',
-              media: ['test']
+              media: ['test'],
             });
             //expect(i18n.t('test', { returnObjectTrees: true, replace: 'three' })).to.eql({ 'res': 'added three' });
             //expect(i18n.t('test', { returnObjectTrees: true, replace: 'four' })).to.eql({ 'res': 'added four' });
           });
-
         });
-
       });
-
     });
 
     describe('resource nesting', function() {
       var resStore = {
         dev: { translation: { nesting1: '1 $t(nesting2)' } },
         en: { translation: { nesting2: '2 $t(nesting3)' } },
-        'en-US': { translation: {  nesting3: '3' } }
+        'en-US': { translation: { nesting3: '3' } },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-          function(t) { done(); });
+        i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+          done();
+        });
       });
 
       it('it should translate nested value', function() {
@@ -1812,65 +1944,74 @@ describe('i18next', function() {
       });
 
       it('it should apply nested value on defaultValue', function() {
-        expect(i18n.t('nesting_default', {defaultValue: '0 $t(nesting1)'})).to.be('0 1 2 3');
+        expect(i18n.t('nesting_default', { defaultValue: '0 $t(nesting1)' })).to.be('0 1 2 3');
       });
 
       describe('resource nesting syntax error', function() {
         var resStore = {
           dev: { translation: { nesting1: '1 $t(nesting2' } },
           en: { translation: { nesting2: '2 $t(nesting3)' } },
-          'en-US': { translation: {  nesting3: '3' } }
+          'en-US': { translation: { nesting3: '3' } },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it.skip('[WONT FIX - FIX YOUR APPLICATION]it should translate nested value', function() {
           expect(i18n.t('nesting1')).to.be('');
         });
-
       });
 
       describe('with setting new options', function() {
         var resStore = {
-          dev: { translation: {
-            nesting1: '$t(nesting2, {"count": __girls__}) and __count__ boy',
-            nesting1_plural: '$t(nesting2, {"count": __girls__}) and __count__ boys'
-          } },
-          en: { translation: {
-            nesting2: '__count__ girl',
-            nesting2_plural: '__count__ girls'
-          } }
+          dev: {
+            translation: {
+              nesting1: '$t(nesting2, {"count": __girls__}) and __count__ boy',
+              nesting1_plural: '$t(nesting2, {"count": __girls__}) and __count__ boys',
+            },
+          },
+          en: {
+            translation: {
+              nesting2: '__count__ girl',
+              nesting2_plural: '__count__ girls',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should translate nested value and set new options', function() {
-          expect(i18n.t('nesting1', {count: 2, girls: 3})).to.be('3 girls and 2 boys');
-          expect(i18n.t('nesting1', {count: 1, girls: 3})).to.be('3 girls and 1 boy');
+          expect(i18n.t('nesting1', { count: 2, girls: 3 })).to.be('3 girls and 2 boys');
+          expect(i18n.t('nesting1', { count: 1, girls: 3 })).to.be('3 girls and 1 boy');
         });
       });
-
     });
 
     describe('resource nesting with multiple namespaces and fallbackNS', function() {
       var resStore = {
         dev: { translation1: { nesting1: '1 $t(nesting2)' } },
         en: { translation: { nesting2: '2 $t(nesting3)' } },
-        'en-US': { translation: {  nesting3: '3' } }
+        'en-US': { translation: { nesting3: '3' } },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-          resStore: resStore,
-          ns: { namespaces: ['translation1', 'translation'], defaultNs: 'translation1'},
-          fallbackNS: ['translation']
-        }), function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, {
+            resStore: resStore,
+            ns: { namespaces: ['translation1', 'translation'], defaultNs: 'translation1' },
+            fallbackNS: ['translation'],
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should translate nested value', function() {
@@ -1879,98 +2020,122 @@ describe('i18next', function() {
     });
 
     describe('interpolation - replacing values inside a string', function() {
-
       describe('default i18next way', function() {
-
         var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
+          dev: { translation: {} },
+          en: { translation: {} },
           'en-US': {
             translation: {
               interpolationTest1: 'added __toAdd__',
               interpolationTest2: 'added __toAdd__ __toAdd__ twice',
               interpolationTest3: 'added __child.one__ __child.two__',
-              interpolationTest4: 'added __child.grandChild.three__'
-            }
-          }
+              interpolationTest4: 'added __child.grandChild.three__',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should replace passed in key/values', function() {
-          expect(i18n.t('interpolationTest1', {toAdd: 'something'})).to.be('added something');
-          expect(i18n.t('interpolationTest1', {toAdd: null})).to.be('added ');
+          expect(i18n.t('interpolationTest1', { toAdd: 'something' })).to.be('added something');
+          expect(i18n.t('interpolationTest1', { toAdd: null })).to.be('added ');
           expect(i18n.t('interpolationTest1', {})).to.be('added ');
-          expect(i18n.t('interpolationTest2', {toAdd: 'something'})).to.be('added something something twice');
-          expect(i18n.t('interpolationTest3', { child: { one: '1', two: '2'}})).to.be('added 1 2');
-          expect(i18n.t('interpolationTest4', { child: { grandChild: { three: '3'}}})).to.be('added 3');
+          expect(i18n.t('interpolationTest2', { toAdd: 'something' })).to.be(
+            'added something something twice',
+          );
+          expect(i18n.t('interpolationTest3', { child: { one: '1', two: '2' } })).to.be(
+            'added 1 2',
+          );
+          expect(i18n.t('interpolationTest4', { child: { grandChild: { three: '3' } } })).to.be(
+            'added 3',
+          );
         });
 
         it('it should replace passed in key/values in replace member', function() {
-          expect(i18n.t('interpolationTest1', { replace: {toAdd: 'something'} })).to.be('added something');
-          expect(i18n.t('interpolationTest2', { replace: {toAdd: 'something'} })).to.be('added something something twice');
-          expect(i18n.t('interpolationTest3', { replace: { child: { one: '1', two: '2'}} })).to.be('added 1 2');
-          expect(i18n.t('interpolationTest4', { replace: { child: { grandChild: { three: '3'}}} })).to.be('added 3');
+          expect(i18n.t('interpolationTest1', { replace: { toAdd: 'something' } })).to.be(
+            'added something',
+          );
+          expect(i18n.t('interpolationTest2', { replace: { toAdd: 'something' } })).to.be(
+            'added something something twice',
+          );
+          expect(
+            i18n.t('interpolationTest3', { replace: { child: { one: '1', two: '2' } } }),
+          ).to.be('added 1 2');
+          expect(
+            i18n.t('interpolationTest4', { replace: { child: { grandChild: { three: '3' } } } }),
+          ).to.be('added 3');
         });
 
-        it("it should not escape HTML", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '<html>'})).to.be('added <html>');
+        it('it should not escape HTML', function() {
+          expect(i18n.t('interpolationTest1', { toAdd: '<html>' })).to.be('added <html>');
         });
 
         it('it should replace passed in key/values on defaultValue', function() {
-          expect(i18n.t('interpolationTest5', {defaultValue: 'added __toAdd__', toAdd: 'something'})).to.be('added something');
+          expect(
+            i18n.t('interpolationTest5', { defaultValue: 'added __toAdd__', toAdd: 'something' }),
+          ).to.be('added something');
         });
 
-        it("it should escape dollar signs in replacement values", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&');
+        it('it should escape dollar signs in replacement values', function() {
+          expect(i18n.t('interpolationTest1', { toAdd: '$&' })).to.be('added $&');
         });
-
       });
 
       describe('default i18next way - different prefix/suffix', function() {
-
         var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
+          dev: { translation: {} },
+          en: { translation: {} },
           'en-US': {
             translation: {
               interpolationTest1: 'added *toAdd*',
               interpolationTest2: 'added *toAdd* *toAdd* twice',
               interpolationTest3: 'added *child.one* *child.two*',
-              interpolationTest4: 'added *child.grandChild.three*'
-            }
-          }
+              interpolationTest4: 'added *child.grandChild.three*',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore,
-            interpolationPrefix: '*',
-            interpolationSuffix: '*'
-          }), function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should replace passed in key/values', function() {
-          expect(i18n.t('interpolationTest1', {toAdd: 'something'})).to.be('added something');
-          expect(i18n.t('interpolationTest2', {toAdd: 'something'})).to.be('added something something twice');
-          expect(i18n.t('interpolationTest3', { child: { one: '1', two: '2'}})).to.be('added 1 2');
-          expect(i18n.t('interpolationTest4', { child: { grandChild: { three: '3'}}})).to.be('added 3');
+          expect(i18n.t('interpolationTest1', { toAdd: 'something' })).to.be('added something');
+          expect(i18n.t('interpolationTest2', { toAdd: 'something' })).to.be(
+            'added something something twice',
+          );
+          expect(i18n.t('interpolationTest3', { child: { one: '1', two: '2' } })).to.be(
+            'added 1 2',
+          );
+          expect(i18n.t('interpolationTest4', { child: { grandChild: { three: '3' } } })).to.be(
+            'added 3',
+          );
         });
 
         it('it should replace passed in key/values on defaultValue', function() {
-          expect(i18n.t('interpolationTest5', {defaultValue: 'added *toAdd*', toAdd: 'something'})).to.be('added something');
+          expect(
+            i18n.t('interpolationTest5', { defaultValue: 'added *toAdd*', toAdd: 'something' }),
+          ).to.be('added something');
         });
-
       });
 
       describe('default i18next way - different prefix/suffix via options', function() {
-
         var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
+          dev: { translation: {} },
+          en: { translation: {} },
           'en-US': {
             translation: {
               interpolationTest1: 'added *toAdd*',
@@ -1978,159 +2143,234 @@ describe('i18next', function() {
               interpolationTest3: 'added *child.one* *child.two*',
               interpolationTest4: 'added *child.grandChild.three*',
               interpolationTest5: 'added *count*',
-              interpolationTest5_plural: 'added *count*'
-            }
-          }
+              interpolationTest5_plural: 'added *count*',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore
-          }), function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should replace passed in key/values', function() {
-          expect(i18n.t('interpolationTest1', {toAdd: 'something', interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added something');
-          expect(i18n.t('interpolationTest2', {toAdd: 'something', interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added something something twice');
-          expect(i18n.t('interpolationTest3', { child: { one: '1', two: '2'}, interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added 1 2');
-          expect(i18n.t('interpolationTest4', { child: { grandChild: { three: '3'}}, interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added 3');
-          expect(i18n.t('interpolationTest5', { count: 3, interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added 3');
+          expect(
+            i18n.t('interpolationTest1', {
+              toAdd: 'something',
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added something');
+          expect(
+            i18n.t('interpolationTest2', {
+              toAdd: 'something',
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added something something twice');
+          expect(
+            i18n.t('interpolationTest3', {
+              child: { one: '1', two: '2' },
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added 1 2');
+          expect(
+            i18n.t('interpolationTest4', {
+              child: { grandChild: { three: '3' } },
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added 3');
+          expect(
+            i18n.t('interpolationTest5', {
+              count: 3,
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added 3');
         });
 
         it('it should replace passed in key/values on defaultValue', function() {
-          expect(i18n.t('interpolationTest6', {defaultValue: 'added *toAdd*', toAdd: 'something', interpolationPrefix: '*', interpolationSuffix: '*'})).to.be('added something');
+          expect(
+            i18n.t('interpolationTest6', {
+              defaultValue: 'added *toAdd*',
+              toAdd: 'something',
+              interpolationPrefix: '*',
+              interpolationSuffix: '*',
+            }),
+          ).to.be('added something');
         });
-
       });
 
-      describe('default i18next way - with escaping interpolated arguments per default', function () {
+      describe('default i18next way - with escaping interpolated arguments per default', function() {
         var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
+          dev: { translation: {} },
+          en: { translation: {} },
           'en-US': {
             translation: {
               interpolationTest1: 'added __toAdd__',
               interpolationTest5: 'added __toAddHTML__',
               interpolationTest6: 'added __child.oneHTML__',
               interpolationTest7: 'added __toAddHTML__ __toAdd__',
-              interpolationTest8: 'added __toAdd1__ __toAdd2__'
-            }
-          }
+              interpolationTest8: 'added __toAdd1__ __toAdd2__',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore,
-            escapeInterpolation: true
-          }), function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              escapeInterpolation: true,
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
-        it("it should escape HTML", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '<html>'})).to.be('added &lt;html&gt;');
+        it('it should escape HTML', function() {
+          expect(i18n.t('interpolationTest1', { toAdd: '<html>' })).to.be('added &lt;html&gt;');
         });
 
-        it("it should not escape when HTML is suffixed", function() {
-          expect(i18n.t('interpolationTest5', {toAdd: '<html>'})).to.be('added <html>');
-          expect(i18n.t('interpolationTest6', { child: { one: '<1>'}})).to.be('added <1>');
+        it('it should not escape when HTML is suffixed', function() {
+          expect(i18n.t('interpolationTest5', { toAdd: '<html>' })).to.be('added <html>');
+          expect(i18n.t('interpolationTest6', { child: { one: '<1>' } })).to.be('added <1>');
         });
 
-        it("it should support both escaping and not escaping HTML", function() {
-          expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
+        it('it should support both escaping and not escaping HTML', function() {
+          expect(
+            i18n.t('interpolationTest7', { toAdd: '<html>', escapeInterpolation: true }),
+          ).to.be('added <html> &lt;html&gt;');
         });
 
-        it("should not accept interpolations from inside interpolations", function() {
-          expect(i18n.t('interpolationTest8', { toAdd1: '__toAdd2HTML__', toAdd2: '<html>'})).to.be('added  &lt;html&gt;');
+        it('should not accept interpolations from inside interpolations', function() {
+          expect(
+            i18n.t('interpolationTest8', { toAdd1: '__toAdd2HTML__', toAdd2: '<html>' }),
+          ).to.be('added  &lt;html&gt;');
         });
 
-        it("it should escape dollar signs in replacement values", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '$&'})).to.be('added $&amp;');
+        it('it should escape dollar signs in replacement values', function() {
+          expect(i18n.t('interpolationTest1', { toAdd: '$&' })).to.be('added $&amp;');
         });
-
       });
 
-      describe('default i18next way - with escaping interpolated arguments per default via options', function () {
+      describe('default i18next way - with escaping interpolated arguments per default via options', function() {
         var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
+          dev: { translation: {} },
+          en: { translation: {} },
           'en-US': {
             translation: {
               interpolationTest1: 'added __toAdd__',
               interpolationTest5: 'added __toAddHTML__',
               interpolationTest6: 'added __child.oneHTML__',
-              interpolationTest7: 'added __toAddHTML__ __toAdd__'
-            }
-          }
-        };
-
-        beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore
-          }), function(t) { done(); });
-        });
-
-        it("it should escape HTML", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '<html>', escapeInterpolation: true})).to.be('added &lt;html&gt;');
-        });
-
-        it("it should not escape when HTML is suffixed", function() {
-          expect(i18n.t('interpolationTest5', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html>');
-          expect(i18n.t('interpolationTest6', { child: { one: '<1>', escapeInterpolation: true}})).to.be('added <1>');
-        });
-
-        it("it should support both escaping and not escaping HTML", function() {
-          expect(i18n.t('interpolationTest7', {toAdd: '<html>', escapeInterpolation: true})).to.be('added <html> &lt;html&gt;');
-        });
-
-        it("it should escape dollar signs in replacement values", function() {
-          expect(i18n.t('interpolationTest1', {toAdd: '$&', escapeInterpolation: true})).to.be('added $&amp;');
-        });
-
-      });
-
-      describe('using sprintf', function() {
-
-        var resStore = {
-          dev: { translation: {  } },
-          en: { translation: {  } },
-          'en-US': {
-            translation: {
-              interpolationTest1: 'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
-              interpolationTest2: 'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
-              interpolationTest3: 'The last letter of the english alphabet is %s',
-              interpolationTest4: 'Water freezes at %d degrees'
-            }
-          }
-        };
-
-        beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
-        });
-
-        it('it should replace passed in key/values', function() {
-          expect(i18n.t('interpolationTest1', {postProcess: 'sprintf', sprintf: ['a', 'b', 'c', 'd']})).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
-          expect(i18n.t('interpolationTest2', {postProcess: 'sprintf', sprintf: { users: [{name: 'Dolly'}, {name: 'Molly'}, {name: 'Polly'}] } })).to.be('Hello Dolly, Molly and Polly');
-        });
-
-        it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
-          expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
-          expect(i18n.t('interpolationTest3', 'z')).to.be('The last letter of the english alphabet is z');
-          expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
-        });
-
-      });
-
-      describe('with default variables', function() {
-
-        var defaultVariables = {
-          name: 'John'
+              interpolationTest7: 'added __toAddHTML__ __toAdd__',
+            },
+          },
         };
 
         beforeEach(function(done) {
           i18n.init(
-            i18n.functions.extend(opts, { defaultVariables: defaultVariables }),
-            function(t) { done(); }
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+            }),
+            function(t) {
+              done();
+            },
           );
+        });
+
+        it('it should escape HTML', function() {
+          expect(
+            i18n.t('interpolationTest1', { toAdd: '<html>', escapeInterpolation: true }),
+          ).to.be('added &lt;html&gt;');
+        });
+
+        it('it should not escape when HTML is suffixed', function() {
+          expect(
+            i18n.t('interpolationTest5', { toAdd: '<html>', escapeInterpolation: true }),
+          ).to.be('added <html>');
+          expect(
+            i18n.t('interpolationTest6', { child: { one: '<1>', escapeInterpolation: true } }),
+          ).to.be('added <1>');
+        });
+
+        it('it should support both escaping and not escaping HTML', function() {
+          expect(
+            i18n.t('interpolationTest7', { toAdd: '<html>', escapeInterpolation: true }),
+          ).to.be('added <html> &lt;html&gt;');
+        });
+
+        it('it should escape dollar signs in replacement values', function() {
+          expect(i18n.t('interpolationTest1', { toAdd: '$&', escapeInterpolation: true })).to.be(
+            'added $&amp;',
+          );
+        });
+      });
+
+      describe('using sprintf', function() {
+        var resStore = {
+          dev: { translation: {} },
+          en: { translation: {} },
+          'en-US': {
+            translation: {
+              interpolationTest1:
+                'The first 4 letters of the english alphabet are: %s, %s, %s and %s',
+              interpolationTest2:
+                'Hello %(users[0].name)s, %(users[1].name)s and %(users[2].name)s',
+              interpolationTest3: 'The last letter of the english alphabet is %s',
+              interpolationTest4: 'Water freezes at %d degrees',
+            },
+          },
+        };
+
+        beforeEach(function(done) {
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
+        });
+
+        it('it should replace passed in key/values', function() {
+          expect(
+            i18n.t('interpolationTest1', { postProcess: 'sprintf', sprintf: ['a', 'b', 'c', 'd'] }),
+          ).to.be('The first 4 letters of the english alphabet are: a, b, c and d');
+          expect(
+            i18n.t('interpolationTest2', {
+              postProcess: 'sprintf',
+              sprintf: { users: [{ name: 'Dolly' }, { name: 'Molly' }, { name: 'Polly' }] },
+            }),
+          ).to.be('Hello Dolly, Molly and Polly');
+        });
+
+        it('it should recognize the sprintf syntax and automatically add the sprintf processor', function() {
+          expect(i18n.t('interpolationTest1', 'a', 'b', 'c', 'd')).to.be(
+            'The first 4 letters of the english alphabet are: a, b, c and d',
+          );
+          expect(i18n.t('interpolationTest3', 'z')).to.be(
+            'The last letter of the english alphabet is z',
+          );
+          expect(i18n.t('interpolationTest4', 0)).to.be('Water freezes at 0 degrees');
+        });
+      });
+
+      describe('with default variables', function() {
+        var defaultVariables = {
+          name: 'John',
+        };
+
+        beforeEach(function(done) {
+          i18n.init(i18n.functions.extend(opts, { defaultVariables: defaultVariables }), function(
+            t,
+          ) {
+            done();
+          });
         });
 
         it('it should use default variable', function() {
@@ -2138,114 +2378,120 @@ describe('i18next', function() {
         });
 
         it('it should replace default variable', function() {
-          expect(i18n.t('Hello __name__', {name: 'Ben'})).to.be('Hello Ben');
+          expect(i18n.t('Hello __name__', { name: 'Ben' })).to.be('Hello Ben');
         });
-
       });
-
     });
 
     describe('plural usage', function() {
-
       describe('basic usage - singular and plural form', function() {
         var resStore = {
-          dev: { 'ns.2': {
-                pluralTest: 'singular from ns.2',
-                pluralTest_plural: 'plural from ns.2',
-                pluralTestWithCount: '__count__ item from ns.2',
-                pluralTestWithCount_plural: '__count__ items from ns.2'
-            }},
-          en: { },
+          dev: {
+            'ns.2': {
+              pluralTest: 'singular from ns.2',
+              pluralTest_plural: 'plural from ns.2',
+              pluralTestWithCount: '__count__ item from ns.2',
+              pluralTestWithCount_plural: '__count__ items from ns.2',
+            },
+          },
+          en: {},
           'en-US': {
             'ns.1': {
-                pluralTest: 'singular',
-                pluralTest_plural: 'plural',
-                pluralTestWithCount: '__count__ item',
-                pluralTestWithCount_plural: '__count__ items'
-            }
-          }
+              pluralTest: 'singular',
+              pluralTest_plural: 'plural',
+              pluralTestWithCount: '__count__ item',
+              pluralTestWithCount_plural: '__count__ items',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
+          i18n.init(
+            i18n.functions.extend(opts, {
               resStore: resStore,
-              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1'}
+              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1' },
             }),
-            function(t) { done(); });
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide correct plural or singular form', function() {
-          expect(i18n.t('pluralTest', {count: 0})).to.be('plural');
-          expect(i18n.t('pluralTest', {count: 1})).to.be('singular');
-          expect(i18n.t('pluralTest', {count: 2})).to.be('plural');
-          expect(i18n.t('pluralTest', {count: 7})).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 0 })).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 1 })).to.be('singular');
+          expect(i18n.t('pluralTest', { count: 2 })).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 7 })).to.be('plural');
         });
 
         it('it should provide correct plural or singular form with interpolation', function() {
-          expect(i18n.t('pluralTestWithCount', {count: 0})).to.be('0 items');
-          expect(i18n.t('pluralTestWithCount', {count: 1})).to.be('1 item');
-          expect(i18n.t('pluralTestWithCount', {count: 7})).to.be('7 items');
+          expect(i18n.t('pluralTestWithCount', { count: 0 })).to.be('0 items');
+          expect(i18n.t('pluralTestWithCount', { count: 1 })).to.be('1 item');
+          expect(i18n.t('pluralTestWithCount', { count: 7 })).to.be('7 items');
         });
 
         it('it should provide correct plural or singular form for second namespace', function() {
-          expect(i18n.t('ns.2:pluralTest', {count: 0})).to.be('plural from ns.2');
-          expect(i18n.t('ns.2:pluralTest', {count: 1})).to.be('singular from ns.2');
-          expect(i18n.t('ns.2:pluralTest', {count: 2})).to.be('plural from ns.2');
-          expect(i18n.t('ns.2:pluralTest', {count: 7})).to.be('plural from ns.2');
+          expect(i18n.t('ns.2:pluralTest', { count: 0 })).to.be('plural from ns.2');
+          expect(i18n.t('ns.2:pluralTest', { count: 1 })).to.be('singular from ns.2');
+          expect(i18n.t('ns.2:pluralTest', { count: 2 })).to.be('plural from ns.2');
+          expect(i18n.t('ns.2:pluralTest', { count: 7 })).to.be('plural from ns.2');
         });
 
         it('it should provide correct plural or singular form for second namespace with interpolation', function() {
-          expect(i18n.t('ns.2:pluralTestWithCount', {count: 1})).to.be('1 item from ns.2');
-          expect(i18n.t('ns.2:pluralTestWithCount', {count: 7})).to.be('7 items from ns.2');
+          expect(i18n.t('ns.2:pluralTestWithCount', { count: 1 })).to.be('1 item from ns.2');
+          expect(i18n.t('ns.2:pluralTestWithCount', { count: 7 })).to.be('7 items from ns.2');
         });
-
       });
 
       describe('fallback on count with non-plurals', function() {
         var resStore = {
-          dev: { 'ns.2': {
-                pluralTestWithCount: '__count__ item from ns.2'
-            }},
-          en: { },
+          dev: {
+            'ns.2': {
+              pluralTestWithCount: '__count__ item from ns.2',
+            },
+          },
+          en: {},
           'en-US': {
             'ns.1': {
-                pluralTestWithCount: '__count__ item'
-            }
-          }
+              pluralTestWithCount: '__count__ item',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
+          i18n.init(
+            i18n.functions.extend(opts, {
               resStore: resStore,
-              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1'}
+              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1' },
             }),
-            function(t) { done(); });
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide correct singular form', function() {
-          expect(i18n.t('pluralTestWithCount', {count: 0})).to.be('0 item');
-          expect(i18n.t('pluralTestWithCount', {count: 1})).to.be('1 item');
-          expect(i18n.t('pluralTestWithCount', {count: 7})).to.be('7 item');
+          expect(i18n.t('pluralTestWithCount', { count: 0 })).to.be('0 item');
+          expect(i18n.t('pluralTestWithCount', { count: 1 })).to.be('1 item');
+          expect(i18n.t('pluralTestWithCount', { count: 7 })).to.be('7 item');
         });
 
         it('it should provide correct singular form for second namespace', function() {
-          expect(i18n.t('ns.2:pluralTestWithCount', {count: 1})).to.be('1 item from ns.2');
-          expect(i18n.t('ns.2:pluralTestWithCount', {count: 7})).to.be('7 item from ns.2');
+          expect(i18n.t('ns.2:pluralTestWithCount', { count: 1 })).to.be('1 item from ns.2');
+          expect(i18n.t('ns.2:pluralTestWithCount', { count: 7 })).to.be('7 item from ns.2');
         });
-
       });
 
       describe('Plurals with passing lng to translation function', function() {
-
         var resStore = {
-          'nl': {
-            'translation': {
-                pluralTest: 'item',
-                pluralTest_plural: 'items',
-                pluralTestWithCount: '__count__ item',
-                pluralTestWithCount_plural: '__count__ items'
-            }
-          }
+          nl: {
+            translation: {
+              pluralTest: 'item',
+              pluralTest_plural: 'items',
+              pluralTestWithCount: '__count__ item',
+              pluralTestWithCount_plural: '__count__ items',
+            },
+          },
         };
 
         // beforeEach(function(done) {
@@ -2257,198 +2503,216 @@ describe('i18next', function() {
         // });
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-              resStore: resStore
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
             }),
-            function(t) { done(); });
+            function(t) {
+              done();
+            },
+          );
         });
         it('should return the correct string for key', function() {
-          expect(i18n.t('pluralTest', {count: 12, lng: 'nl'})).to.equal('items');
-          expect(i18n.t('pluralTest', {count: 0, lng: 'nl'})).to.equal('items');
+          expect(i18n.t('pluralTest', { count: 12, lng: 'nl' })).to.equal('items');
+          expect(i18n.t('pluralTest', { count: 0, lng: 'nl' })).to.equal('items');
         });
 
         it('should return the correct string for key with count interpoation', function() {
-          expect(i18n.t('pluralTestWithCount', {count: 12, lng: 'nl'})).to.equal('12 items');
-          expect(i18n.t('pluralTestWithCount', {count: 0, lng: 'nl'})).to.equal('0 items');
+          expect(i18n.t('pluralTestWithCount', { count: 12, lng: 'nl' })).to.equal('12 items');
+          expect(i18n.t('pluralTestWithCount', { count: 0, lng: 'nl' })).to.equal('0 items');
         });
       });
 
       describe('basic usage - singular and plural form on fallbacks', function() {
         var resStore = {
-          'fr': {
-            'translation': {}
+          fr: {
+            translation: {},
           },
-          'en': {
-            'translation': {
-                pluralTest: 'singular',
-                pluralTest_plural: 'plural',
-                pluralTestWithCount: '__count__ item',
-                pluralTestWithCount_plural: '__count__ items'
-            }
-          }
+          en: {
+            translation: {
+              pluralTest: 'singular',
+              pluralTest_plural: 'plural',
+              pluralTestWithCount: '__count__ item',
+              pluralTestWithCount_plural: '__count__ items',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore,
-            lng: 'fr',
-            fallbackLng: 'en'
-          }),
-          function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              lng: 'fr',
+              fallbackLng: 'en',
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide correct plural or singular form', function() {
-          expect(i18n.t('pluralTest', {count: 0})).to.be('plural');
-          expect(i18n.t('pluralTest', {count: 1})).to.be('singular');
-          expect(i18n.t('pluralTest', {count: 2})).to.be('plural');
-          expect(i18n.t('pluralTest', {count: 7})).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 0 })).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 1 })).to.be('singular');
+          expect(i18n.t('pluralTest', { count: 2 })).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 7 })).to.be('plural');
         });
 
         it('it should provide correct plural or singular form with count', function() {
-          expect(i18n.t('pluralTestWithCount', {count: 0})).to.be('0 items');
-          expect(i18n.t('pluralTestWithCount', {count: 1})).to.be('1 item');
-          expect(i18n.t('pluralTestWithCount', {count: 7})).to.be('7 items');
+          expect(i18n.t('pluralTestWithCount', { count: 0 })).to.be('0 items');
+          expect(i18n.t('pluralTestWithCount', { count: 1 })).to.be('1 item');
+          expect(i18n.t('pluralTestWithCount', { count: 7 })).to.be('7 items');
         });
-
       });
-
 
       describe('basic usage 2 - singular and plural form in french', function() {
         var resStore = {
-          dev: { 'ns.2': {
-                pluralTest: 'singular from ns.2',
-                pluralTest_plural: 'plural from ns.2',
-                pluralTestWithCount: '__count__ item from ns.2',
-                pluralTestWithCount_plural: '__count__ items from ns.2'
-            }},
-          en: { },
-          'fr': {
+          dev: {
+            'ns.2': {
+              pluralTest: 'singular from ns.2',
+              pluralTest_plural: 'plural from ns.2',
+              pluralTestWithCount: '__count__ item from ns.2',
+              pluralTestWithCount_plural: '__count__ items from ns.2',
+            },
+          },
+          en: {},
+          fr: {
             'ns.1': {
-                pluralTest: 'singular',
-                pluralTest_plural: 'plural',
-                pluralTestWithCount: '__count__ item',
-                pluralTestWithCount_plural: '__count__ items'
-            }
-          }
+              pluralTest: 'singular',
+              pluralTest_plural: 'plural',
+              pluralTestWithCount: '__count__ item',
+              pluralTestWithCount_plural: '__count__ items',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
+          i18n.init(
+            i18n.functions.extend(opts, {
               lng: 'fr',
               resStore: resStore,
-              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1'}
+              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1' },
             }),
-            function(t) { done(); });
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide correct plural or singular form', function() {
-          expect(i18n.t('pluralTest', {count: 0})).to.be('singular');
-          expect(i18n.t('pluralTest', {count: 1})).to.be('singular');
-          expect(i18n.t('pluralTest', {count: 2})).to.be('plural');
-          expect(i18n.t('pluralTest', {count: 7})).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 0 })).to.be('singular');
+          expect(i18n.t('pluralTest', { count: 1 })).to.be('singular');
+          expect(i18n.t('pluralTest', { count: 2 })).to.be('plural');
+          expect(i18n.t('pluralTest', { count: 7 })).to.be('plural');
         });
 
         it('it should provide correct plural or singular form with count', function() {
-          expect(i18n.t('pluralTestWithCount', {count: 0})).to.be('0 item');
-          expect(i18n.t('pluralTestWithCount', {count: 1})).to.be('1 item');
-          expect(i18n.t('pluralTestWithCount', {count: 7})).to.be('7 items');
+          expect(i18n.t('pluralTestWithCount', { count: 0 })).to.be('0 item');
+          expect(i18n.t('pluralTestWithCount', { count: 1 })).to.be('1 item');
+          expect(i18n.t('pluralTestWithCount', { count: 7 })).to.be('7 items');
         });
       });
 
       describe('extended usage - multiple plural forms - ar', function() {
         var resStore = {
-            dev: { translation: { } },
-            ar: { translation: {
-                key: 'singular',
-                key_plural_0: 'zero',
-                key_plural_2: 'two',
-                key_plural_3: 'few',
-                key_plural_11: 'many',
-                key_plural_100: 'plural'
-              }
+          dev: { translation: {} },
+          ar: {
+            translation: {
+              key: 'singular',
+              key_plural_0: 'zero',
+              key_plural_2: 'two',
+              key_plural_3: 'few',
+              key_plural_11: 'many',
+              key_plural_100: 'plural',
             },
-            'ar-??': { translation: { } }
+          },
+          'ar-??': { translation: {} },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { lng: 'ar', resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { lng: 'ar', resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should provide correct plural forms', function() {
-          expect(i18n.t('key', {count: 0})).to.be('zero');
-          expect(i18n.t('key', {count: 1})).to.be('singular');
-          expect(i18n.t('key', {count: 2})).to.be('two');
-          expect(i18n.t('key', {count: 3})).to.be('few');
-          expect(i18n.t('key', {count: 4})).to.be('few');
-          expect(i18n.t('key', {count: 104})).to.be('few');
-          expect(i18n.t('key', {count: 11})).to.be('many');
-          expect(i18n.t('key', {count: 99})).to.be('many');
-          expect(i18n.t('key', {count: 199})).to.be('many');
-          expect(i18n.t('key', {count: 100})).to.be('plural');
+          expect(i18n.t('key', { count: 0 })).to.be('zero');
+          expect(i18n.t('key', { count: 1 })).to.be('singular');
+          expect(i18n.t('key', { count: 2 })).to.be('two');
+          expect(i18n.t('key', { count: 3 })).to.be('few');
+          expect(i18n.t('key', { count: 4 })).to.be('few');
+          expect(i18n.t('key', { count: 104 })).to.be('few');
+          expect(i18n.t('key', { count: 11 })).to.be('many');
+          expect(i18n.t('key', { count: 99 })).to.be('many');
+          expect(i18n.t('key', { count: 199 })).to.be('many');
+          expect(i18n.t('key', { count: 100 })).to.be('plural');
         });
       });
 
       describe('extended usage - multiple plural forms - ru', function() {
         var resStore = {
-            dev: { translation: { } },
-            ru: { translation: {
-                key: '1,21,31',
-                key_plural_2: '2,3,4',
-                key_plural_5: '0,5,6'
-              }
+          dev: { translation: {} },
+          ru: {
+            translation: {
+              key: '1,21,31',
+              key_plural_2: '2,3,4',
+              key_plural_5: '0,5,6',
             },
-            'ru-??': { translation: { } }
+          },
+          'ru-??': { translation: {} },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { lng: 'ru', resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { lng: 'ru', resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should provide correct plural forms', function() {
-          expect(i18n.t('key', {count: 0})).to.be('0,5,6');
-          expect(i18n.t('key', {count: 1})).to.be('1,21,31');
-          expect(i18n.t('key', {count: 2})).to.be('2,3,4');
-          expect(i18n.t('key', {count: 3})).to.be('2,3,4');
-          expect(i18n.t('key', {count: 4})).to.be('2,3,4');
-          expect(i18n.t('key', {count: 104})).to.be('2,3,4');
-          expect(i18n.t('key', {count: 11})).to.be('0,5,6');
-          expect(i18n.t('key', {count: 24})).to.be('2,3,4');
-          expect(i18n.t('key', {count: 25})).to.be('0,5,6');
-          expect(i18n.t('key', {count: 99})).to.be('0,5,6');
-          expect(i18n.t('key', {count: 199})).to.be('0,5,6');
-          expect(i18n.t('key', {count: 100})).to.be('0,5,6');
+          expect(i18n.t('key', { count: 0 })).to.be('0,5,6');
+          expect(i18n.t('key', { count: 1 })).to.be('1,21,31');
+          expect(i18n.t('key', { count: 2 })).to.be('2,3,4');
+          expect(i18n.t('key', { count: 3 })).to.be('2,3,4');
+          expect(i18n.t('key', { count: 4 })).to.be('2,3,4');
+          expect(i18n.t('key', { count: 104 })).to.be('2,3,4');
+          expect(i18n.t('key', { count: 11 })).to.be('0,5,6');
+          expect(i18n.t('key', { count: 24 })).to.be('2,3,4');
+          expect(i18n.t('key', { count: 25 })).to.be('0,5,6');
+          expect(i18n.t('key', { count: 99 })).to.be('0,5,6');
+          expect(i18n.t('key', { count: 199 })).to.be('0,5,6');
+          expect(i18n.t('key', { count: 100 })).to.be('0,5,6');
         });
       });
 
       describe('extended usage - ask for a key in a language with a different plural form', function() {
         var resStore = {
-            en: { translation: {
-                key:'singular_en',
-                key_plural:'plural_en'
-              }
+          en: {
+            translation: {
+              key: 'singular_en',
+              key_plural: 'plural_en',
             },
-            zh: { translation: {
-                key: 'singular_zh'
-              }
-            }
+          },
+          zh: {
+            translation: {
+              key: 'singular_zh',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { lng: 'zh', resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { lng: 'zh', resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should provide translation for passed in language with 1 item', function() {
-          expect(i18n.t('key', { lng: 'en', count:1 })).to.be('singular_en');
+          expect(i18n.t('key', { lng: 'en', count: 1 })).to.be('singular_en');
         });
 
         it('it should provide translation for passed in language with 2 items', function() {
-          expect(i18n.t('key', { lng: 'en', count:2 })).to.be('plural_en');
+          expect(i18n.t('key', { lng: 'en', count: 2 })).to.be('plural_en');
         });
       });
-
     });
 
     describe.skip('[WONT FIX - FIND A BETTER SOLUTION]indefinite article usage', function() {
@@ -2459,168 +2723,194 @@ describe('i18next', function() {
               thing: '__count__ thing from ns.2',
               thing_plural: '__count__ things from ns.2',
               thing_indefinite: 'A thing from ns.2',
-              thing_plural_indefinite: 'Some things from ns.2'
+              thing_plural_indefinite: 'Some things from ns.2',
             },
             'ns.3': {
               thing: '__count__ things',
               thing_indefinite: 'A thing',
-              thing_plural_indefinite: 'Some things'
-            }
+              thing_plural_indefinite: 'Some things',
+            },
           },
-          en: { },
+          en: {},
           'en-US': {
             'ns.1': {
               thing: '__count__ thing',
               thing_plural: '__count__ things',
-              thing_indefinite: 'A thing'
-            }
-          }
+              thing_indefinite: 'A thing',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            resStore: resStore,
-            ns: { namespaces: ['ns.1', 'ns.2', 'ns.3'], defaultNs: 'ns.1'}
-          }), function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              resStore: resStore,
+              ns: { namespaces: ['ns.1', 'ns.2', 'ns.3'], defaultNs: 'ns.1' },
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide the indefinite article when requested for singular forms', function() {
           expect(i18n.t('thing')).to.be('__count__ thing');
-          expect(i18n.t('thing', {indefinite_article: true})).to.be('A thing');
-          expect(i18n.t('thing', {count:1})).to.be('1 thing');
-          expect(i18n.t('thing', {count:5})).to.be('5 things');
-          expect(i18n.t('thing', {count:1, indefinite_article: true})).to.be('A thing');
-          expect(i18n.t('thing', {count:5, indefinite_article: true})).to.be('5 things');
+          expect(i18n.t('thing', { indefinite_article: true })).to.be('A thing');
+          expect(i18n.t('thing', { count: 1 })).to.be('1 thing');
+          expect(i18n.t('thing', { count: 5 })).to.be('5 things');
+          expect(i18n.t('thing', { count: 1, indefinite_article: true })).to.be('A thing');
+          expect(i18n.t('thing', { count: 5, indefinite_article: true })).to.be('5 things');
         });
 
         it('it should provide the indefinite article when requested for singular forms for second namespace', function() {
-          expect(i18n.t('ns.2:thing', {count:1})).to.be('1 thing from ns.2');
-          expect(i18n.t('ns.2:thing', {count:5})).to.be('5 things from ns.2');
-          expect(i18n.t('ns.2:thing', {count:1, indefinite_article: true})).to.be('A thing from ns.2');
-          expect(i18n.t('ns.2:thing', {count:5, indefinite_article: true})).to.be('Some things from ns.2');
+          expect(i18n.t('ns.2:thing', { count: 1 })).to.be('1 thing from ns.2');
+          expect(i18n.t('ns.2:thing', { count: 5 })).to.be('5 things from ns.2');
+          expect(i18n.t('ns.2:thing', { count: 1, indefinite_article: true })).to.be(
+            'A thing from ns.2',
+          );
+          expect(i18n.t('ns.2:thing', { count: 5, indefinite_article: true })).to.be(
+            'Some things from ns.2',
+          );
         });
 
         it('it should provide the right indefinite translations from the third namespace', function() {
-          expect(i18n.t('ns.3:thing', {count:5})).to.be('5 things');
-          expect(i18n.t('ns.3:thing', {count:1, indefinite_article: true})).to.be('A thing');
-          expect(i18n.t('ns.3:thing', {count:5, indefinite_article: true})).to.be('Some things')
+          expect(i18n.t('ns.3:thing', { count: 5 })).to.be('5 things');
+          expect(i18n.t('ns.3:thing', { count: 1, indefinite_article: true })).to.be('A thing');
+          expect(i18n.t('ns.3:thing', { count: 5, indefinite_article: true })).to.be('Some things');
         });
       });
 
       describe('extended usage - indefinite articles in languages with different plural forms', function() {
         var resStore = {
           dev: {
-            translation: {
-            }
+            translation: {},
           },
           zh: {
             translation: {
-              key: "__count__ thing",
-              key_indefinite: "a thing"
-            }
-          }
+              key: '__count__ thing',
+              key_indefinite: 'a thing',
+            },
+          },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
-            lng: 'zh',
-            resStore: resStore
-          }), function(t) { done(); });
+          i18n.init(
+            i18n.functions.extend(opts, {
+              lng: 'zh',
+              resStore: resStore,
+            }),
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide the correct indefinite articles', function() {
-          expect(i18n.t('key', {count: 1})).to.be('1 thing');
-          expect(i18n.t('key', {count: 5})).to.be('5 thing');
-          expect(i18n.t('key', {count: 1, indefinite_article: true})).to.be('a thing');
-          expect(i18n.t('key', {count: 5, indefinite_article: true})).to.be('a thing');
+          expect(i18n.t('key', { count: 1 })).to.be('1 thing');
+          expect(i18n.t('key', { count: 5 })).to.be('5 thing');
+          expect(i18n.t('key', { count: 1, indefinite_article: true })).to.be('a thing');
+          expect(i18n.t('key', { count: 5, indefinite_article: true })).to.be('a thing');
         });
       });
     });
 
     describe('context usage', function() {
-
       describe('basic usage', function() {
         var resStore = {
-            dev: { 'ns.2': {
-                friend_context: 'A friend from ns2',
-                friend_context_male: 'A boyfriend from ns2',
-                friend_context_female: 'A girlfriend from ns2'
-              }
+          dev: {
+            'ns.2': {
+              friend_context: 'A friend from ns2',
+              friend_context_male: 'A boyfriend from ns2',
+              friend_context_female: 'A girlfriend from ns2',
             },
-            en: { 'ns.1': {
-                friend_context: 'A friend',
-                friend_context_male: 'A boyfriend',
-                friend_context_female: 'A girlfriend'
-              }
+          },
+          en: {
+            'ns.1': {
+              friend_context: 'A friend',
+              friend_context_male: 'A boyfriend',
+              friend_context_female: 'A girlfriend',
             },
-            'en-US': { translation: { } }
+          },
+          'en-US': { translation: {} },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, {
+          i18n.init(
+            i18n.functions.extend(opts, {
               resStore: resStore,
-              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1'}
+              ns: { namespaces: ['ns.1', 'ns.2'], defaultNs: 'ns.1' },
             }),
-            function(t) { done(); });
+            function(t) {
+              done();
+            },
+          );
         });
 
         it('it should provide correct context form', function() {
           expect(i18n.t('friend_context')).to.be('A friend');
-          expect(i18n.t('friend_context', {context: ''})).to.be('A friend');
-          expect(i18n.t('friend_context', {context: 'male'})).to.be('A boyfriend');
-          expect(i18n.t('friend_context', {context: 'female'})).to.be('A girlfriend');
+          expect(i18n.t('friend_context', { context: '' })).to.be('A friend');
+          expect(i18n.t('friend_context', { context: 'male' })).to.be('A boyfriend');
+          expect(i18n.t('friend_context', { context: 'female' })).to.be('A girlfriend');
         });
 
         it('it should provide correct context form for second namespace', function() {
           expect(i18n.t('ns.2:friend_context')).to.be('A friend from ns2');
-          expect(i18n.t('ns.2:friend_context', {context: ''})).to.be('A friend from ns2');
-          expect(i18n.t('ns.2:friend_context', {context: 'male'})).to.be('A boyfriend from ns2');
-          expect(i18n.t('ns.2:friend_context', {context: 'female'})).to.be('A girlfriend from ns2');
+          expect(i18n.t('ns.2:friend_context', { context: '' })).to.be('A friend from ns2');
+          expect(i18n.t('ns.2:friend_context', { context: 'male' })).to.be('A boyfriend from ns2');
+          expect(i18n.t('ns.2:friend_context', { context: 'female' })).to.be(
+            'A girlfriend from ns2',
+          );
         });
       });
 
       describe('extended usage - in combination with plurals', function() {
         var resStore = {
-            dev: { translation: { } },
-            en: { translation: {
-                friend_context: '__count__ friend',
-                friend_context_male: '__count__ boyfriend',
-                friend_context_female: '__count__ girlfriend',
-                friend_context_plural: '__count__ friends',
-                friend_context_male_plural: '__count__ boyfriends',
-                friend_context_female_plural: '__count__ girlfriends'
-              }
+          dev: { translation: {} },
+          en: {
+            translation: {
+              friend_context: '__count__ friend',
+              friend_context_male: '__count__ boyfriend',
+              friend_context_female: '__count__ girlfriend',
+              friend_context_plural: '__count__ friends',
+              friend_context_male_plural: '__count__ boyfriends',
+              friend_context_female_plural: '__count__ girlfriends',
             },
-            'en-US': { translation: { } }
+          },
+          'en-US': { translation: {} },
         };
 
         beforeEach(function(done) {
-          i18n.init(i18n.functions.extend(opts, { resStore: resStore }),
-            function(t) { done(); });
+          i18n.init(i18n.functions.extend(opts, { resStore: resStore }), function(t) {
+            done();
+          });
         });
 
         it('it should provide correct context with plural forms', function() {
           expect(i18n.t('friend_context', { count: 1 })).to.be('1 friend');
-          expect(i18n.t('friend_context', {context: '', count: 1 })).to.be('1 friend');
-          expect(i18n.t('friend_context', {context: 'male', count: 1 })).to.be('1 boyfriend');
-          expect(i18n.t('friend_context', {context: 'female', count: 1 })).to.be('1 girlfriend');
+          expect(i18n.t('friend_context', { context: '', count: 1 })).to.be('1 friend');
+          expect(i18n.t('friend_context', { context: 'male', count: 1 })).to.be('1 boyfriend');
+          expect(i18n.t('friend_context', { context: 'female', count: 1 })).to.be('1 girlfriend');
 
           expect(i18n.t('friend_context', { count: 10 })).to.be('10 friends');
-          expect(i18n.t('friend_context', {context: '', count: 10 })).to.be('10 friends');
-          expect(i18n.t('friend_context', {context: 'male', count: 10 })).to.be('10 boyfriends');
-          expect(i18n.t('friend_context', {context: 'female', count: 10 })).to.be('10 girlfriends');
+          expect(i18n.t('friend_context', { context: '', count: 10 })).to.be('10 friends');
+          expect(i18n.t('friend_context', { context: 'male', count: 10 })).to.be('10 boyfriends');
+          expect(i18n.t('friend_context', { context: 'female', count: 10 })).to.be(
+            '10 girlfriends',
+          );
         });
-
       });
-
     });
 
     describe('with passed in languages different from set one', function() {
-
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, {
-            preload: ['de-DE'] }),
-          function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, {
+            preload: ['de-DE'],
+          }),
+          function(t) {
+            done();
+          },
+        );
       });
 
       it('it should provide translation for passed in language', function() {
@@ -2628,40 +2918,36 @@ describe('i18next', function() {
       });
 
       describe.skip('[WONT FIX - HARD DEPRECATION OF SYNC LOADING]with language not preloaded', function() {
-
         it('it should provide translation for passed in language after loading file sync', function() {
           var expectedValue = i18n.clientVersion ? 'simple_fr' : 'ok_from_fr';
           expect(i18n.t('simple_fr', { lng: 'fr' })).to.be(expectedValue);
         });
-
       });
-
     });
 
     describe('using sprintf', function() {
-
       var resStore = {
-        dev: { translation: {  } },
-        en: { translation: {  } },
+        dev: { translation: {} },
+        en: { translation: {} },
         'en-US': {
           translation: {
-            test: 'hi'
-          }
-        }
+            test: 'hi',
+          },
+        },
       };
 
       beforeEach(function(done) {
-        i18n.init(i18n.functions.extend(opts, { resStore: resStore, shortcutFunction: 'defaultValue' }),
-          function(t) { done(); });
+        i18n.init(
+          i18n.functions.extend(opts, { resStore: resStore, shortcutFunction: 'defaultValue' }),
+          function(t) {
+            done();
+          },
+        );
       });
-
 
       it('it should recognize the defaultValue syntax set as shortcutFunction', function() {
         expect(i18n.t('notFound', 'second param defaultValue')).to.be('second param defaultValue');
       });
-
     });
-
   });
-
 });

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -1,26 +1,24 @@
 import EventEmitter from '../src/EventEmitter';
 
 describe('i18next', () => {
-
   describe('published', () => {
-
     let emitter;
     beforeEach(() => {
       emitter = new EventEmitter();
     });
 
-    it('it should emit', (done) => {
+    it('it should emit', done => {
       // test on
-      emitter.on('ok', (payload) => {
+      emitter.on('ok', payload => {
         expect(payload).to.equal('data ok');
         done();
       });
 
       // test off
-      const nok = (payload) => {
+      const nok = payload => {
         expect(payload).to.equal('not called as off');
         done();
-      }
+      };
       emitter.on('nok', nok);
       emitter.off('nok', nok);
 
@@ -28,7 +26,7 @@ describe('i18next', () => {
       emitter.emit('ok', 'data ok');
     });
 
-    it('it should emit wildcard', (done) => {
+    it('it should emit wildcard', done => {
       // test on
       emitter.on('*', (name, payload) => {
         expect(name).to.equal('ok');
@@ -39,7 +37,7 @@ describe('i18next', () => {
       emitter.emit('ok', 'data ok');
     });
 
-    it('it should emit with array params', (done) => {
+    it('it should emit with array params', done => {
       // test on
       emitter.on('array-event', (array, data) => {
         expect(array).to.eql(['array ok 1', 'array ok 2']);
@@ -50,7 +48,7 @@ describe('i18next', () => {
       emitter.emit('array-event', ['array ok 1', 'array ok 2'], 'data ok');
     });
 
-    it('it should emit wildcard with array params', (done) => {
+    it('it should emit wildcard with array params', done => {
       // test on
       emitter.on('*', (ev, array, data) => {
         expect(ev).to.equal('array-event');
@@ -69,5 +67,4 @@ describe('i18next', () => {
       expect(returned).to.equal(emitter);
     });
   });
-
 });

--- a/test/i18next.defaults.spec.js
+++ b/test/i18next.defaults.spec.js
@@ -2,45 +2,87 @@ import * as defaultFc from '../src/defaults';
 const defaults = defaultFc.get();
 
 describe('defaults', () => {
-
   it('it should have default shortcut', () => {
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value'])).to.eql({ defaultValue: 'my default value' });
+    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value'])).to.eql({
+      defaultValue: 'my default value',
+    });
   });
 
   it('defaultValue as option', () => {
-    console.log(defaults.overloadTranslationOptionHandler(['key', { defaultValue: 'option default value' }]));
-    expect(defaults.overloadTranslationOptionHandler(['key', { defaultValue: 'option default value' }])).to.eql({ defaultValue: 'option default value' });
+    console.log(
+      defaults.overloadTranslationOptionHandler(['key', { defaultValue: 'option default value' }]),
+    );
+    expect(
+      defaults.overloadTranslationOptionHandler(['key', { defaultValue: 'option default value' }]),
+    ).to.eql({ defaultValue: 'option default value' });
   });
 
   it('description', () => {
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value', 'the description'])).to.eql({ defaultValue: 'my default value', tDescription: 'the description' });
+    expect(
+      defaults.overloadTranslationOptionHandler(['key', 'my default value', 'the description']),
+    ).to.eql({ defaultValue: 'my default value', tDescription: 'the description' });
   });
 
   it('description with options defaultValue', () => {
     // Options overwrites params default value
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value', 'the description'])).to.eql({ defaultValue: 'my default value', tDescription: 'the description' });
+    expect(
+      defaults.overloadTranslationOptionHandler(['key', 'my default value', 'the description']),
+    ).to.eql({ defaultValue: 'my default value', tDescription: 'the description' });
   });
 
   it('interpolation', () => {
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value {{params}}', {params: 'the value'}])).to.eql({ defaultValue: 'my default value {{params}}', params: 'the value' });
+    expect(
+      defaults.overloadTranslationOptionHandler([
+        'key',
+        'my default value {{params}}',
+        { params: 'the value' },
+      ]),
+    ).to.eql({ defaultValue: 'my default value {{params}}', params: 'the value' });
   });
 
   it('interpolation with options defaultValue', () => {
     // Options overwrites params default value
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value {{params}}', {defaultValue: 'options default value', params: 'the value'}])).to.eql({ defaultValue: 'options default value', params: 'the value' });
+    expect(
+      defaults.overloadTranslationOptionHandler([
+        'key',
+        'my default value {{params}}',
+        { defaultValue: 'options default value', params: 'the value' },
+      ]),
+    ).to.eql({ defaultValue: 'options default value', params: 'the value' });
   });
 
   it('interpolation description', () => {
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value {{params}}', 'the description', {params: 'the value'}])).to.eql({ defaultValue: 'my default value {{params}}', params: 'the value', tDescription: 'the description' });
+    expect(
+      defaults.overloadTranslationOptionHandler([
+        'key',
+        'my default value {{params}}',
+        'the description',
+        { params: 'the value' },
+      ]),
+    ).to.eql({
+      defaultValue: 'my default value {{params}}',
+      params: 'the value',
+      tDescription: 'the description',
+    });
   });
 
   it('interpolation description with options defaultValue', () => {
     // Options overwrites params default value
-    expect(defaults.overloadTranslationOptionHandler(['key', 'my default value {{params}}', 'the description', {defaultValue: 'options default value', params: 'the value'}])).to.eql({ defaultValue: 'options default value', params: 'the value', tDescription: 'the description' });
+    expect(
+      defaults.overloadTranslationOptionHandler([
+        'key',
+        'my default value {{params}}',
+        'the description',
+        { defaultValue: 'options default value', params: 'the value' },
+      ]),
+    ).to.eql({
+      defaultValue: 'options default value',
+      params: 'the value',
+      tDescription: 'the description',
+    });
   });
 
   it('it should have default format function', () => {
     expect(defaults.interpolation.format('my value', '###', 'de')).to.equal('my value');
   });
-
 });

--- a/test/i18next.promises.spec.js
+++ b/test/i18next.promises.spec.js
@@ -1,64 +1,51 @@
 import i18next from '../src/i18next.js';
 
 describe('i18next', () => {
-
   describe('promise based api', () => {
-
     describe('init()', () => {
-      it('it should return a promise', (done) => {
-        i18next
-          .init()
-          .then((t) => {
-            expect(typeof t).to.equal('function');
-            done();
-          });
+      it('it should return a promise', done => {
+        i18next.init().then(t => {
+          expect(typeof t).to.equal('function');
+          done();
+        });
       });
     });
 
     describe('changeLanguage()', () => {
-      it('it should return a promise', (done) => {
+      it('it should return a promise', done => {
         i18next.init();
-        i18next
-          .changeLanguage()
-          .then((t) => {
-            expect(typeof t).to.equal('function');
-            done();
-          });
+        i18next.changeLanguage().then(t => {
+          expect(typeof t).to.equal('function');
+          done();
+        });
       });
     });
 
     describe('loadLanguages()', () => {
-      it('it should return a promise', (done) => {
+      it('it should return a promise', done => {
         i18next.init();
-        i18next
-          .loadLanguages('en')
-          .then(() => {
-            done();
-          });
+        i18next.loadLanguages('en').then(() => {
+          done();
+        });
       });
     });
 
     describe('loadNamespaces()', () => {
-      it('it should return a promise', (done) => {
+      it('it should return a promise', done => {
         i18next.init();
-        i18next
-          .loadNamespaces('common')
-          .then(() => {
-            done();
-          });
+        i18next.loadNamespaces('common').then(() => {
+          done();
+        });
       });
     });
 
     describe('reloadResources()', () => {
-      it('it should return a promise', (done) => {
+      it('it should return a promise', done => {
         i18next.init();
-        i18next
-          .reloadResources()
-          .then(() => {
-            done();
-          });
+        i18next.reloadResources().then(() => {
+          done();
+        });
       });
     });
-
   });
 });

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -1,11 +1,10 @@
 import i18next from '../src/i18next.js';
 
 describe('i18next', () => {
-
   before(() => {
     i18next.init({
       foo: 'bar',
-      debug: false
+      debug: false,
     });
     i18next.changeLanguage('en');
   });
@@ -14,7 +13,7 @@ describe('i18next', () => {
     describe('createInstance()', () => {
       let newInstance;
       before(() => {
-        newInstance = i18next.createInstance({bar: 'foo'});
+        newInstance = i18next.createInstance({ bar: 'foo' });
       });
 
       it('it should not inherit options from inital i18next', () => {
@@ -30,7 +29,7 @@ describe('i18next', () => {
     describe('cloneInstance()', () => {
       let newInstance;
       before(() => {
-        newInstance = i18next.cloneInstance({bar: 'foo'});
+        newInstance = i18next.cloneInstance({ bar: 'foo' });
       });
 
       it('it should inherit options from inital i18next', () => {
@@ -56,7 +55,7 @@ describe('i18next', () => {
     describe('create/cloneInstance()', () => {
       let instance1;
       let instance2;
-      before((done) => {
+      before(done => {
         instance1 = i18next.createInstance({ lng: 'en' }, () => {
           instance2 = instance1.cloneInstance({ lng: 'de' }, () => done());
         });
@@ -68,5 +67,4 @@ describe('i18next', () => {
       });
     });
   });
-
 });

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -1,26 +1,28 @@
 import Interpolator from '../src/Interpolator';
 
 describe('Interpolator', () => {
-
   describe('interpolate()', () => {
     var ip;
 
     before(() => {
-      ip = new Interpolator({interpolation: { escapeValue: false }});
+      ip = new Interpolator({ interpolation: { escapeValue: false } });
     });
 
     var tests = [
-      {args: ['test', {test: '123'}], expected: 'test'},
-      {args: ['test {{test}}', {test: '123'}], expected: 'test 123'},
-      {args: ['test {{test}} a {{bit.more}}', {test: '123', bit: {more: '456'}}], expected: 'test 123 a 456'},
-      {args: ['test {{ test }}', {test: '123'}], expected: 'test 123'},
-      {args: ['test {{ test }}', {test: null}], expected: 'test '},
-      {args: ['test {{ test }}', {test: undefined}], expected: 'test '},
-      {args: ['test {{ test }}', {}], expected: 'test '},
-      {args: ['test {{test.deep}}', {test: {deep: '123'}}], expected: 'test 123'}
+      { args: ['test', { test: '123' }], expected: 'test' },
+      { args: ['test {{test}}', { test: '123' }], expected: 'test 123' },
+      {
+        args: ['test {{test}} a {{bit.more}}', { test: '123', bit: { more: '456' } }],
+        expected: 'test 123 a 456',
+      },
+      { args: ['test {{ test }}', { test: '123' }], expected: 'test 123' },
+      { args: ['test {{ test }}', { test: null }], expected: 'test ' },
+      { args: ['test {{ test }}', { test: undefined }], expected: 'test ' },
+      { args: ['test {{ test }}', {}], expected: 'test ' },
+      { args: ['test {{test.deep}}', { test: { deep: '123' } }], expected: 'test 123' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -30,57 +32,91 @@ describe('Interpolator', () => {
   describe('interpolate() - options', () => {
     var tests = [
       {
-        options: {interpolation: {}},
-        expected: {escapeValue: true, prefix: '{{', suffix: '}}', formatSeparator: ',', unescapePrefix: '-', unescapeSuffix: '', nestingPrefix: '\\$t\\(', nestingSuffix: '\\)' }
+        options: { interpolation: {} },
+        expected: {
+          escapeValue: true,
+          prefix: '{{',
+          suffix: '}}',
+          formatSeparator: ',',
+          unescapePrefix: '-',
+          unescapeSuffix: '',
+          nestingPrefix: '\\$t\\(',
+          nestingSuffix: '\\)',
+        },
       },
       {
         options: {},
-        expected: {escapeValue: true, prefix: '{{', suffix: '}}', formatSeparator: ',', unescapePrefix: '-', unescapeSuffix: '', nestingPrefix: '\\$t\\(', nestingSuffix: '\\)' }
+        expected: {
+          escapeValue: true,
+          prefix: '{{',
+          suffix: '}}',
+          formatSeparator: ',',
+          unescapePrefix: '-',
+          unescapeSuffix: '',
+          nestingPrefix: '\\$t\\(',
+          nestingSuffix: '\\)',
+        },
       },
       {
         description: 'uses and regex escapes prefix and suffix',
-        options: {interpolation: {prefix: '(*(', suffix: ')*)', prefixEscaped: '\\(\\^\\(', suffixEscaped: ')\\^\\)'}},
-        expected: {prefix: '\\(\\*\\(', suffix: '\\)\\*\\)'}
+        options: {
+          interpolation: {
+            prefix: '(*(',
+            suffix: ')*)',
+            prefixEscaped: '\\(\\^\\(',
+            suffixEscaped: ')\\^\\)',
+          },
+        },
+        expected: { prefix: '\\(\\*\\(', suffix: '\\)\\*\\)' },
       },
       {
         description: 'uses prefixEscaped and suffixEscaped if prefix and suffix not provided',
-        options: {interpolation: {prefixEscaped: '<<', suffixEscaped: '>>'}},
-        expected: {prefix: '<<', suffix: '>>'}
+        options: { interpolation: { prefixEscaped: '<<', suffixEscaped: '>>' } },
+        expected: { prefix: '<<', suffix: '>>' },
       },
       {
         description: 'uses unescapePrefix if provided',
-        options: {interpolation: {unescapePrefix: '=>'}},
-        expected: {unescapePrefix: '=>', unescapeSuffix: ''}
+        options: { interpolation: { unescapePrefix: '=>' } },
+        expected: { unescapePrefix: '=>', unescapeSuffix: '' },
       },
       {
         description: 'uses unescapeSuffix if provided',
-        options: {interpolation: {unescapeSuffix: '<='}},
-        expected: {unescapePrefix: '', unescapeSuffix: '<='}
+        options: { interpolation: { unescapeSuffix: '<=' } },
+        expected: { unescapePrefix: '', unescapeSuffix: '<=' },
       },
       {
         description: 'uses unescapeSuffix if both unescapePrefix and unescapeSuffix are provided',
-        options: {interpolation: {unescapePrefix: '=>', unescapeSuffix: '<='}},
-        expected: {unescapePrefix: '', unescapeSuffix: '<='}
+        options: { interpolation: { unescapePrefix: '=>', unescapeSuffix: '<=' } },
+        expected: { unescapePrefix: '', unescapeSuffix: '<=' },
       },
       {
         description: 'uses and regex escapes nestingPrefix and nestingSuffix',
-        options: {interpolation: {nestingPrefix: 'nest(', nestingSuffix: ')nest', nestingPrefixEscaped: 'neste\\(', nestingSuffixEscaped: '\\)neste'}},
-        expected: {nestingPrefix: 'nest\\(', nestingSuffix: '\\)nest'}
+        options: {
+          interpolation: {
+            nestingPrefix: 'nest(',
+            nestingSuffix: ')nest',
+            nestingPrefixEscaped: 'neste\\(',
+            nestingSuffixEscaped: '\\)neste',
+          },
+        },
+        expected: { nestingPrefix: 'nest\\(', nestingSuffix: '\\)nest' },
       },
       {
-        description: 'uses nestingPrefixEscaped and nestingSuffixEscaped if nestingPrefix and nestingSuffix not provided',
-        options: {interpolation: {nestingPrefixEscaped: 'neste\\(', nestingSuffixEscaped: '\\)neste'}},
-        expected: {nestingPrefix: 'neste\\(', nestingSuffix: '\\)neste'}
+        description:
+          'uses nestingPrefixEscaped and nestingSuffixEscaped if nestingPrefix and nestingSuffix not provided',
+        options: {
+          interpolation: { nestingPrefixEscaped: 'neste\\(', nestingSuffixEscaped: '\\)neste' },
+        },
+        expected: { nestingPrefix: 'neste\\(', nestingSuffix: '\\)neste' },
       },
       {
         description: 'uses maxReplaces if provided',
-        options: { interpolation: { maxReplaces: 100}},
-        expected: { maxReplaces: 100}
-      }
+        options: { interpolation: { maxReplaces: 100 } },
+        expected: { maxReplaces: 100 },
+      },
     ];
 
-    tests.forEach((test) => {
-
+    tests.forEach(test => {
       describe(test.description || 'when called with ' + JSON.stringify(test.options), () => {
         var ip;
 
@@ -88,7 +124,7 @@ describe('Interpolator', () => {
           ip = new Interpolator(test.options);
         });
 
-        Object.keys(test.expected).forEach((key) => {
+        Object.keys(test.expected).forEach(key => {
           it(key + ' is set correctly', () => {
             expect(ip[key]).to.eql(test.expected[key]);
           });
@@ -109,17 +145,17 @@ describe('Interpolator', () => {
             if (format === 'lowercase') return value.toLowerCase();
             if (format === 'throw') throw new Error('Formatter error');
             return value;
-          }
-        }
+          },
+        },
       });
     });
 
     var tests = [
-      {args: ['test {{test, uppercase}}', {test: 'up'}], expected: 'test UP'},
-      {args: ['test {{test, lowercase}}', {test: 'DOWN'}], expected: 'test down'}
+      { args: ['test {{test, uppercase}}', { test: 'up' }], expected: 'test UP' },
+      { args: ['test {{test, lowercase}}', { test: 'DOWN' }], expected: 'test down' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -127,7 +163,7 @@ describe('Interpolator', () => {
 
     it('correctly manage exception in formatter', () => {
       expect(() => {
-        ip.interpolate.apply(ip,  ['test {{test, throw}}', {test: 'up'}])
+        ip.interpolate.apply(ip, ['test {{test, throw}}', { test: 'up' }]);
       }).to.throw(Error, 'Formatter error');
 
       const test = tests[0];
@@ -146,16 +182,14 @@ describe('Interpolator', () => {
           format: function(value, format, lng) {
             if (format === 'uppercase') return value.toUpperCase();
             return value;
-          }
-        }
+          },
+        },
       });
     });
 
-    var tests = [
-      {args: ['test {{test | uppercase}}', {test: 'up'}], expected: 'test UP'}
-    ];
+    var tests = [{ args: ['test {{test | uppercase}}', { test: 'up' }], expected: 'test UP' }];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -170,13 +204,28 @@ describe('Interpolator', () => {
     });
 
     var tests = [
-      {args: ['test {{test}}', {test: '<a>foo</a>'}], expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;'},
-      {args: ['test {{test.deep}}', {test: {deep: '<a>foo</a>'}}], expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;'},
-      {args: ['test {{- test.deep}}', {test: {deep: '<a>foo</a>'}}], expected: 'test <a>foo</a>'},
-      {args: ['test {{- test}} {{- test2}} {{- test3}}', {test:' ', test2: '<span>test2</span>', test3:'<span>test3</span>'}], expected: 'test   <span>test2</span> <span>test3</span>'},
+      {
+        args: ['test {{test}}', { test: '<a>foo</a>' }],
+        expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;',
+      },
+      {
+        args: ['test {{test.deep}}', { test: { deep: '<a>foo</a>' } }],
+        expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;',
+      },
+      {
+        args: ['test {{- test.deep}}', { test: { deep: '<a>foo</a>' } }],
+        expected: 'test <a>foo</a>',
+      },
+      {
+        args: [
+          'test {{- test}} {{- test2}} {{- test3}}',
+          { test: ' ', test2: '<span>test2</span>', test3: '<span>test3</span>' },
+        ],
+        expected: 'test   <span>test2</span> <span>test3</span>',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -191,12 +240,36 @@ describe('Interpolator', () => {
     });
 
     var tests = [
-      {args: ['test $t(test)', function() { return 'success'; }], expected: 'test success'},
-      {args: ['$t(test, {"key": "success"})', function(key, opts) { return 'test ' + opts.key; }], expected: 'test success'},
-      {args: ['$t(test, {\'key\': \'success\'})', function(key, opts) { return 'test ' + opts.key }], expected: 'test success'}
+      {
+        args: [
+          'test $t(test)',
+          function() {
+            return 'success';
+          },
+        ],
+        expected: 'test success',
+      },
+      {
+        args: [
+          '$t(test, {"key": "success"})',
+          function(key, opts) {
+            return 'test ' + opts.key;
+          },
+        ],
+        expected: 'test success',
+      },
+      {
+        args: [
+          "$t(test, {'key': 'success'})",
+          function(key, opts) {
+            return 'test ' + opts.key;
+          },
+        ],
+        expected: 'test success',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly nests for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.nest.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -207,25 +280,39 @@ describe('Interpolator', () => {
     var ip;
 
     before(() => {
-      ip = new Interpolator({interpolation: {
-        escapeValue: true,
-        prefix: '__',
-        suffix: '__',
-        unescapeSuffix: 'HTML'
-      }});
+      ip = new Interpolator({
+        interpolation: {
+          escapeValue: true,
+          prefix: '__',
+          suffix: '__',
+          unescapeSuffix: 'HTML',
+        },
+      });
     });
 
     var tests = [
-      {args: ['test __test__', {test: '123'}], expected: 'test 123'},
-      {args: ['test __test__ a __bit.more__', {test: '123', bit: {more: '456'}}], expected: 'test 123 a 456'},
-      {args: ['test __ test __', {test: '123'}], expected: 'test 123'},
-      {args: ['test __test.deep__', {test: {deep: '123'}}], expected: 'test 123'},
-      {args: ['test __test__', {test: '<a>foo</a>'}], expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;'},
-      {args: ['test __test.deep__', {test: {deep: '<a>foo</a>'}}], expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;'},
-      {args: ['test __test.deepHTML__', {test: {deep: '<a>foo</a>'}}], expected: 'test <a>foo</a>'},
+      { args: ['test __test__', { test: '123' }], expected: 'test 123' },
+      {
+        args: ['test __test__ a __bit.more__', { test: '123', bit: { more: '456' } }],
+        expected: 'test 123 a 456',
+      },
+      { args: ['test __ test __', { test: '123' }], expected: 'test 123' },
+      { args: ['test __test.deep__', { test: { deep: '123' } }], expected: 'test 123' },
+      {
+        args: ['test __test__', { test: '<a>foo</a>' }],
+        expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;',
+      },
+      {
+        args: ['test __test.deep__', { test: { deep: '<a>foo</a>' } }],
+        expected: 'test &lt;a&gt;foo&lt;&#x2F;a&gt;',
+      },
+      {
+        args: ['test __test.deepHTML__', { test: { deep: '<a>foo</a>' } }],
+        expected: 'test <a>foo</a>',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
@@ -236,27 +323,31 @@ describe('Interpolator', () => {
     var ip;
 
     before(() => {
-      ip = new Interpolator({interpolation: {
-        maxReplaces: 10
-      }});
+      ip = new Interpolator({
+        interpolation: {
+          maxReplaces: 10,
+        },
+      });
     });
 
     var tests = [
-      { args: ['test {{test}}', { test: 'tested {{test}}' }], expected: 'test tested tested tested tested tested tested tested tested tested tested {{test}}' }
+      {
+        args: ['test {{test}}', { test: 'tested {{test}}' }],
+        expected:
+          'test tested tested tested tested tested tested tested tested tested tested {{test}}',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });
     });
   });
 
-  describe("interpolate() - with undefined interpolation value", () => {
+  describe('interpolate() - with undefined interpolation value', () => {
     var ip;
-    var tests = [
-      {args: ['{{test}}'], expected: ''},
-    ];
+    var tests = [{ args: ['{{test}}'], expected: '' }];
 
     before(() => {
       ip = new Interpolator({
@@ -264,22 +355,23 @@ describe('Interpolator', () => {
           expect(str).to.eql('{{test}}');
           expect(match[0]).to.eql('{{test}}');
           expect(match[1]).to.eql('test');
-        }
+        },
       });
     });
 
-    tests.forEach((test) => {
-      it('correctly calls missingInterpolationHandler for ' + JSON.stringify(test.args) + ' args', () => {
-        expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
-      });
+    tests.forEach(test => {
+      it(
+        'correctly calls missingInterpolationHandler for ' + JSON.stringify(test.args) + ' args',
+        () => {
+          expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
+        },
+      );
     });
   });
 
-  describe("interpolate() - with undefined interpolation value - filled by missingInterpolationHandler", () => {
+  describe('interpolate() - with undefined interpolation value - filled by missingInterpolationHandler', () => {
     var ip;
-    var tests = [
-      {args: ['{{test}}'], expected: 'test'},
-    ];
+    var tests = [{ args: ['{{test}}'], expected: 'test' }];
 
     before(() => {
       ip = new Interpolator({
@@ -288,38 +380,41 @@ describe('Interpolator', () => {
           expect(match[0]).to.eql('{{test}}');
           expect(match[1]).to.eql('test');
           return 'test';
-        }
+        },
       });
     });
 
-    tests.forEach((test) => {
-      it('correctly calls missingInterpolationHandler for ' + JSON.stringify(test.args) + ' args', () => {
-        expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
-      });
+    tests.forEach(test => {
+      it(
+        'correctly calls missingInterpolationHandler for ' + JSON.stringify(test.args) + ' args',
+        () => {
+          expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
+        },
+      );
     });
 
     it('correctly calls handler provided via options', () => {
-      expect(ip.interpolate('{{custom}}', {}, null, {
-        missingInterpolationHandler: (str, match) => 'overridden',
-      })).to.eql('overridden');
+      expect(
+        ip.interpolate('{{custom}}', {}, null, {
+          missingInterpolationHandler: (str, match) => 'overridden',
+        }),
+      ).to.eql('overridden');
     });
   });
 
-  describe("interpolate() - with null interpolation value - not filled by missingInterpolationHandler", () => {
+  describe('interpolate() - with null interpolation value - not filled by missingInterpolationHandler', () => {
     var ip;
-    var tests = [
-      {args: ['{{test}}', {test: null}], expected: ''},
-    ];
+    var tests = [{ args: ['{{test}}', { test: null }], expected: '' }];
 
     before(() => {
       ip = new Interpolator({
         missingInterpolationHandler: (str, match) => {
-          return 'test'
-        }
+          return 'test';
+        },
       });
     });
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
       });

--- a/test/languageUtils.spec.js
+++ b/test/languageUtils.spec.js
@@ -1,7 +1,6 @@
 import LanguageUtils from '../src/LanguageUtils';
 
 describe('LanguageUtils', () => {
-
   describe('toResolveHierarchy()', () => {
     var cu;
 
@@ -10,17 +9,17 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'en']},
-      {args: ['de', 'fr'], expected: ['de', 'fr']},
-      {args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de', 'fr']},
-      {args: ['de-CH'], expected: ['de-CH', 'de', 'en']},
-      {args: ['nb-NO'], expected: ['nb-NO', 'nb', 'en']},
-      {args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'en'] },
+      { args: ['de', 'fr'], expected: ['de', 'fr'] },
+      { args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de', 'fr'] },
+      { args: ['de-CH'], expected: ['de-CH', 'de', 'en'] },
+      { args: ['nb-NO'], expected: ['nb-NO', 'nb', 'en'] },
+      { args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -33,30 +32,29 @@ describe('LanguageUtils', () => {
     before(() => {
       cu = new LanguageUtils({
         fallbackLng: {
-          'de': ['de-CH', 'en'],
+          de: ['de-CH', 'en'],
           'de-CH': ['fr', 'it', 'en'],
           'zh-Hans': ['zh-Hant', 'zh', 'en'],
           'zh-Hant': ['zh-Hans', 'zh', 'en'],
-          'default' : ['en']
-        }
+          default: ['en'],
+        },
       });
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'de-CH', 'en']},
-      {args: ['de-CH'], expected: ['de-CH', 'de', 'fr', 'it', 'en']},
-      {args: ['nb-NO'], expected: ['nb-NO', 'nb', 'en']},
-      {args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'zh-Hans', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'de-CH', 'en'] },
+      { args: ['de-CH'], expected: ['de-CH', 'de', 'fr', 'it', 'en'] },
+      { args: ['nb-NO'], expected: ['nb-NO', 'nb', 'en'] },
+      { args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'zh-Hans', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
     });
   });
-
 
   describe('toResolveHierarchy() - cleanCode Option', () => {
     var cu;
@@ -66,17 +64,17 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['EN'], expected: ['en']},
-      {args: ['DE'], expected: ['de', 'en']},
-      {args: ['DE', 'fr'], expected: ['de', 'fr']},
-      {args: ['de', ['FR', 'en']], expected: ['de', 'fr', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de', 'fr']},
-      {args: ['DE-CH'], expected: ['de-CH', 'de', 'en']},
-      {args: ['NB-NO'], expected: ['nb-NO', 'nb', 'en']},
-      {args: ['ZH-HANT-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'en']}
+      { args: ['EN'], expected: ['en'] },
+      { args: ['DE'], expected: ['de', 'en'] },
+      { args: ['DE', 'fr'], expected: ['de', 'fr'] },
+      { args: ['de', ['FR', 'en']], expected: ['de', 'fr', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de', 'fr'] },
+      { args: ['DE-CH'], expected: ['de-CH', 'de', 'en'] },
+      { args: ['NB-NO'], expected: ['nb-NO', 'nb', 'en'] },
+      { args: ['ZH-HANT-MO'], expected: ['zh-Hant-MO', 'zh-Hant', 'zh', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -91,17 +89,17 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['EN'], expected: ['en']},
-      {args: ['DE'], expected: ['de', 'en']},
-      {args: ['DE', 'fr'], expected: ['de', 'fr']},
-      {args: ['de', ['FR', 'en']], expected: ['de', 'fr', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de', 'fr']},
-      {args: ['DE-CH'], expected: ['de-ch', 'de', 'en']},
-      {args: ['nb-NO'], expected: ['nb-no', 'nb', 'en']},
-      {args: ['zh-Hant-MO'], expected: ['zh-hant-mo', 'zh-hant', 'zh', 'en']}
+      { args: ['EN'], expected: ['en'] },
+      { args: ['DE'], expected: ['de', 'en'] },
+      { args: ['DE', 'fr'], expected: ['de', 'fr'] },
+      { args: ['de', ['FR', 'en']], expected: ['de', 'fr', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de', 'fr'] },
+      { args: ['DE-CH'], expected: ['de-ch', 'de', 'en'] },
+      { args: ['nb-NO'], expected: ['nb-no', 'nb', 'en'] },
+      { args: ['zh-Hant-MO'], expected: ['zh-hant-mo', 'zh-hant', 'zh', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -116,17 +114,17 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'en']},
-      {args: ['de', 'fr'], expected: ['de', 'fr']},
-      {args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de', 'fr']},
-      {args: ['de-CH'], expected: ['de', 'en']},
-      {args: ['nb-NO'], expected: ['nb', 'en']},
-      {args: ['zh-Hant-MO'], expected: ['zh', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'en'] },
+      { args: ['de', 'fr'], expected: ['de', 'fr'] },
+      { args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de', 'fr'] },
+      { args: ['de-CH'], expected: ['de', 'en'] },
+      { args: ['nb-NO'], expected: ['nb', 'en'] },
+      { args: ['zh-Hant-MO'], expected: ['zh', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -141,17 +139,17 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'en']},
-      {args: ['de', 'fr'], expected: ['de', 'fr']},
-      {args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de', 'fr']},
-      {args: ['de-CH'], expected: ['de-CH', 'en']},
-      {args: ['nb-NO'], expected: ['nb-NO', 'en']},
-      {args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'en'] },
+      { args: ['de', 'fr'], expected: ['de', 'fr'] },
+      { args: ['de', ['fr', 'en']], expected: ['de', 'fr', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de', 'fr'] },
+      { args: ['de-CH'], expected: ['de-CH', 'en'] },
+      { args: ['nb-NO'], expected: ['nb-NO', 'en'] },
+      { args: ['zh-Hant-MO'], expected: ['zh-Hant-MO', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -167,16 +165,16 @@ describe('LanguageUtils', () => {
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'en']},
-      {args: ['de', 'fr'], expected: ['de']},
-      {args: ['de', ['fr', 'en']], expected: ['de', 'en']},
-      {args: ['de', ['fr', 'de']], expected: ['de']},
-      {args: ['de-CH'], expected: ['de', 'en']},
-      {args: ['nb-NO'], expected: ['nb-NO', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'en'] },
+      { args: ['de', 'fr'], expected: ['de'] },
+      { args: ['de', ['fr', 'en']], expected: ['de', 'en'] },
+      { args: ['de', ['fr', 'de']], expected: ['de'] },
+      { args: ['de-CH'], expected: ['de', 'en'] },
+      { args: ['nb-NO'], expected: ['nb-NO', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
@@ -187,22 +185,25 @@ describe('LanguageUtils', () => {
     var cu;
 
     before(() => {
-      cu = new LanguageUtils({ fallbackLng: ['en'], whitelist: ['de', 'en', 'zh'] , nonExplicitWhitelist: true});
+      cu = new LanguageUtils({
+        fallbackLng: ['en'],
+        whitelist: ['de', 'en', 'zh'],
+        nonExplicitWhitelist: true,
+      });
     });
 
     var tests = [
-      {args: ['en'], expected: ['en']},
-      {args: ['de'], expected: ['de', 'en']},
-      {args: ['de-AT'], expected: ['de-AT', 'de', 'en']},
-      {args: ['zh-HK'], expected: ['zh-HK', 'zh', 'en']},
-      {args: ['zh-CN'], expected: ['zh-CN', 'zh', 'en']}
+      { args: ['en'], expected: ['en'] },
+      { args: ['de'], expected: ['de', 'en'] },
+      { args: ['de-AT'], expected: ['de-AT', 'de', 'en'] },
+      { args: ['zh-HK'], expected: ['zh-HK', 'zh', 'en'] },
+      { args: ['zh-CN'], expected: ['zh-CN', 'zh', 'en'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly prepares resolver for ' + JSON.stringify(test.args) + ' args', () => {
         expect(cu.toResolveHierarchy.apply(cu, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -18,13 +18,12 @@ const mockLogger = {
   output(type, args) {
     return {
       type,
-      args
+      args,
     };
-  }
+  },
 };
 
 describe('logger', () => {
-
   before(() => {
     logger.init(mockLogger, { debug: true });
   });
@@ -50,5 +49,4 @@ describe('logger', () => {
       expect(logger.deprecate('hello').args[0]).to.equal('WARNING DEPRECATED: i18next: hello');
     });
   });
-
 });

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -2,7 +2,6 @@ import PluralResolver from '../src/PluralResolver';
 import LanguageUtils from '../src/LanguageUtils';
 
 describe('PluralResolver', () => {
-
   describe('needsPlural()', () => {
     let pr;
 
@@ -12,37 +11,37 @@ describe('PluralResolver', () => {
     });
 
     var tests = [
-      {args: ['en'], expected: true},
-      {args: ['fr'], expected: true},
-      {args: ['ar'], expected: true},
-      {args: ['ru'], expected: true},
-      {args: ['ms'], expected: false},
-      {args: ['lo'], expected: false},
-      {args: ['su'], expected: false},
-      {args: ['ach'], expected: true},
-      {args: ['af'], expected: true},
-      {args: ['ay'], expected: false},
-      {args: ['be'], expected: true},
-      {args: ['cs'], expected: true},
-      {args: ['csb'], expected: true},
-      {args: ['cy'], expected: true},
-      {args: ['ga'], expected: true},
-      {args: ['gd'], expected: true},
-      {args: ['is'], expected: true},
-      {args: ['jv'], expected: true},
-      {args: ['kw'], expected: true},
-      {args: ['lt'], expected: true},
-      {args: ['lv'], expected: true},
-      {args: ['mk'], expected: true},
-      {args: ['mnk'], expected: true},
-      {args: ['mt'], expected: true},
-      {args: ['or'], expected: true},
-      {args: ['ro'], expected: true},
-      {args: ['sl'], expected: true},
-      {args: ['he'], expected: true}
+      { args: ['en'], expected: true },
+      { args: ['fr'], expected: true },
+      { args: ['ar'], expected: true },
+      { args: ['ru'], expected: true },
+      { args: ['ms'], expected: false },
+      { args: ['lo'], expected: false },
+      { args: ['su'], expected: false },
+      { args: ['ach'], expected: true },
+      { args: ['af'], expected: true },
+      { args: ['ay'], expected: false },
+      { args: ['be'], expected: true },
+      { args: ['cs'], expected: true },
+      { args: ['csb'], expected: true },
+      { args: ['cy'], expected: true },
+      { args: ['ga'], expected: true },
+      { args: ['gd'], expected: true },
+      { args: ['is'], expected: true },
+      { args: ['jv'], expected: true },
+      { args: ['kw'], expected: true },
+      { args: ['lt'], expected: true },
+      { args: ['lv'], expected: true },
+      { args: ['mk'], expected: true },
+      { args: ['mnk'], expected: true },
+      { args: ['mt'], expected: true },
+      { args: ['or'], expected: true },
+      { args: ['ro'], expected: true },
+      { args: ['sl'], expected: true },
+      { args: ['he'], expected: true },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly returns needsPlural for ' + JSON.stringify(test.args) + ' args', () => {
         expect(pr.needsPlural.apply(pr, test.args)).to.eql(test.expected);
       });
@@ -58,156 +57,156 @@ describe('PluralResolver', () => {
     });
 
     var tests = [
-      {args: ['en', 0], expected: 'plural'},
-      {args: ['en', 1], expected: ''},
-      {args: ['en', 10], expected: 'plural'},
-      {args: ['en', 10.5], expected: 'plural'},
+      { args: ['en', 0], expected: 'plural' },
+      { args: ['en', 1], expected: '' },
+      { args: ['en', 10], expected: 'plural' },
+      { args: ['en', 10.5], expected: 'plural' },
 
-      {args: ['fr', 0], expected: ''},
-      {args: ['fr', 1], expected: ''},
-      {args: ['fr', 10], expected: 'plural'},
-      {args: ['fr', 10.5], expected: 'plural'},
+      { args: ['fr', 0], expected: '' },
+      { args: ['fr', 1], expected: '' },
+      { args: ['fr', 10], expected: 'plural' },
+      { args: ['fr', 10.5], expected: 'plural' },
 
-      {args: ['pt', 0], expected: ''},
-      {args: ['pt', 1], expected: ''},
-      {args: ['pt', 10], expected: 'plural'},
-      {args: ['pt', 10.5], expected: 'plural'},
+      { args: ['pt', 0], expected: '' },
+      { args: ['pt', 1], expected: '' },
+      { args: ['pt', 10], expected: 'plural' },
+      { args: ['pt', 10.5], expected: 'plural' },
 
-      {args: ['pt-PT', 0], expected: 'plural'},
-      {args: ['pt-PT', 1], expected: ''},
-      {args: ['pt-PT', 10], expected: 'plural'},
-      {args: ['pt-PT', 10.5], expected: 'plural'},
+      { args: ['pt-PT', 0], expected: 'plural' },
+      { args: ['pt-PT', 1], expected: '' },
+      { args: ['pt-PT', 10], expected: 'plural' },
+      { args: ['pt-PT', 10.5], expected: 'plural' },
 
-      {args: ['pt-BR', 0], expected: ''},
-      {args: ['pt-BR', 1], expected: ''},
-      {args: ['pt-BR', 10], expected: 'plural'},
-      {args: ['pt-BR', 10.5], expected: 'plural'},
+      { args: ['pt-BR', 0], expected: '' },
+      { args: ['pt-BR', 1], expected: '' },
+      { args: ['pt-BR', 10], expected: 'plural' },
+      { args: ['pt-BR', 10.5], expected: 'plural' },
 
-      {args: ['ach', 0], expected: ''},
-      {args: ['ach', 1], expected: ''},
-      {args: ['ach', 10], expected: 'plural'},
-      {args: ['ach', 10.5], expected: 'plural'},
+      { args: ['ach', 0], expected: '' },
+      { args: ['ach', 1], expected: '' },
+      { args: ['ach', 10], expected: 'plural' },
+      { args: ['ach', 10.5], expected: 'plural' },
 
       // only singular
-      {args: ['su', 0], expected: '0'},
-      {args: ['su', 1], expected: '0'},
-      {args: ['su', 10], expected: '0'},
+      { args: ['su', 0], expected: '0' },
+      { args: ['su', 1], expected: '0' },
+      { args: ['su', 10], expected: '0' },
 
       // ar
-      {args: ['ar', 0], expected: '0'},
-      {args: ['ar', 1], expected: '1'},
-      {args: ['ar', 2], expected: '2'},
-      {args: ['ar', 3], expected: '3'},
-      {args: ['ar', 4], expected: '3'},
-      {args: ['ar', 104], expected: '3'},
-      {args: ['ar', 11], expected: '4'},
-      {args: ['ar', 99], expected: '4'},
-      {args: ['ar', 199], expected: '4'},
-      {args: ['ar', 100], expected: '5'},
+      { args: ['ar', 0], expected: '0' },
+      { args: ['ar', 1], expected: '1' },
+      { args: ['ar', 2], expected: '2' },
+      { args: ['ar', 3], expected: '3' },
+      { args: ['ar', 4], expected: '3' },
+      { args: ['ar', 104], expected: '3' },
+      { args: ['ar', 11], expected: '4' },
+      { args: ['ar', 99], expected: '4' },
+      { args: ['ar', 199], expected: '4' },
+      { args: ['ar', 100], expected: '5' },
 
       // be
-      {args: ['be', 0], expected: '2'},
-      {args: ['be', 1], expected: '0'},
-      {args: ['be', 5], expected: '2'},
+      { args: ['be', 0], expected: '2' },
+      { args: ['be', 1], expected: '0' },
+      { args: ['be', 5], expected: '2' },
 
       // sk
-      {args: ['sk', 0], expected: '2'},
-      {args: ['sk', 1], expected: '0'},
-      {args: ['sk', 5], expected: '2'},
+      { args: ['sk', 0], expected: '2' },
+      { args: ['sk', 1], expected: '0' },
+      { args: ['sk', 5], expected: '2' },
 
       // pl
-      {args: ['pl', 0], expected: '2'},
-      {args: ['pl', 1], expected: '0'},
-      {args: ['pl', 5], expected: '2'},
+      { args: ['pl', 0], expected: '2' },
+      { args: ['pl', 1], expected: '0' },
+      { args: ['pl', 5], expected: '2' },
 
       // cy
-      {args: ['cy', 0], expected: '2'},
-      {args: ['cy', 1], expected: '0'},
-      {args: ['cy', 3], expected: '2'},
-      {args: ['cy', 8], expected: '3'},
+      { args: ['cy', 0], expected: '2' },
+      { args: ['cy', 1], expected: '0' },
+      { args: ['cy', 3], expected: '2' },
+      { args: ['cy', 8], expected: '3' },
 
       // ga
-      {args: ['ga', 1], expected: '0'},
-      {args: ['ga', 2], expected: '1'},
-      {args: ['ga', 3], expected: '2'},
-      {args: ['ga', 7], expected: '3'},
-      {args: ['ga', 11], expected: '4'},
+      { args: ['ga', 1], expected: '0' },
+      { args: ['ga', 2], expected: '1' },
+      { args: ['ga', 3], expected: '2' },
+      { args: ['ga', 7], expected: '3' },
+      { args: ['ga', 11], expected: '4' },
 
       // gd
-      {args: ['gd', 1], expected: '0'},
-      {args: ['gd', 2], expected: '1'},
-      {args: ['gd', 3], expected: '2'},
-      {args: ['gd', 20], expected: '3'},
+      { args: ['gd', 1], expected: '0' },
+      { args: ['gd', 2], expected: '1' },
+      { args: ['gd', 3], expected: '2' },
+      { args: ['gd', 20], expected: '3' },
 
       // is
-      {args: ['is', 1], expected: ''},
-      {args: ['is', 2], expected: 'plural'},
+      { args: ['is', 1], expected: '' },
+      { args: ['is', 2], expected: 'plural' },
 
       // jv
-      {args: ['jv', 0], expected: '0'},
-      {args: ['jv', 1], expected: '1'},
+      { args: ['jv', 0], expected: '0' },
+      { args: ['jv', 1], expected: '1' },
 
       // kw
-      {args: ['kw', 1], expected: '0'},
-      {args: ['kw', 2], expected: '1'},
-      {args: ['kw', 3], expected: '2'},
-      {args: ['kw', 4], expected: '3'},
+      { args: ['kw', 1], expected: '0' },
+      { args: ['kw', 2], expected: '1' },
+      { args: ['kw', 3], expected: '2' },
+      { args: ['kw', 4], expected: '3' },
 
       // lt
-      {args: ['lt', 1], expected: '0'},
-      {args: ['lt', 2], expected: '1'},
-      {args: ['lt', 10], expected: '2'},
+      { args: ['lt', 1], expected: '0' },
+      { args: ['lt', 2], expected: '1' },
+      { args: ['lt', 10], expected: '2' },
 
       // lv
-      {args: ['lv', 1], expected: '0'},
-      {args: ['lv', 2], expected: '1'},
-      {args: ['lv', 0], expected: '2'},
+      { args: ['lv', 1], expected: '0' },
+      { args: ['lv', 2], expected: '1' },
+      { args: ['lv', 0], expected: '2' },
 
       // mk
-      {args: ['mk', 1], expected: ''},
-      {args: ['mk', 2], expected: 'plural'},
-      {args: ['mk', 0], expected: 'plural'},
+      { args: ['mk', 1], expected: '' },
+      { args: ['mk', 2], expected: 'plural' },
+      { args: ['mk', 0], expected: 'plural' },
 
       // mnk
-      {args: ['mnk', 0], expected: '0'},
-      {args: ['mnk', 1], expected: '1'},
-      {args: ['mnk', 2], expected: '2'},
+      { args: ['mnk', 0], expected: '0' },
+      { args: ['mnk', 1], expected: '1' },
+      { args: ['mnk', 2], expected: '2' },
 
       // mt
-      {args: ['mt', 1], expected: '0'},
-      {args: ['mt', 2], expected: '1'},
-      {args: ['mt', 11], expected: '2'},
-      {args: ['mt', 20], expected: '3'},
+      { args: ['mt', 1], expected: '0' },
+      { args: ['mt', 2], expected: '1' },
+      { args: ['mt', 11], expected: '2' },
+      { args: ['mt', 20], expected: '3' },
 
       // or
-      {args: ['or', 2], expected: '1'},
-      {args: ['or', 1], expected: '0'},
+      { args: ['or', 2], expected: '1' },
+      { args: ['or', 1], expected: '0' },
 
       // ro
-      {args: ['ro', 0], expected: '1'},
-      {args: ['ro', 1], expected: '0'},
-      {args: ['ro', 20], expected: '2'},
+      { args: ['ro', 0], expected: '1' },
+      { args: ['ro', 1], expected: '0' },
+      { args: ['ro', 20], expected: '2' },
 
       // sl
-      {args: ['sl', 5], expected: '0'},
-      {args: ['sl', 1], expected: '1'},
-      {args: ['sl', 2], expected: '2'},
-      {args: ['sl', 3], expected: '3'},
+      { args: ['sl', 5], expected: '0' },
+      { args: ['sl', 1], expected: '1' },
+      { args: ['sl', 2], expected: '2' },
+      { args: ['sl', 3], expected: '3' },
 
       // he
-      {args: ['he', 0], expected: '3'},
-      {args: ['he', 0.5], expected: '3'},
-      {args: ['he', 1], expected: '0'},
-      {args: ['he', 2], expected: '1'},
-      {args: ['he', 3], expected: '3'},
-      {args: ['he', 20], expected: '2'},
-      {args: ['he', 21], expected: '3'},
-      {args: ['he', 30], expected: '2'},
-      {args: ['he', 100], expected: '2'},
-      {args: ['he', 101], expected: '3'},
+      { args: ['he', 0], expected: '3' },
+      { args: ['he', 0.5], expected: '3' },
+      { args: ['he', 1], expected: '0' },
+      { args: ['he', 2], expected: '1' },
+      { args: ['he', 3], expected: '3' },
+      { args: ['he', 20], expected: '2' },
+      { args: ['he', 21], expected: '3' },
+      { args: ['he', 30], expected: '2' },
+      { args: ['he', 100], expected: '2' },
+      { args: ['he', 101], expected: '3' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly returns suffix for ' + JSON.stringify(test.args) + ' args', () => {
         expect(pr.getSuffix.apply(pr, test.args)).to.eql(test.expected);
       });
@@ -223,14 +222,17 @@ describe('PluralResolver', () => {
     });
 
     var tests = [
-      {args: ['en', 'key'], expected: ['key', 'key_plural']},
-      {args: ['ar', 'key'], expected: ['key_0', 'key_1', 'key_2', 'key_3', 'key_4', 'key_5']}
+      { args: ['en', 'key'], expected: ['key', 'key_plural'] },
+      { args: ['ar', 'key'], expected: ['key_0', 'key_1', 'key_2', 'key_3', 'key_4', 'key_5'] },
     ];
 
-    tests.forEach((test) => {
-      it('correctly returns pluralforms of a given key for ' + JSON.stringify(test.args) + ' args', () => {
-        expect(pr.getPluralFormsOfKey.apply(pr, test.args)).to.eql(test.expected);
-      });
+    tests.forEach(test => {
+      it(
+        'correctly returns pluralforms of a given key for ' + JSON.stringify(test.args) + ' args',
+        () => {
+          expect(pr.getPluralFormsOfKey.apply(pr, test.args)).to.eql(test.expected);
+        },
+      );
     });
   });
 
@@ -243,14 +245,17 @@ describe('PluralResolver', () => {
     });
 
     var tests = [
-      {args: ['en', 'key'], expected: ['key_0', 'key_1']},
-      {args: ['ar', 'key'], expected: ['key_0', 'key_1', 'key_2', 'key_3', 'key_4', 'key_5']}
+      { args: ['en', 'key'], expected: ['key_0', 'key_1'] },
+      { args: ['ar', 'key'], expected: ['key_0', 'key_1', 'key_2', 'key_3', 'key_4', 'key_5'] },
     ];
 
-    tests.forEach((test) => {
-      it('correctly returns pluralforms of a given key for ' + JSON.stringify(test.args) + ' args', () => {
-        expect(pr.getPluralFormsOfKey.apply(pr, test.args)).to.eql(test.expected);
-      });
+    tests.forEach(test => {
+      it(
+        'correctly returns pluralforms of a given key for ' + JSON.stringify(test.args) + ' args',
+        () => {
+          expect(pr.getPluralFormsOfKey.apply(pr, test.args)).to.eql(test.expected);
+        },
+      );
     });
   });
 });

--- a/test/postProcessor.spec.js
+++ b/test/postProcessor.spec.js
@@ -1,27 +1,22 @@
 import postProcessor from '../src/postProcessor';
 
 describe('postProcessor', () => {
-
   describe('add and handle()', () => {
-
     before(() => {
       postProcessor.addPostProcessor({
         name: 'dummy',
         process: (value, key, options, translator) => {
           return value.toUpperCase();
-        }
+        },
       });
     });
 
-    var tests = [
-      {args: [['dummy'], 'test', 'key', {}, () => {}], expected: 'TEST'}
-    ];
+    var tests = [{ args: [['dummy'], 'test', 'key', {}, () => {}], expected: 'TEST' }];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly process for ' + JSON.stringify(test.args) + ' args', () => {
         expect(postProcessor.handle.apply(postProcessor, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/resourceStore.spec.js
+++ b/test/resourceStore.spec.js
@@ -1,7 +1,6 @@
 import ResourceStore from '../src/ResourceStore.js';
 
 describe('ResourceStore', () => {
-
   describe('constructor', () => {
     it('it should set empty data if not passing them in', () => {
       let rs = new ResourceStore();
@@ -12,9 +11,9 @@ describe('ResourceStore', () => {
       const data = {
         en: {
           translation: {
-            test: 'test'
-          }
-        }
+            test: 'test',
+          },
+        },
       };
       let rs = new ResourceStore(data);
       expect(rs.toJSON()).to.equal(data);
@@ -51,57 +50,75 @@ describe('ResourceStore', () => {
         expect(rs.getResource('de.translation.nest.object')).to.eql({ something: 'deeper' });
       });
 
-      it('it should emit \'added\' event on addResource call', () => {
+      it("it should emit 'added' event on addResource call", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
         rs.addResource('fr', 'translation', 'hi', 'salut');
         expect(spy.calledWithExactly('fr', 'translation', 'hi', 'salut')).to.be.true;
       });
 
-      it('it should not emit \'added\' event on addResource call with silent option', () => {
+      it("it should not emit 'added' event on addResource call with silent option", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
         rs.addResource('fr', 'translation', 'hi', 'salut', { silent: true });
         expect(spy.notCalled).to.be.true;
       });
 
-      it('it should emit \'added\' event on addResources call', () => {
+      it("it should emit 'added' event on addResources call", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
         rs.addResources('fr', 'translation', {
-          'hi': 'salut',
-          'hello': 'bonjour',
+          hi: 'salut',
+          hello: 'bonjour',
         });
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('it should not emit \'added\' event on addResources call with silent option', () => {
+      it("it should not emit 'added' event on addResources call with silent option", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
-        rs.addResources('fr', 'translation', {
-          'hi': 'salut',
-          'hello': 'bonjour',
-        }, { silent: true });
+        rs.addResources(
+          'fr',
+          'translation',
+          {
+            hi: 'salut',
+            hello: 'bonjour',
+          },
+          { silent: true },
+        );
         expect(spy.notCalled).to.be.true;
       });
 
-      it('it should emit \'added\' event on addResourceBundle call', () => {
+      it("it should emit 'added' event on addResourceBundle call", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
-        rs.addResourceBundle('fr', 'translation', {
-          'hi': 'salut',
-          'hello': 'bonjour',
-        }, true, true);
+        rs.addResourceBundle(
+          'fr',
+          'translation',
+          {
+            hi: 'salut',
+            hello: 'bonjour',
+          },
+          true,
+          true,
+        );
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('it should not emit \'added\' event on addResourceBundle call with silent option', () => {
+      it("it should not emit 'added' event on addResourceBundle call with silent option", () => {
         const spy = sinon.spy();
         rs.on('added', spy);
-        rs.addResourceBundle('fr', 'translation', {
-          'hi': 'salut',
-          'hello': 'bonjour',
-        }, true, true, { silent: true });
+        rs.addResourceBundle(
+          'fr',
+          'translation',
+          {
+            hi: 'salut',
+            hello: 'bonjour',
+          },
+          true,
+          true,
+          { silent: true },
+        );
         expect(spy.notCalled).to.be.true;
       });
     });
@@ -118,7 +135,11 @@ describe('ResourceStore', () => {
 
         // dotty
         rs.addResourceBundle('en.translation', { something1: 'deeper1' });
-        expect(rs.getResource('en.translation')).to.eql({ something: 'deeper', something1: 'deeper1', test: 'test' });
+        expect(rs.getResource('en.translation')).to.eql({
+          something: 'deeper',
+          something1: 'deeper1',
+          test: 'test',
+        });
       });
     });
 
@@ -168,5 +189,4 @@ describe('ResourceStore', () => {
       });
     });
   });
-
 });

--- a/test/translator/translator.cimode.spec.js
+++ b/test/translator/translator.cimode.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() in cimode', () => {
     var t;
 
@@ -13,43 +12,63 @@ describe('Translator', () => {
       const rs = new ResourceStore({
         en: {
           translation: {
-            test: 'test_en'
-          }
+            test: 'test_en',
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('cimode');
     });
 
     var tests = [
-      {args: ['translation:test', { appendNamespaceToCIMode: false, ns: 'translation', nsSeparator: ':' }], expected: 'test'},
-      {args: ['test', { appendNamespaceToCIMode: false, ns: 'translation', nsSeparator: ':' }], expected: 'test'},
-      {args: ['translation:test', { appendNamespaceToCIMode: true, ns: 'translation', nsSeparator: ':' }], expected: 'translation:test'},
-      {args: ['test', { appendNamespaceToCIMode: true, ns: 'translation', nsSeparator: ':' }], expected: 'translation:test'},
+      {
+        args: [
+          'translation:test',
+          { appendNamespaceToCIMode: false, ns: 'translation', nsSeparator: ':' },
+        ],
+        expected: 'test',
+      },
+      {
+        args: ['test', { appendNamespaceToCIMode: false, ns: 'translation', nsSeparator: ':' }],
+        expected: 'test',
+      },
+      {
+        args: [
+          'translation:test',
+          { appendNamespaceToCIMode: true, ns: 'translation', nsSeparator: ':' },
+        ],
+        expected: 'translation:test',
+      },
+      {
+        args: ['test', { appendNamespaceToCIMode: true, ns: 'translation', nsSeparator: ':' }],
+        expected: 'translation:test',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly return key for ' + JSON.stringify(test.args) + ' args in cimode', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.exists.spec.js
+++ b/test/translator/translator.exists.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('exists()', () => {
     var t;
 
@@ -15,51 +14,53 @@ describe('Translator', () => {
           translation: {
             test: 'test_en',
             deep: {
-              test: 'deep_en'
-            }
-          }
+              test: 'deep_en',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test'], expected: true},
-      {args: ['translation:test', { lngs: ['en-US', 'en'] }], expected: true},
-      {args: ['translation:test', { lngs: ['de'] }], expected: true},
-      {args: ['translation:test', { lng: 'de' }], expected: true},
-      {args: ['translation:test', { lng: 'fr' }], expected: true},
-      {args: ['translation:test', { lng: 'en-US' }], expected: true},
-      {args: ['translation.test', { lng: 'en-US', nsSeparator: '.' }], expected: true},
-      {args: ['translation.deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: true},
-      {args: ['deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: true}
+      { args: ['translation:test'], expected: true },
+      { args: ['translation:test', { lngs: ['en-US', 'en'] }], expected: true },
+      { args: ['translation:test', { lngs: ['de'] }], expected: true },
+      { args: ['translation:test', { lng: 'de' }], expected: true },
+      { args: ['translation:test', { lng: 'fr' }], expected: true },
+      { args: ['translation:test', { lng: 'en-US' }], expected: true },
+      { args: ['translation.test', { lng: 'en-US', nsSeparator: '.' }], expected: true },
+      { args: ['translation.deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: true },
+      { args: ['deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: true },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.exists.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.fallbackLng.spec.js
+++ b/test/translator/translator.fallbackLng.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() - fallback', () => {
     let t;
 
@@ -14,49 +13,51 @@ describe('Translator', () => {
         en: {
           translation: {
             test: 'test_en',
-            notInDE: 'test_notInDE_en'
-          }
+            notInDE: 'test_notInDE_en',
+          },
         },
         fr: {
           translation: {
             test: 'test_fr',
-            notInDE: 'test_notInDE_fr'
-          }
+            notInDE: 'test_notInDE_fr',
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('de');
     });
 
     const tests = [
-      { args: ['translation:notInDE', { }], expected: 'test_notInDE_en' },
-      { args: ['translation:notInDE', { fallbackLng: 'fr' }], expected: 'test_notInDE_fr' }
+      { args: ['translation:notInDE', {}], expected: 'test_notInDE_en' },
+      { args: ['translation:notInDE', { fallbackLng: 'fr' }], expected: 'test_notInDE_fr' },
     ];
 
-    tests.forEach((test) => {
-      it(`correctly translates for ${JSON.stringify(test.args) } args`, () => {
+    tests.forEach(test => {
+      it(`correctly translates for ${JSON.stringify(test.args)} args`, () => {
         expect(t.translate(...test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.getResource.spec.js
+++ b/test/translator/translator.getResource.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('getResource()', () => {
     var t;
 
@@ -13,36 +12,38 @@ describe('Translator', () => {
       const rs = new ResourceStore({
         en: {
           translation: {
-            test: 'test'
-          }
-        }
+            test: 'test',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['en', 'translation', 'test'], expected: 'test'},
-      {args: ['de', 'translation', 'test'], expected: undefined}
+      { args: ['en', 'translation', 'test'], expected: 'test' },
+      { args: ['de', 'translation', 'test'], expected: undefined },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly gets resource for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.getResource.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.array.spec.js
+++ b/test/translator/translator.translate.array.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with arrays', () => {
     var t;
 
@@ -14,51 +13,53 @@ describe('Translator', () => {
         en: {
           translation: {
             test: ['test_en_1', 'test_en_2', '{{myVar}}'],
-            flagList: [
-              ['basic1', 'Basic1'],
-              ['simple1', 'Simple1']
-            ],
+            flagList: [['basic1', 'Basic1'], ['simple1', 'Simple1']],
             search: {
-              flagList: [
-                ['basic', 'Basic'],
-                ['simple', 'Simple']
-              ]
-            }
-          }
-        }
+              flagList: [['basic', 'Basic'], ['simple', 'Simple']],
+            },
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        returnObjects: true,
-        ns: 'translation',
-        defaultNS: 'translation',
-        keySeparator: '.',
-        interpolation: {
-          // interpolateResult: true,
-          // interpolateDefaultValue: true,
-          // interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          returnObjects: true,
+          ns: 'translation',
+          defaultNS: 'translation',
+          keySeparator: '.',
+          interpolation: {
+            // interpolateResult: true,
+            // interpolateDefaultValue: true,
+            // interpolateKey: true
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
       { args: ['translation:test.0'], expected: 'test_en_1' },
-      { args: ['translation:test.2', {myVar: 'test'}], expected: 'test' },
-      { args: ['translation:test', {myVar: 'test', joinArrays: '+'}], expected: 'test_en_1+test_en_2+test' },
-      { args: [['search.flagList', 'flagList'], {}], expected: [['basic', 'Basic'], ['simple', 'Simple']] }
+      { args: ['translation:test.2', { myVar: 'test' }], expected: 'test' },
+      {
+        args: ['translation:test', { myVar: 'test', joinArrays: '+' }],
+        expected: 'test_en_1+test_en_2+test',
+      },
+      {
+        args: [['search.flagList', 'flagList'], {}],
+        expected: [['basic', 'Basic'], ['simple', 'Simple']],
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.combination.spec.js
+++ b/test/translator/translator.translate.combination.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with combined functionality', () => {
     var t;
 
@@ -13,9 +12,9 @@ describe('Translator', () => {
       const rs = new ResourceStore({
         en: {
           translation: {
-            'key1': 'hello world',
-            'key2': 'It is: $t(key1)',
-            'key3': 'It is: {{val}}',
+            key1: 'hello world',
+            key2: 'It is: $t(key1)',
+            key3: 'It is: {{val}}',
 
             // context with pluralization
             test: 'test_en',
@@ -25,29 +24,29 @@ describe('Translator', () => {
 
             nest: {
               foo: 'bar',
-              nest: '$t(nestedArray)'
+              nest: '$t(nestedArray)',
             },
-            nestedArray: [
-              { a: 'b', c: 'd' },
-              { a: 'b', c: 'd' }
-            ]
-          }
-        }
+            nestedArray: [{ a: 'b', c: 'd' }, { a: 'b', c: 'd' }],
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        contextSeparator: '_',
-        keySeparator: '.',
-        ns: 'translation',
-        defaultNS: 'translation',
-        interpolation: {},
-        returnObjects: true
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          contextSeparator: '_',
+          keySeparator: '.',
+          ns: 'translation',
+          defaultNS: 'translation',
+          interpolation: {},
+          returnObjects: true,
+        },
+      );
       t.changeLanguage('en');
     });
 
@@ -60,18 +59,17 @@ describe('Translator', () => {
       { args: ['key3', { val: '$t(key1)', nest: false }], expected: 'It is: $t(key1)' },
 
       // context with pluralization
-      {args: ['test', { context: 'unknown', count: 1 }], expected: 'test_en'},
-      {args: ['test', { context: 'unknown', count: 2 }], expected: 'tests_en'},
-      {args: ['test', { context: 'male', count: 1 }], expected: 'test_male_en'},
-      {args: ['test', { context: 'male', count: 2 }], expected: 'tests_male_en'},
-      {args: ['nest'], expected: { foo: 'bar', nest: [{ a: 'b', c: 'd' }, { a: 'b', c: 'd' } ]}}
+      { args: ['test', { context: 'unknown', count: 1 }], expected: 'test_en' },
+      { args: ['test', { context: 'unknown', count: 2 }], expected: 'tests_en' },
+      { args: ['test', { context: 'male', count: 1 }], expected: 'test_male_en' },
+      { args: ['test', { context: 'male', count: 2 }], expected: 'tests_male_en' },
+      { args: ['nest'], expected: { foo: 'bar', nest: [{ a: 'b', c: 'd' }, { a: 'b', c: 'd' }] } },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.context.spec.js
+++ b/test/translator/translator.translate.context.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with context', () => {
     var t;
 
@@ -16,54 +15,68 @@ describe('Translator', () => {
             test: 'test_en',
             test_male: 'test_male_en',
             test_female: 'test_female_en',
-          }
+          },
         },
         de: {
           translation: {
             test: 'test_de',
             test_male: 'test_male_de',
-            test_female: 'test_female_de'
-          }
-        }
+            test_female: 'test_female_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        contextSeparator: '_',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          contextSeparator: '_',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test', { context: 'unknown' }], expected: 'test_en'},
-      {args: ['translation:test', { context: 'male' }], expected: 'test_male_en'},
-      {args: ['translation:test', { context: 'female' }], expected: 'test_female_en'},
-      {args: ['translation:test', { context: 'male', lngs: ['en-US', 'en'] }], expected: 'test_male_en'},
-      {args: ['translation:test', { context: 'female', lngs: ['en-US', 'en'] }], expected: 'test_female_en'},
-      {args: ['translation:test', { context: 'male', lngs: ['de'] }], expected: 'test_male_de'},
-      {args: ['translation:test', { context: 'female', lngs: ['de'] }], expected: 'test_female_de'},
-      {args: ['translation:test', { context: 'male', lng: 'de' }], expected: 'test_male_de'},
-      {args: ['translation:test', { context: 'female', lng: 'de' }], expected: 'test_female_de'},
-      {args: ['translation:test', { context: 'male', lng: 'fr' }], expected: 'test_male_en'},
-      {args: ['translation:test', { context: 'female', lng: 'fr' }], expected: 'test_female_en'},
-      {args: ['translation:test', { context: 'male', lng: 'en-US' }], expected: 'test_male_en'},
-      {args: ['translation:test', { context: 'female', lng: 'en-US' }], expected: 'test_female_en'}
+      { args: ['translation:test', { context: 'unknown' }], expected: 'test_en' },
+      { args: ['translation:test', { context: 'male' }], expected: 'test_male_en' },
+      { args: ['translation:test', { context: 'female' }], expected: 'test_female_en' },
+      {
+        args: ['translation:test', { context: 'male', lngs: ['en-US', 'en'] }],
+        expected: 'test_male_en',
+      },
+      {
+        args: ['translation:test', { context: 'female', lngs: ['en-US', 'en'] }],
+        expected: 'test_female_en',
+      },
+      { args: ['translation:test', { context: 'male', lngs: ['de'] }], expected: 'test_male_de' },
+      {
+        args: ['translation:test', { context: 'female', lngs: ['de'] }],
+        expected: 'test_female_de',
+      },
+      { args: ['translation:test', { context: 'male', lng: 'de' }], expected: 'test_male_de' },
+      { args: ['translation:test', { context: 'female', lng: 'de' }], expected: 'test_female_de' },
+      { args: ['translation:test', { context: 'male', lng: 'fr' }], expected: 'test_male_en' },
+      { args: ['translation:test', { context: 'female', lng: 'fr' }], expected: 'test_female_en' },
+      { args: ['translation:test', { context: 'male', lng: 'en-US' }], expected: 'test_male_en' },
+      {
+        args: ['translation:test', { context: 'female', lng: 'en-US' }],
+        expected: 'test_female_en',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.defaultValue.spec.js
+++ b/test/translator/translator.translate.defaultValue.spec.js
@@ -5,45 +5,52 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() defaultValue', () => {
     var t;
 
     before(() => {
       const rs = new ResourceStore({
         en: {
-          translation: {}
-        }
+          translation: {},
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test', { defaultValue: 'test_en' }], expected: 'test_en'},
-      {args: ['translation:test', { defaultValue: 'test_en', count: 1 }], expected: 'test_en'},
-      {args: ['translation:test', { defaultValue_plural: 'test_en_plural', defaultValue: 'test_en', count: 10 }], expected: 'test_en_plural'},
+      { args: ['translation:test', { defaultValue: 'test_en' }], expected: 'test_en' },
+      { args: ['translation:test', { defaultValue: 'test_en', count: 1 }], expected: 'test_en' },
+      {
+        args: [
+          'translation:test',
+          { defaultValue_plural: 'test_en_plural', defaultValue: 'test_en', count: 10 },
+        ],
+        expected: 'test_en_plural',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.escape.spec.js
+++ b/test/translator/translator.translate.escape.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() un/escape', () => {
     var t;
 
@@ -13,41 +12,55 @@ describe('Translator', () => {
       const rs = new ResourceStore({
         en: {
           translation: {
-            test: 'text {{var}}'
-          }
-        }
+            test: 'text {{var}}',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true,
-          escapeValue: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+            escapeValue: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test', { var: 'a&b' }], expected: 'text a&amp;b'},
-      {args: ['translation:test', { var: 'a&b', interpolation: { escapeValue: false } }], expected: 'text a&b'},
-      {args: ['translation:test', { var: ['a', 'b'] }], expected: 'text a,b'},
-      {args: ['translation:test', { var: ['a', 'b'], interpolation: { useRawValueToEscape: true, escape: (value) => value.join('-') } }], expected: 'text a-b'},
+      { args: ['translation:test', { var: 'a&b' }], expected: 'text a&amp;b' },
+      {
+        args: ['translation:test', { var: 'a&b', interpolation: { escapeValue: false } }],
+        expected: 'text a&b',
+      },
+      { args: ['translation:test', { var: ['a', 'b'] }], expected: 'text a,b' },
+      {
+        args: [
+          'translation:test',
+          {
+            var: ['a', 'b'],
+            interpolation: { useRawValueToEscape: true, escape: value => value.join('-') },
+          },
+        ],
+        expected: 'text a-b',
+      },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.missing.spec.js
+++ b/test/translator/translator.translate.missing.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() using missing', () => {
     var t;
 
@@ -15,40 +14,41 @@ describe('Translator', () => {
           translation: {
             test: 'test_en',
             deep: {
-              test: 'deep_en'
-            }
-          }
+              test: 'deep_en',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        saveMissing: true,
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          saveMissing: true,
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
-    var tests = [
-      {args: ['translation:test.missing'], expected: 'test.missing'}
-    ];
+    var tests = [{ args: ['translation:test.missing'], expected: 'test.missing' }];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
         t.options.missingKeyHandler = (lngs, namespace, key, res) => {
           expect(lngs).to.eql(['en']);
@@ -62,7 +62,6 @@ describe('Translator', () => {
     });
   });
 
-
   describe('translate() using missing with saveMissingPlurals options', () => {
     const NB_PLURALS_ARABIC = 6;
     var t;
@@ -73,42 +72,45 @@ describe('Translator', () => {
           translation: {
             test: 'test_en',
             deep: {
-              test: 'deep_en'
-            }
-          }
+              test: 'deep_en',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        saveMissing: true,
-        saveMissingPlurals: true,
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          saveMissing: true,
+          saveMissingPlurals: true,
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('ar');
     });
 
     var tests = [
-      {args: ['translation:test.missing', { count: 10 }], expected: NB_PLURALS_ARABIC},
-      {args: ['translation:test.missing', { count: 0 }], expected: NB_PLURALS_ARABIC}
+      { args: ['translation:test.missing', { count: 10 }], expected: NB_PLURALS_ARABIC },
+      { args: ['translation:test.missing', { count: 0 }], expected: NB_PLURALS_ARABIC },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
         let todo = test.expected;
         t.options.missingKeyHandler = (lngs, namespace, key, res) => {
@@ -117,7 +119,7 @@ describe('Translator', () => {
         };
 
         t.translate.apply(t, test.args);
-        expect(todo).to.eql(0)
+        expect(todo).to.eql(0);
       });
     });
   });

--- a/test/translator/translator.translate.noSeparator.spec.js
+++ b/test/translator/translator.translate.noSeparator.spec.js
@@ -5,57 +5,64 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with separators set to false', () => {
     var t;
 
     before(() => {
-      const rs = new ResourceStore({
-        en: {
-          translation: {
-            'test: with a sentence. or more text': 'test_en'
-          }
+      const rs = new ResourceStore(
+        {
+          en: {
+            translation: {
+              'test: with a sentence. or more text': 'test_en',
+            },
+          },
+          de: {
+            translation: {
+              'test: with a sentence. or more text': 'test_de',
+            },
+          },
         },
-        de: {
-          translation: {
-            'test: with a sentence. or more text': 'test_de'
-          }
-        }
-      }, { keySeparator: false });
+        { keySeparator: false },
+      );
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        ns: ['translation'],
-        defaultNS: 'translation',
-        nsSeparator: false,
-        keySeparator: false,
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          ns: ['translation'],
+          defaultNS: 'translation',
+          nsSeparator: false,
+          keySeparator: false,
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['test: with a sentence. or more text'], expected: 'test_en'},
-      {args: ['test: with a sentence. or more text', { lngs: ['en-US', 'en'] }], expected: 'test_en'},
-      {args: ['test: with a sentence. or more text', { lngs: ['de'] }], expected: 'test_de'},
-      {args: ['test: with a sentence. or more text', { lng: 'de' }], expected: 'test_de'},
-      {args: ['test: with a sentence. or more text', { lng: 'fr' }], expected: 'test_en'},
-      {args: ['test: with a sentence. or more text', { lng: 'en-US' }], expected: 'test_en'}
+      { args: ['test: with a sentence. or more text'], expected: 'test_en' },
+      {
+        args: ['test: with a sentence. or more text', { lngs: ['en-US', 'en'] }],
+        expected: 'test_en',
+      },
+      { args: ['test: with a sentence. or more text', { lngs: ['de'] }], expected: 'test_de' },
+      { args: ['test: with a sentence. or more text', { lng: 'de' }], expected: 'test_de' },
+      { args: ['test: with a sentence. or more text', { lng: 'fr' }], expected: 'test_en' },
+      { args: ['test: with a sentence. or more text', { lng: 'en-US' }], expected: 'test_en' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.plural.spec.js
+++ b/test/translator/translator.translate.plural.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with plural', () => {
     var t;
 
@@ -14,61 +13,63 @@ describe('Translator', () => {
         en: {
           translation: {
             test: 'test_en',
-            test_plural: 'tests_en'
-          }
+            test_plural: 'tests_en',
+          },
         },
         de: {
           translation: {
             test: 'test_de',
-            test_plural: 'tests_de'
-          }
+            test_plural: 'tests_de',
+          },
         },
         ja: {
           translation: {
             test: 'test_ja',
-            test_0: 'tests_ja'
-          }
-        }
+            test_0: 'tests_ja',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test', { count: 1 }], expected: 'test_en'},
-      {args: ['translation:test', { count: 2 }], expected: 'tests_en'},
-      {args: ['translation:test', { count: 1, lngs: ['en-US', 'en'] }], expected: 'test_en'},
-      {args: ['translation:test', { count: 2, lngs: ['en-US', 'en'] }], expected: 'tests_en'},
-      {args: ['translation:test', { count: 1, lngs: ['de'] }], expected: 'test_de'},
-      {args: ['translation:test', { count: 2, lngs: ['de'] }], expected: 'tests_de'},
-      {args: ['translation:test', { count: 1, lng: 'de' }], expected: 'test_de'},
-      {args: ['translation:test', { count: 2, lng: 'de' }], expected: 'tests_de'},
-      {args: ['translation:test', { count: 1, lng: 'fr' }], expected: 'test_en'},
-      {args: ['translation:test', { count: 2, lng: 'fr' }], expected: 'tests_en'},
-      {args: ['translation:test', { count: 1, lng: 'en-US' }], expected: 'test_en'},
-      {args: ['translation:test', { count: 2, lng: 'en-US' }], expected: 'tests_en'},
-      {args: ['translation:test', { count: 1, lng: 'ja' }], expected: 'tests_ja'},
-      {args: ['translation:test', { count: 2, lng: 'ja' }], expected: 'tests_ja'},
-      {args: ['translation:test', { count: 10, lng: 'ja' }], expected: 'tests_ja'}
+      { args: ['translation:test', { count: 1 }], expected: 'test_en' },
+      { args: ['translation:test', { count: 2 }], expected: 'tests_en' },
+      { args: ['translation:test', { count: 1, lngs: ['en-US', 'en'] }], expected: 'test_en' },
+      { args: ['translation:test', { count: 2, lngs: ['en-US', 'en'] }], expected: 'tests_en' },
+      { args: ['translation:test', { count: 1, lngs: ['de'] }], expected: 'test_de' },
+      { args: ['translation:test', { count: 2, lngs: ['de'] }], expected: 'tests_de' },
+      { args: ['translation:test', { count: 1, lng: 'de' }], expected: 'test_de' },
+      { args: ['translation:test', { count: 2, lng: 'de' }], expected: 'tests_de' },
+      { args: ['translation:test', { count: 1, lng: 'fr' }], expected: 'test_en' },
+      { args: ['translation:test', { count: 2, lng: 'fr' }], expected: 'tests_en' },
+      { args: ['translation:test', { count: 1, lng: 'en-US' }], expected: 'test_en' },
+      { args: ['translation:test', { count: 2, lng: 'en-US' }], expected: 'tests_en' },
+      { args: ['translation:test', { count: 1, lng: 'ja' }], expected: 'tests_ja' },
+      { args: ['translation:test', { count: 2, lng: 'ja' }], expected: 'tests_ja' },
+      { args: ['translation:test', { count: 10, lng: 'ja' }], expected: 'tests_ja' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.returnObject.spec.js
+++ b/test/translator/translator.translate.returnObject.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() with returnObjects=true', () => {
     var t;
 
@@ -15,69 +14,71 @@ describe('Translator', () => {
           common: {
             test: ['common_test_en_1', 'common_test_en_2'],
             something: {
-              range: '[{{min}}..{{max}}]'
+              range: '[{{min}}..{{max}}]',
             },
             boolean: { value: true },
-            number: { value: 42 }
+            number: { value: 42 },
           },
           special: {
-            test: ['special_test_en_1', 'special_test_en_2']
+            test: ['special_test_en_1', 'special_test_en_2'],
           },
           withContext: {
             string: 'hello world',
-            string_lined: ['hello', 'world']
-          }
+            string_lined: ['hello', 'world'],
+          },
         },
         de: {
           common: {
-            test: ['common_test_de_1', 'common_test_de_2']
+            test: ['common_test_de_1', 'common_test_de_2'],
           },
           special: {
-            test: ['special_test_de_1', 'special_test_de_2']
-          }
-        }
+            test: ['special_test_de_1', 'special_test_de_2'],
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        keySeparator: '.',
-        contextSeparator: '_',
-        returnObjects: true,
-        ns: ['common', 'special', 'withContext'],
-        defaultNS: 'common',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          keySeparator: '.',
+          contextSeparator: '_',
+          returnObjects: true,
+          ns: ['common', 'special', 'withContext'],
+          defaultNS: 'common',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['common:test'], expected: [ 'common_test_en_1', 'common_test_en_2' ]},
-      {args: ['special:test'], expected: [ 'special_test_en_1', 'special_test_en_2' ]},
+      { args: ['common:test'], expected: ['common_test_en_1', 'common_test_en_2'] },
+      { args: ['special:test'], expected: ['special_test_en_1', 'special_test_en_2'] },
 
       // should not overwrite store value
-      {args: ['common:something'], expected: { range: '[..]' }},
-      {args: ['common:something.range', { min: '1', max: '1000' }], expected: '[1..1000]'},
-      {args: ['common:boolean'], expected: { value: true }},
-      {args: ['common:number'], expected: { value: 42 }},
+      { args: ['common:something'], expected: { range: '[..]' } },
+      { args: ['common:something.range', { min: '1', max: '1000' }], expected: '[1..1000]' },
+      { args: ['common:boolean'], expected: { value: true } },
+      { args: ['common:number'], expected: { value: 42 } },
 
       // with context
-      {args: ['withContext:string'], expected: 'hello world'},
-      {args: ['withContext:string', { context: 'lined' }], expected: ['hello', 'world']},
+      { args: ['withContext:string'], expected: 'hello world' },
+      { args: ['withContext:string', { context: 'lined' }], expected: ['hello', 'world'] },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.separator.spec.js
+++ b/test/translator/translator.translate.separator.spec.js
@@ -5,63 +5,73 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() separator usage', () => {
     var t;
 
     before(() => {
-      const rs = new ResourceStore({
-        en: {
-          translation: {
-            test: 'test_en',
-            deep: {
-              test: 'testDeep_en'
+      const rs = new ResourceStore(
+        {
+          en: {
+            translation: {
+              test: 'test_en',
+              deep: {
+                test: 'testDeep_en',
+              },
+              'test::single': 'single_en',
+              'test.single': 'single_en',
             },
-            'test::single': 'single_en',
-            'test.single': 'single_en'
+            translation2: {
+              test: 'test2_en',
+            },
           },
-          translation2: {
-            test: 'test2_en'
-          }
-        }
-      }, {
-        keySeparator: '::',
-        nsSeparator: ':::'
-      });
+        },
+        {
+          keySeparator: '::',
+          nsSeparator: ':::',
+        },
+      );
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        keySeparator: '::',
-        nsSeparator: ':::',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          keySeparator: '::',
+          nsSeparator: ':::',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:::test'], expected: 'test_en'},
-      {args: ['translation2:::test'], expected: 'test2_en'},
-      {args: ['translation:::deep::test'], expected: 'testDeep_en'},
-      {args: ['translation:test', {nsSeparator: ':', keySeparator: '.'}], expected: 'test_en'},
-      {args: ['translation2:test', {nsSeparator: ':', keySeparator: '.'}], expected: 'test2_en'},
-      {args: ['translation:deep.test', {nsSeparator: ':', keySeparator: '.'}], expected: 'testDeep_en'},
-      {args: ['translation:::test::single', {keySeparator: false}], expected: 'single_en'},
-      {args: ['translation:::test.single', {keySeparator: false}], expected: 'single_en'}
+      { args: ['translation:::test'], expected: 'test_en' },
+      { args: ['translation2:::test'], expected: 'test2_en' },
+      { args: ['translation:::deep::test'], expected: 'testDeep_en' },
+      { args: ['translation:test', { nsSeparator: ':', keySeparator: '.' }], expected: 'test_en' },
+      {
+        args: ['translation2:test', { nsSeparator: ':', keySeparator: '.' }],
+        expected: 'test2_en',
+      },
+      {
+        args: ['translation:deep.test', { nsSeparator: ':', keySeparator: '.' }],
+        expected: 'testDeep_en',
+      },
+      { args: ['translation:::test::single', { keySeparator: false }], expected: 'single_en' },
+      { args: ['translation:::test.single', { keySeparator: false }], expected: 'single_en' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.skipInterpolation.spec.js
+++ b/test/translator/translator.translate.skipInterpolation.spec.js
@@ -6,7 +6,6 @@ import Interpolator from '../../src/Interpolator';
 import PostProcessor from '../../src/postProcessor';
 
 describe('Translator', () => {
-
   describe('translate() skip interpolation', () => {
     var t;
 
@@ -16,56 +15,73 @@ describe('Translator', () => {
           translation: {
             test: 'test_en {{key}}',
             deep: {
-              arr: ['deep_en arr {{key1}}', 'deep_en arr {{key2}}']
+              arr: ['deep_en arr {{key1}}', 'deep_en arr {{key2}}'],
             },
-          }
+          },
         },
         de: {
           translation: {
-            test: 'test_de {{key}}'
-          }
-        }
+            test: 'test_de {{key}}',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator(),
-      }, {
-        keySeparator: '.',
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {},
-
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          keySeparator: '.',
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {},
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
       { args: ['translation:test', { skipInterpolation: true }], expected: 'test_en {{key}}' },
-      { args: ['translation:test', { skipInterpolation: false, key: 'value' }], expected: 'test_en value' },
-      { args: ['translation:test', { lng: 'de', skipInterpolation: true }], expected: 'test_de {{key}}' },
-      { args: ['translation:test', { lng: 'fr', skipInterpolation: true }], expected: 'test_en {{key}}' },
       {
-        args: ['translation:deep', { returnObjects: true, skipInterpolation: true }],
-        expected: { arr: ['deep_en arr {{key1}}', 'deep_en arr {{key2}}'] }
+        args: ['translation:test', { skipInterpolation: false, key: 'value' }],
+        expected: 'test_en value',
       },
       {
-        args: ['translation:deep', { returnObjects: true, skipInterpolation: false, key1: 'value1', key2: 'value2' }],
-        expected: { arr: ['deep_en arr value1', 'deep_en arr value2'] }
+        args: ['translation:test', { lng: 'de', skipInterpolation: true }],
+        expected: 'test_de {{key}}',
+      },
+      {
+        args: ['translation:test', { lng: 'fr', skipInterpolation: true }],
+        expected: 'test_en {{key}}',
+      },
+      {
+        args: ['translation:deep', { returnObjects: true, skipInterpolation: true }],
+        expected: { arr: ['deep_en arr {{key1}}', 'deep_en arr {{key2}}'] },
+      },
+      {
+        args: [
+          'translation:deep',
+          { returnObjects: true, skipInterpolation: false, key1: 'value1', key2: 'value2' },
+        ],
+        expected: { arr: ['deep_en arr value1', 'deep_en arr value2'] },
       },
       {
         args: ['translation:deep.arr', { joinArrays: ' + ', skipInterpolation: true }],
-        expected: 'deep_en arr {{key1}} + deep_en arr {{key2}}'
+        expected: 'deep_en arr {{key1}} + deep_en arr {{key2}}',
       },
       {
-        args: ['translation:deep.arr', { joinArrays: ' + ', skipInterpolation: false, key1: '1', key2: '2' }],
-        expected: 'deep_en arr 1 + deep_en arr 2'
+        args: [
+          'translation:deep.arr',
+          { joinArrays: ' + ', skipInterpolation: false, key1: '1', key2: '2' },
+        ],
+        expected: 'deep_en arr 1 + deep_en arr 2',
       },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
@@ -80,31 +96,33 @@ describe('Translator', () => {
         en: {
           translation: {
             test: 'test_en',
-            simpleArr: ['simpleArr_en 1', 'simpleArr_en 2']
-          }
+            simpleArr: ['simpleArr_en 1', 'simpleArr_en 2'],
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator(),
-      }, {
-        keySeparator: '.',
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {},
-
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          keySeparator: '.',
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {},
+        },
+      );
       PostProcessor.addPostProcessor({
         name: 'postProcessValue',
-        process: (value, key, options, translator) => ("post processed: " + value),
+        process: (value, key, options, translator) => 'post processed: ' + value,
       });
       t.changeLanguage('en');
     });
@@ -112,35 +130,46 @@ describe('Translator', () => {
     var tests = [
       {
         args: ['translation:test', { skipInterpolation: true, postProcess: 'postProcessValue' }],
-        expected: 'post processed: test_en'
+        expected: 'post processed: test_en',
       },
       {
         args: ['translation:test', { skipInterpolation: false, postProcess: 'postProcessValue' }],
-        expected: 'post processed: test_en'
+        expected: 'post processed: test_en',
       },
       {
-        args: ['translation:simpleArr', { returnObjects: true, skipInterpolation: true, postProcess: 'postProcessValue' }],
-        expected: ['post processed: simpleArr_en 1', 'post processed: simpleArr_en 2']
+        args: [
+          'translation:simpleArr',
+          { returnObjects: true, skipInterpolation: true, postProcess: 'postProcessValue' },
+        ],
+        expected: ['post processed: simpleArr_en 1', 'post processed: simpleArr_en 2'],
       },
       {
-        args: ['translation:simpleArr', { returnObjects: true, skipInterpolation: false, postProcess: 'postProcessValue' }],
-        expected: ['post processed: simpleArr_en 1', 'post processed: simpleArr_en 2']
+        args: [
+          'translation:simpleArr',
+          { returnObjects: true, skipInterpolation: false, postProcess: 'postProcessValue' },
+        ],
+        expected: ['post processed: simpleArr_en 1', 'post processed: simpleArr_en 2'],
       },
       {
-        args: ['translation:simpleArr', { joinArrays: ' + ', skipInterpolation: true, postProcess: 'postProcessValue' }],
-        expected: 'post processed: simpleArr_en 1 + simpleArr_en 2'
+        args: [
+          'translation:simpleArr',
+          { joinArrays: ' + ', skipInterpolation: true, postProcess: 'postProcessValue' },
+        ],
+        expected: 'post processed: simpleArr_en 1 + simpleArr_en 2',
       },
       {
-        args: ['translation:simpleArr', { joinArrays: ' + ', skipInterpolation: false, postProcess: 'postProcessValue' }],
-        expected: 'post processed: simpleArr_en 1 + simpleArr_en 2'
+        args: [
+          'translation:simpleArr',
+          { joinArrays: ' + ', skipInterpolation: false, postProcess: 'postProcessValue' },
+        ],
+        expected: 'post processed: simpleArr_en 1 + simpleArr_en 2',
       },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.spec.js
+++ b/test/translator/translator.translate.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate()', () => {
     var t;
 
@@ -15,51 +14,53 @@ describe('Translator', () => {
           translation: {
             test: 'test_en',
             deep: {
-              test: 'deep_en'
-            }
-          }
+              test: 'deep_en',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test'], expected: 'test_en'},
-      {args: ['translation:test', { lngs: ['en-US', 'en'] }], expected: 'test_en'},
-      {args: ['translation:test', { lngs: ['de'] }], expected: 'test_de'},
-      {args: ['translation:test', { lng: 'de' }], expected: 'test_de'},
-      {args: ['translation:test', { lng: 'fr' }], expected: 'test_en'},
-      {args: ['translation:test', { lng: 'en-US' }], expected: 'test_en'},
-      {args: ['translation.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'test_en'},
-      {args: ['translation.deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'deep_en'},
-      {args: ['deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'deep_en'}
+      { args: ['translation:test'], expected: 'test_en' },
+      { args: ['translation:test', { lngs: ['en-US', 'en'] }], expected: 'test_en' },
+      { args: ['translation:test', { lngs: ['de'] }], expected: 'test_de' },
+      { args: ['translation:test', { lng: 'de' }], expected: 'test_de' },
+      { args: ['translation:test', { lng: 'fr' }], expected: 'test_en' },
+      { args: ['translation:test', { lng: 'en-US' }], expected: 'test_en' },
+      { args: ['translation.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'test_en' },
+      { args: ['translation.deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'deep_en' },
+      { args: ['deep.test', { lng: 'en-US', nsSeparator: '.' }], expected: 'deep_en' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.systemProperties.spec.js
+++ b/test/translator/translator.translate.systemProperties.spec.js
@@ -14,7 +14,6 @@ import Interpolator from '../../src/Interpolator';
 // when a fallback is needed to find the actual definition of that property
 
 describe('Translator', () => {
-
   describe('translate()', () => {
     var t;
 
@@ -24,45 +23,47 @@ describe('Translator', () => {
           translation: {
             test: {
               length: 'test_length',
-              search: 'test_search'
-            }
-          }
+              search: 'test_search',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('de');
     });
 
     var tests = [
-      {args: ['test', { lng: 'de', nsSeparator: '.' }], expected: 'test_de'},
-      {args: ['test.length', { lng: 'de', nsSeparator: '.' }], expected: 'test_length'},
-      {args: ['test.search', { lng: 'de', nsSeparator: '.' }], expected: 'test_search'}
+      { args: ['test', { lng: 'de', nsSeparator: '.' }], expected: 'test_de' },
+      { args: ['test.length', { lng: 'de', nsSeparator: '.' }], expected: 'test_length' },
+      { args: ['test.search', { lng: 'de', nsSeparator: '.' }], expected: 'test_search' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
   });
-
 });

--- a/test/translator/translator.translate.updateMissing.spec.js
+++ b/test/translator/translator.translate.updateMissing.spec.js
@@ -5,7 +5,6 @@ import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
-
   describe('translate() using updateMissing', () => {
     var t;
 
@@ -15,41 +14,44 @@ describe('Translator', () => {
           translation: {
             test: 'test_en',
             deep: {
-              test: 'deep_en'
-            }
-          }
+              test: 'deep_en',
+            },
+          },
         },
         de: {
           translation: {
-            test: 'test_de'
-          }
-        }
+            test: 'test_de',
+          },
+        },
       });
       const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator({
-        resourceStore: rs,
-        languageUtils: lu,
-        pluralResolver: new PluralResolver(lu, {prepend: '_', simplifyPluralSuffix: true}),
-        interpolator: new Interpolator()
-      }, {
-        defaultNS: 'translation',
-        ns: 'translation',
-        saveMissing: true,
-        updateMissing: true,
-        interpolation: {
-          interpolateResult: true,
-          interpolateDefaultValue: true,
-          interpolateKey: true
-        }
-      });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          defaultNS: 'translation',
+          ns: 'translation',
+          saveMissing: true,
+          updateMissing: true,
+          interpolation: {
+            interpolateResult: true,
+            interpolateDefaultValue: true,
+            interpolateKey: true,
+          },
+        },
+      );
       t.changeLanguage('en');
     });
 
     var tests = [
-      {args: ['translation:test', { defaultValue: 'new value' }], expected: 'test_en'}
+      { args: ['translation:test', { defaultValue: 'new value' }], expected: 'test_en' },
     ];
 
-    tests.forEach((test) => {
+    tests.forEach(test => {
       it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
         let wasCalled = false;
 
@@ -68,5 +70,4 @@ describe('Translator', () => {
       });
     });
   });
-
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,32 +1,37 @@
 import * as utils from '../src/utils';
 
 describe('utils', () => {
-
   describe('#deepExtend', () => {
-
     it('it should overwrite if flag set', () => {
-      const res = utils.deepExtend({
-        some: 'thing'
-      }, {
-        some: 'else'
-      }, true);
+      const res = utils.deepExtend(
+        {
+          some: 'thing',
+        },
+        {
+          some: 'else',
+        },
+        true,
+      );
 
       expect(res).to.eql({
-        some: 'else'
+        some: 'else',
       });
     });
 
     it('it should not overwrite', () => {
-      const res = utils.deepExtend({
-        some: 'thing'
-      }, {
-        some: 'else'
-      }, false);
+      const res = utils.deepExtend(
+        {
+          some: 'thing',
+        },
+        {
+          some: 'else',
+        },
+        false,
+      );
 
       expect(res).to.eql({
-        some: 'thing'
+        some: 'thing',
       });
     });
-
   });
 });


### PR DESCRIPTION
For the sake of PRs and keeping files in shape for reviews, I'd like to add lint-staged and prettier.  This adds the config in the `package.json` in one commit, and performs a baseline `npm run prettier` so the repo is setup for new PRs.

If we want the prettier settings changed, let's get the `.prettierrc` corrected and I'll add this to react-i18next as well if approved.