### PR TITLE
TFunction external use broken without using interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -469,6 +469,7 @@ declare namespace i18next {
 
   interface WithT {
     // Expose parameterized t in the i18next interface hierarchy
+    // NOTE: duplicate of TFunction - not sure why I can't find a workable reuse pattern
     t<
       TResult extends string | object | Array<string | object> = string,
       TKeys extends string = string,
@@ -479,7 +480,14 @@ declare namespace i18next {
     ): TResult;
   }
 
-  type TFunction = WithT['t'];
+  // NOTE: duplicate of WithT.t - not sure why I can't find a workable reuse pattern
+  interface TFunction<
+    TResult extends string | object | Array<string | object> = string,
+    TKeys extends string = string,
+    TValues extends object = object
+  > {
+    (key: TKeys | TKeys[], options?: TOptions<TValues>): TResult;
+  }
 
   interface Resource {
     [language: string]: ResourceLanguage;

--- a/test/typescript/t.external.ts
+++ b/test/typescript/t.external.ts
@@ -1,0 +1,12 @@
+import i18next from 'i18next';
+
+/**
+ * Use of the exported TFunction in external utility methods
+ */
+function resolveText(t: i18next.TFunction, keyOrText?: string): undefined | string {
+  if (keyOrText && keyOrText.startsWith(':')) {
+    return t(keyOrText.substring(1, keyOrText.length));
+  } else {
+    return keyOrText;
+  }
+}

--- a/test/typescript/t.external.ts
+++ b/test/typescript/t.external.ts
@@ -1,7 +1,8 @@
 import i18next from 'i18next';
 
 /**
- * Use of the exported TFunction in external utility methods
+ * Use of the exported TFunction in external utility methods such as
+ *  NamespaceConsumer children t
  */
 function resolveText(t: i18next.TFunction, keyOrText?: string): undefined | string {
   if (keyOrText && keyOrText.startsWith(':')) {


### PR DESCRIPTION
Unfortunately this duplicates the interface outside of `WithT`, but as the test shows (and breaks in react `NamespaceConsumer` https://github.com/i18next/react-i18next/issues/693) we need it (at least until we find a better way to reference it).