### PR TITLE
#1189 typescript - accept templatestringsarray as TKey

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -469,21 +469,12 @@ declare namespace i18next {
 
   interface WithT {
     // Expose parameterized t in the i18next interface hierarchy
-    // NOTE: duplicate of TFunction - not sure why I can't find a workable reuse pattern
-    t<
-      TResult extends string | object | Array<string | object> | undefined = string,
-      TKeys extends string = string,
-      TValues extends object = object
-    >(
-      key: TKeys | TKeys[],
-      options?: TOptions<TValues>,
-    ): TResult;
+    t: TFunction;
   }
 
-  // NOTE: somewhat duplicate of WithT.t but cannot use interface - not sure why I can't find a workable reuse pattern
   type TFunction = <
     TResult extends string | object | Array<string | object> | undefined = string,
-    TKeys extends string = string,
+    TKeys extends string | TemplateStringsArray = string,
     TValues extends object = object
   >(
     key: TKeys | TKeys[],

--- a/test/typescript/t.tfunction.test.ts
+++ b/test/typescript/t.tfunction.test.ts
@@ -7,12 +7,14 @@ import i18next from 'i18next';
 function childrenNamespacesConsumer(t: i18next.TFunction, i18n: i18next.i18n) {
   // sanity first - tests from i18next t.test
   const is: string = i18n.t('friend'); // same as <string>
+  const is2: string = i18n.t`friend`; // same as <string>
   const io: object = i18n.t<object>('friend');
   const isa: string[] = i18n.t<string[]>('friend');
   const ioa: object[] = i18n.t<object[]>('friend');
 
   // (failing) now try t provided by NamespacesConsumer
   const s: string = t('friend'); // same as <string>
+  const s2: string = t`friend`;
   const o: object = t<object>('friend');
   const sa: string[] = t<string[]>('friend');
   const oa: object[] = t<object[]>('friend');

--- a/test/typescript/t.witht.test.ts
+++ b/test/typescript/t.witht.test.ts
@@ -73,12 +73,14 @@ i18next.t('arrayOfObjects.0.name');
 // -> "tom"
 
 i18next.t('friend');
+i18next.t`friend`;
 i18next.t(['friend', 'tree']);
 i18next.t('friend', { myVar: 'someValue' });
 i18next.t(['friend', 'tree'], { myVar: 'someValue' });
 
 // various returns <string> is the default
 const s: string = i18next.t('friend'); // same as <string>
+const s2: string = i18next.t`friend`;
 const o: object = i18next.t<object>('friend');
 const sa: string[] = i18next.t<string[]>('friend');
 const oa: object[] = i18next.t<object[]>('friend');


### PR DESCRIPTION
I added a few cases to the tests and pass the `npm run test:typescript`. Please let me know if there is anything uncool.

PS:  
1. it may conflict with https://github.com/i18next/i18next/pull/1186, please check if my tweak is fine.
2. things like `t'key-with-${var}'` won't work with this declaration but I don't think that's a big deal