### PR TITLE
Fix exports for node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,5 @@
-module.exports = require('./dist/commonjs/index.js').default;
+/* eslint no-var: 0 */
+var main = require('./dist/commonjs/index.js').default;
+
+module.exports = main;
+module.exports.default = main;


### PR DESCRIPTION
Both import methods (`import * as i18next from 'i18next'` and `import i18next from 'i18next'`) work this way. It is necessary since the browser exports use a default export but the node ones don't.