### PR TITLE
Add `hashTransKey` to `ReactOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ declare namespace i18next {
      * that always throws an error.
      * @default undefined
      */
-    hashTransKey?(defaultValue: typeof TOptionsBase['defaultValue']): typeof TOptionsBase['defaultValue'];
+    hashTransKey?(defaultValue: TOptionsBase['defaultValue']): TOptionsBase['defaultValue'];
   }
 
   interface InitOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,15 @@ declare namespace i18next {
      * @default undefined
      */
     transEmptyNodeValue?: string;
+    /**
+     * Function to generate an i18nKey from the defaultValue (or Trans children)
+     * when no key is provided.
+     * By default, the defaultValue (Trans text) itself is used as the key.
+     * If you want to require keys for all translations, supply a function
+     * that always throws an error.
+     * @default undefined
+     */
+    hashTransKey?(defaultValue: typeof TOptionsBase['defaultValue']): typeof TOptionsBase['defaultValue'];
   }
 
   interface InitOptions {

--- a/test/typescript/init.test.ts
+++ b/test/typescript/init.test.ts
@@ -419,3 +419,15 @@ i18next.init({
     },
   },
 });
+
+i18next.init({
+  react: {
+    hashTransKey: defaultValue => {
+      if (typeof defaultValue === 'string') {
+        return defaultValue.replace(/\s+/g, '_');
+      } else {
+        throw new Error("Don't know how to make key for non-string defaultValue");
+      }
+    },
+  },
+});


### PR DESCRIPTION
Add typings for `hashTransKey` [introduced][1] in react-i18next 6.2.0.

[1]: https://github.com/i18next/react-i18next/commit/06fb359371f9c5a21eb4fd0148a7e739b5975fd1

(It might be more readable to define something like `type DefaultValue = any` and use that throughout.)