### PR TITLE
Add useSuspense to ReactOptions, fix error throwing on test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,11 @@ declare namespace i18next {
      */
     transEmptyNodeValue?: string;
     /**
+     * Set it to false if you do not want to use Suspense
+     * @default true
+     */
+    useSuspense?: boolean;
+    /**
      * Function to generate an i18nKey from the defaultValue (or Trans children)
      * when no key is provided.
      * By default, the defaultValue (Trans text) itself is used as the key.

--- a/test/typescript/init.test.ts
+++ b/test/typescript/init.test.ts
@@ -425,9 +425,9 @@ i18next.init({
     hashTransKey: defaultValue => {
       if (typeof defaultValue === 'string') {
         return defaultValue.replace(/\s+/g, '_');
-      } else {
-        throw new Error("Don't know how to make key for non-string defaultValue");
       }
+
+      throw new Error("Don't know how to make key for non-string defaultValue");
     },
   },
 });


### PR DESCRIPTION
Hello, first contribution to the project. Ran into this earlier today when integrating with i18next:

![Screen Shot 2019-03-13 at 2 09 36 PM (1)](https://user-images.githubusercontent.com/15256554/54330429-a9ca2200-45e3-11e9-8229-b0894ca8e986.png)

Turns out useSuspense is not on the ReactOptions interface, but is listed in the documentation: https://react.i18next.com/latest/i18next-instance

This PR should address the above. It may also be worthwhile to add the additional options for react in init options listed in the same link above. Happy to do so at a later time.

Ran tests prior to committing and ran into this:
<img width="849" alt="Screen Shot 2019-03-13 at 10 52 31 PM" src="https://user-images.githubusercontent.com/15256554/54330536-2d840e80-45e4-11e9-9fdf-ebd4dff5e829.png">

Which led the update to the init.test.ts file.