### PR TITLE
adding init function to 3rdParty module typings and enforcing type property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -613,7 +613,8 @@ declare namespace i18next {
   }
 
   interface ThirdPartyModule {
-    type?: '3rdParty';
+    type: '3rdParty';
+    init(i18n: i18n): void;
   }
 
   interface Modules {

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -29,6 +29,7 @@ const i18nFormatModule = {
 
 const thirdPartyModule = {
   type: '3rdParty' as '3rdParty',
+  init: () => null,
 };
 
 const externalModules = [thirdPartyModule];


### PR DESCRIPTION
While the plugin interfaces can't be used directly since they're not exported, it still serves as reference / documentation.