### PR TITLE
Update BackendModule interface to allow null or undefined for the cal…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -544,7 +544,7 @@ declare namespace i18next {
     read(
       language: string,
       namespace: string,
-      callback: (err: Error, data: ResourceLanguage) => void,
+      callback: (err: Error | null | undefined, data: ResourceLanguage) => void,
     ): void;
     /** Save the missing translation */
     create(languages: string[], namespace: string, key: string, fallbackValue: string): void;
@@ -552,7 +552,7 @@ declare namespace i18next {
     readMulti?(
       languages: string[],
       namespaces: string[],
-      callback: (err: Error, data: Resource) => void,
+      callback: (err: Error | null | undefined, data: Resource) => void,
     ): void;
     /** Store the translation. For backends acting as cache layer */
     save?(language: string, namespace: string, data: ResourceLanguage): void;


### PR DESCRIPTION
The current typings require that there is always an `Error` passed in to the `BackendModule` callbacks.  `null | undefined` needs to be added for callbacks with no error.  `null` because that is what is shown in the docs for creating a custom backend and it's commonly used.  `undefined` because many projects use linting rules that disallow `null` in favor of `undefined`.

I don't think there are any tests that need updating based on this change.  Please let me know if that is incorrect.