### PR TITLE
ResourceKey type should allow top level string value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -638,10 +638,12 @@ declare namespace i18next {
   interface ResourceLanguage {
     [namespace: string]: ResourceKey;
   }
-
-  interface ResourceKey {
-    [key: string]: any;
-  }
+               
+  type ResourceKey =
+    | string
+    | {
+        [key: string]: any;
+      };
 
   export interface Interpolator {
     init(options: InterpolationOptions, reset: boolean): undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -638,7 +638,7 @@ declare namespace i18next {
   interface ResourceLanguage {
     [namespace: string]: ResourceKey;
   }
-               
+
   type ResourceKey =
     | string
     | {

--- a/test/typescript/init.test.ts
+++ b/test/typescript/init.test.ts
@@ -10,6 +10,7 @@ i18next.init(
         translation: {
           key: 'hello world',
         },
+        key: 'hello world',
       },
     },
   },


### PR DESCRIPTION
`ResourceKey` can also be string like in this case

```
{
  en: {
    "logout": "Logout"
  }
}
```