### PR TITLE
[TS]Allow non synthetic default imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -974,4 +974,4 @@ declare namespace i18next {
 }
 
 declare const i18next: i18next.i18n;
-export default i18next;
+export = i18next;


### PR DESCRIPTION
Based on https://github.com/DefinitelyTyped/DefinitelyTyped#a-package-uses-export--but-i-prefer-to-use-default-imports-can-i-change-export--to-export-default

this should work for imports such as `const i18n = require('i18next')` and `import * as i18n from "i18n"`.

Fixes https://github.com/i18next/i18next/issues/1271
