### PR TITLE
Correct `use(module)` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -697,7 +697,7 @@ declare namespace i18next {
     type: 'languageDetector';
     init(services: Services, detectorOptions: object, i18nextOptions: InitOptions): void;
     /** Must return detected language */
-    detect(): string;
+    detect(): string | undefined;
     cacheUserLanguage(lng: string): void;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -604,8 +604,7 @@ declare namespace i18next {
   /**
    * Options that allow open ended values for interpolation unless type is provided.
    */
-  type TOptions<TInterpolationMap extends object = StringMap> = TOptionsBase & 
-  TInterpolationMap;
+  type TOptions<TInterpolationMap extends object = StringMap> = TOptionsBase & TInterpolationMap;
 
   type Callback = (error: any, t: TFunction) => void;
 
@@ -666,13 +665,17 @@ declare namespace i18next {
     resourceStore: Resource;
   }
 
+  interface Module {
+    type: 'backend' | 'logger' | 'languageDetector' | 'postProcessor' | 'i18nFormat' | '3rdParty';
+  }
+
   /**
    * Used to load data for i18next.
    * Can be provided as a singleton or as a prototype constructor (preferred for supporting multiple instances of i18next).
    * For singleton set property `type` to `'backend'` For a prototype constructor set static property.
    */
-  interface BackendModule {
-    type?: 'backend';
+  interface BackendModule extends Module {
+    type: 'backend';
     init(services: Services, backendOptions: object, i18nextOptions: InitOptions): void;
     read(
       language: string,
@@ -696,8 +699,8 @@ declare namespace i18next {
    * Can be provided as a singleton or as a prototype constructor (preferred for supporting multiple instances of i18next).
    * For singleton set property `type` to `'languageDetector'` For a prototype constructor set static property.
    */
-  interface LanguageDetectorModule {
-    type?: 'languageDetector';
+  interface LanguageDetectorModule extends Module {
+    type: 'languageDetector';
     init(services: Services, detectorOptions: object, i18nextOptions: InitOptions): void;
     /** Must return detected language */
     detect(): string;
@@ -709,8 +712,8 @@ declare namespace i18next {
    * Can be provided as a singleton or as a prototype constructor (preferred for supporting multiple instances of i18next).
    * For singleton set property `type` to `'languageDetector'` For a prototype constructor set static property.
    */
-  interface LanguageDetectorAsyncModule {
-    type?: 'languageDetector';
+  interface LanguageDetectorAsyncModule extends Module {
+    type: 'languageDetector';
     /** Set to true to enable async detection */
     async: true;
     init(services: Services, detectorOptions: object, i18nextOptions: InitOptions): void;
@@ -723,7 +726,7 @@ declare namespace i18next {
    * Used to extend or manipulate the translated values before returning them in `t` function.
    * Need to be a singleton object.
    */
-  interface PostProcessorModule {
+  interface PostProcessorModule extends Module {
     /** Unique name */
     name: string;
     type: 'postProcessor';
@@ -734,18 +737,18 @@ declare namespace i18next {
    * Override the built-in console logger.
    * Do not need to be a prototype function.
    */
-  interface LoggerModule {
-    type?: 'logger';
+  interface LoggerModule extends Module {
+    type: 'logger';
     log(...args: any[]): void;
     warn(...args: any[]): void;
     error(...args: any[]): void;
   }
 
-  interface I18nFormatModule {
-    type?: 'i18nFormat';
+  interface I18nFormatModule extends Module {
+    type: 'i18nFormat';
   }
 
-  interface ThirdPartyModule {
+  interface ThirdPartyModule extends Module {
     type: '3rdParty';
     init(i18next: i18n): void;
   }
@@ -759,7 +762,6 @@ declare namespace i18next {
   }
 
   interface i18n {
-
     // Expose parameterized t in the i18next interface hierarchy
     t: TFunction;
 
@@ -779,15 +781,7 @@ declare namespace i18next {
      * The use function is there to load additional plugins to i18next.
      * For available module see the plugins page and don't forget to read the documentation of the plugin.
      */
-    use(
-      module:
-        | BackendModule
-        | LoggerModule
-        | LanguageDetectorModule
-        | LanguageDetectorAsyncModule
-        | I18nFormatModule
-        | ThirdPartyModule[],
-    ): i18n;
+    use<T extends Module>(module: T | ThirdPartyModule[]): i18n;
 
     /**
      * List of modules used

--- a/index.d.ts
+++ b/index.d.ts
@@ -669,27 +669,21 @@ declare namespace i18next {
     type: 'backend' | 'logger' | 'languageDetector' | 'postProcessor' | 'i18nFormat' | '3rdParty';
   }
 
+  type ReadCallback = (err: Error | null | undefined, data: Resource) => void;
+
   /**
    * Used to load data for i18next.
    * Can be provided as a singleton or as a prototype constructor (preferred for supporting multiple instances of i18next).
    * For singleton set property `type` to `'backend'` For a prototype constructor set static property.
    */
-  interface BackendModule extends Module {
+  interface BackendModule<TOptions = object> extends Module {
     type: 'backend';
-    init(services: Services, backendOptions: object, i18nextOptions: InitOptions): void;
-    read(
-      language: string,
-      namespace: string,
-      callback: (err: Error | null | undefined, data: ResourceLanguage) => void,
-    ): void;
+    init(services: Services, backendOptions: TOptions, i18nextOptions: InitOptions): void;
+    read(language: string, namespace: string, callback: ReadCallback): void;
     /** Save the missing translation */
     create(languages: string[], namespace: string, key: string, fallbackValue: string): void;
     /** Load multiple languages and namespaces. For backends supporting multiple resources loading */
-    readMulti?(
-      languages: string[],
-      namespaces: string[],
-      callback: (err: Error | null | undefined, data: Resource) => void,
-    ): void;
+    readMulti?(languages: string[], namespaces: string[], callback: ReadCallback): void;
     /** Store the translation. For backends acting as cache layer */
     save?(language: string, namespace: string, data: ResourceLanguage): void;
   }

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -1,7 +1,14 @@
-import i18next, { Modules } from 'i18next';
+import i18next, {
+  Modules,
+  BackendModule,
+  LanguageDetectorModule,
+  LoggerModule,
+  I18nFormatModule,
+  ThirdPartyModule,
+} from 'i18next';
 
-const backendModule = {
-  type: 'backend' as 'backend',
+const backendModule: BackendModule = {
+  type: 'backend',
   init: () => null,
   read: () => null,
   create: () => null,
@@ -9,26 +16,26 @@ const backendModule = {
   save: () => null,
 };
 
-const languageDetectorModule = {
-  type: 'languageDetector' as 'languageDetector',
+const languageDetectorModule: LanguageDetectorModule = {
+  type: 'languageDetector',
   init: () => null,
   detect: () => '',
   cacheUserLanguage: () => null,
 };
 
-const loggerModule = {
-  type: 'logger' as 'logger',
+const loggerModule: LoggerModule = {
+  type: 'logger',
   log: () => null,
   warn: () => null,
   error: () => null,
 };
 
-const i18nFormatModule = {
-  type: 'i18nFormat' as 'i18nFormat',
+const i18nFormatModule: I18nFormatModule = {
+  type: 'i18nFormat',
 };
 
-const thirdPartyModule = {
-  type: '3rdParty' as '3rdParty',
+const thirdPartyModule: ThirdPartyModule = {
+  type: '3rdParty',
   init: () => null,
 };
 
@@ -42,8 +49,8 @@ const modules: Modules = {
   external: externalModules,
 };
 
-i18next.use(externalModules);
 i18next.use(backendModule);
 i18next.use(languageDetectorModule);
 i18next.use(loggerModule);
+i18next.use(i18nFormatModule);
 i18next.use(externalModules);

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -7,6 +7,9 @@ import i18next, {
   ThirdPartyModule,
 } from 'i18next';
 
+// declare modules in a way that the `type` is not widened
+// @see https://github.com/microsoft/TypeScript/issues/20271#issuecomment-347020203
+
 const backendModule: BackendModule = {
   type: 'backend',
   init: () => null,


### PR DESCRIPTION
This is going to be a cascading set of changes across projects. Tightening the `use()` method args in #1291 exposed that the downstream types were incorrect, and the types here were not flexible enough to accomodate.

Closes #1294 (along with related PRs in other repos)

## Rebuild and merge after this release:
- [ ] https://github.com/i18next/i18next-xhr-backend/pull/319
- [ ] https://github.com/i18next/i18next-browser-languageDetector/pull/180
- [ ] https://github.com/i18next/react-i18next/pull/912