### PR TITLE
Expose more classes in rollup bundle for downstream testing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
 import i18next from './i18next.js';
 
 export default i18next;
+
+// expose the following in the rollup bundle for downstream testing e.g. i18next-xhr-backend
+export { default as BackendConnector } from './BackendConnector';
+export { default as Interpolator } from './Interpolator';
+export { default as ResourceStore } from './ResourceStore';


### PR DESCRIPTION
Needed for https://github.com/i18next/i18next-xhr-backend/pull/319

Updating the i18next dependency there revealed test dependence on old non-rollup dist structure.