### PR TITLE
Allow augmentation of TFunction to be able to add overloads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -623,14 +623,16 @@ declare namespace i18next {
     t: TFunction;
   }
 
-  type TFunction = <
-    TResult extends string | object | Array<string | object> | undefined | null = string,
-    TKeys extends string | TemplateStringsArray = string,
-    TInterpolationMap extends object = StringMap
-  >(
-    key: TKeys | TKeys[],
-    options?: TOptions<TInterpolationMap> | string,
-  ) => TResult;
+  interface TFunction {
+    <
+      TResult extends string | object | Array<string | object> | undefined | null = string,
+      TKeys extends string | TemplateStringsArray = string,
+      TInterpolationMap extends object = StringMap
+    >(
+      key: TKeys | TKeys[],
+      options?: TOptions<TInterpolationMap> | string,
+    ): TResult;
+  }
 
   interface Resource {
     [language: string]: ResourceLanguage;


### PR DESCRIPTION
Required for the types for i18next-sprintf-postprocessor at DT to be updated to make use of the bundled i18next types.