### PR TITLE
remove unused Interpolator#init reset param (only used internally)

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -5,15 +5,13 @@ class Interpolator {
   constructor(options = {}) {
     this.logger = baseLogger.create('interpolator');
 
-    this.init(options, true);
+    this.options = options;
+    this.format = (options.interpolation && options.interpolation.format) || (value => value);
+    this.init(options);
   }
 
   /* eslint no-param-reassign: 0 */
-  init(options = {}, reset) {
-    if (reset) {
-      this.options = options;
-      this.format = (options.interpolation && options.interpolation.format) || (value => value);
-    }
+  init(options = {}) {
     if (!options.interpolation) options.interpolation = { escapeValue: true };
 
     const iOpts = options.interpolation;


### PR DESCRIPTION
Hi!

I started to use this library and I would like to collaborate. I removed Interpolator#init `reset` param because it's just used internally in the constructor.

Cheers!

