### PR TITLE
Incorrect callback type for backend module read callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -684,7 +684,9 @@ declare namespace i18next {
     type: 'backend' | 'logger' | 'languageDetector' | 'postProcessor' | 'i18nFormat' | '3rdParty';
   }
 
-  type ReadCallback = (err: Error | null | undefined, data: Resource) => void;
+  type CallbackError = Error | null | undefined;
+  type ReadCallback = (err: CallbackError, data: ResourceKey) => void;
+  type MultiReadCallback = (err: CallbackError, data: Resource) => void;
 
   /**
    * Used to load data for i18next.

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -13,9 +13,21 @@ import i18next, {
 const backendModule: BackendModule = {
   type: 'backend',
   init: () => null,
-  read: () => null,
+  read: (_language, _namespace, callback) => {
+    callback(null, {
+      key: 'value',
+    });
+  },
   create: () => null,
-  readMulti: () => null,
+  readMulti: (_languages, _namespaces, callback) => {
+    callback(null, {
+      en: {
+        namespace: {
+          key: 'value',
+        },
+      },
+    });
+  },
   save: () => null,
 };
 


### PR DESCRIPTION
The `ReadCallback` is the same for both `read` and `readMulti` but according to the docs they expected two different values: https://www.i18next.com/misc/creating-own-plugins#backend

Code from the docs:

```javascript
  read: function(language, namespace, callback) {
    /* return resources */
    callback(null, {
      key: 'value'
    });
  },

  // optional
  readMulti: function(languages, namespaces, callback) {
    /* return multiple resources - usefull eg. for bundling loading in one xhr request */
    callback(null, {
      en: {
        translations: {
          key: 'value'
        }
      },
      de: {
        translations: {
          key: 'value'
        }
      }
    });
  },
```

Before this change, it would error: `Type 'string' is not assignable to type 'ResourceLanguage'`.

In the following code: 

```typescript
const backendModule: BackendModule = {
  type: 'backend',
  init: () => null,
  read: (_language, _namespace, callback) => {
    callback(null, {
      key: 'value', // <-- Type 'string' is not assignable to type 'ResourceLanguage'
    });
  },
  create: () => null,
  readMulti: (_languages, _namespaces, callback) => {
    callback(null, {
      en: {
        namespace: {
          key: 'value',
        },
      },
    });
  },
  save: () => null,
};
```