### PR TITLE
Add allLanguages property to initOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -537,6 +537,12 @@ declare namespace i18next {
        */
       allowedHosts?: string[];
     };
+
+     /**
+       * Returns an array of language-codes that will be used to look up the available languages.
+       * @default []
+       */
+      allLanguages?: string[];
   }
 
   interface TOptionsBase {


### PR DESCRIPTION
We tried to lookup allLanguages by logging i18n.options to console. Since there is no interface for allLanguages property we couldn't retrieve values. We made it work by adding interface to initOptions.