### PR TITLE
Improve performance of EventEmitter.off

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -17,7 +17,7 @@ class EventEmitter {
     }
 
     const observers = this.observers[event];
-    for (const i = observers.length - 1; i >= 0; i--) {
+    for (let i = observers.length - 1; i >= 0; i--) {
       const observer = observers[i];
       if (observer === listener) {
         observers.splice(i, 1);

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -13,7 +13,10 @@ class EventEmitter {
 
   off(event, listener) {
     if (!this.observers[event]) return;
-    if (!listener) return delete this.observers[event];
+    if (!listener) {
+      delete this.observers[event];
+      return;
+    }
 
     this.observers[event] = this.observers[event].filter(l => l !== listener);
   }

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -12,17 +12,10 @@ class EventEmitter {
   }
 
   off(event, listener) {
-    if (!this.observers[event]) {
-      return;
-    }
+    if (!this.observers[event]) return;
+    if (!listener) return delete this.observers[event];
 
-    const observers = this.observers[event];
-    for (let i = observers.length - 1; i >= 0; i--) {
-      const observer = observers[i];
-      if (observer === listener) {
-        observers.splice(i, 1);
-      }
-    }
+    this.observers[event] = this.observers[event].filter(l => l !== listener);
   }
 
   emit(event, ...args) {

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -16,16 +16,13 @@ class EventEmitter {
       return;
     }
 
-    this.observers[event].forEach(() => {
-      if (!listener) {
-        delete this.observers[event];
-      } else {
-        const index = this.observers[event].indexOf(listener);
-        if (index > -1) {
-          this.observers[event].splice(index, 1);
-        }
+    var observers = this.observers[event];
+    for (var i = observers.length - 1; i >= 0; i--) {
+      var observer = observers[i];
+      if (observer === listener) {
+        observers.splice(i, 1);
       }
-    });
+    }
   }
 
   emit(event, ...args) {

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -16,9 +16,9 @@ class EventEmitter {
       return;
     }
 
-    var observers = this.observers[event];
-    for (var i = observers.length - 1; i >= 0; i--) {
-      var observer = observers[i];
+    const observers = this.observers[event];
+    for (const i = observers.length - 1; i >= 0; i--) {
+      const observer = observers[i];
       if (observer === listener) {
         observers.splice(i, 1);
       }

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -66,5 +66,30 @@ describe('i18next', () => {
 
       expect(returned).to.equal(emitter);
     });
+
+    it('it should correctly unbind observers', () => {
+      const calls1 = [];
+      const calls2 = [];
+      const listener1 = payload => {
+        calls1.push(payload);
+      };
+      const listener2 = payload => {
+        calls2.push(payload);
+      };
+
+      emitter.on('events', listener1);
+      emitter.on('events', listener2);
+      emitter.on('events', listener1);
+
+      emitter.emit('events', 1);
+      emitter.off('events', listener1);
+      emitter.emit('events', 2);
+      emitter.off('events', listener2);
+      emitter.emit('events', 3);
+      emitter.off('events', listener2);
+
+      expect(calls1).to.eql([1, 1]);
+      expect(calls2).to.eql([1, 2]);
+    });
   });
 });

--- a/test/eventEmitter.spec.js
+++ b/test/eventEmitter.spec.js
@@ -69,16 +69,23 @@ describe('i18next', () => {
 
     it('it should correctly unbind observers', () => {
       const calls1 = [];
-      const calls2 = [];
       const listener1 = payload => {
         calls1.push(payload);
       };
+
+      const calls2 = [];
       const listener2 = payload => {
         calls2.push(payload);
       };
 
+      const calls3 = [];
+      const listener3 = payload => {
+        calls3.push(payload);
+      };
+
       emitter.on('events', listener1);
       emitter.on('events', listener2);
+      emitter.on('events', listener3);
       emitter.on('events', listener1);
 
       emitter.emit('events', 1);
@@ -87,9 +94,12 @@ describe('i18next', () => {
       emitter.off('events', listener2);
       emitter.emit('events', 3);
       emitter.off('events', listener2);
+      emitter.off('events');
+      emitter.emit('events', 4);
 
       expect(calls1).to.eql([1, 1]);
       expect(calls2).to.eql([1, 2]);
+      expect(calls3).to.eql([1, 2, 3]);
     });
   });
 });


### PR DESCRIPTION
The loop in `EventEmitter.off` is is unnecessarily expensive.
Looping over all observers and calling `indexOf` each time results in (roughly) quadratic time complexity, leading to slowdowns when lots of listeners are registered.

This solution might still not be ideal due to the `Array.slice` call and we might be better off just using `Array.filter` (it certainly would be cleaner).
Unfortunately I don't know enough about the backwards-compatibility requirements off this project to make this decision.