### PR TITLE
Support using ImmutableJS Records as the data model.

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -70,20 +70,21 @@ class Interpolator {
     const defaultData =
       (this.options && this.options.interpolation && this.options.interpolation.defaultVariables) ||
       {};
-    let combindedData = { ...defaultData, ...data };
 
     function regexSafe(val) {
       return val.replace(/\$/g, '$$$$');
     }
 
     const handleFormat = key => {
-      if (key.indexOf(this.formatSeparator) < 0) return utils.getPath(combindedData, key);
+      if (key.indexOf(this.formatSeparator) < 0) {
+        return utils.getPathWithDefaults(data, defaultData, key);
+      }
 
       const p = key.split(this.formatSeparator);
       const k = p.shift().trim();
       const f = p.join(this.formatSeparator).trim();
 
-      return this.format(utils.getPath(combindedData, k), f, lng);
+      return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
     };
 
     this.resetRegExp();

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,15 @@ export function getPath(object, path) {
   return obj[k];
 }
 
+export function getPathWithDefaults(data, defaultData, key) {
+  const value = getPath(data, key);
+  if (value !== undefined) {
+    return value;
+  }
+  // Fallback to default values
+  return getPath(defaultData, key);
+}
+
 export function deepExtend(target, source, overwrite) {
   /* eslint no-restricted-syntax: 0 */
   for (const prop in source) {

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -51,7 +51,9 @@ describe('Interpolator', () => {
       // prio has passed in variables
       { args: ['test {{ test }}', { test: '124' }], expected: 'test 124' },
       { args: ['test {{ test }}', { test: null }], expected: 'test ' },
-      { args: ['test {{ test }}', { test: undefined }], expected: 'test ' },
+
+      // Override default variable only with null, not with undefined.
+      { args: ['test {{ test }}', { test: undefined }], expected: 'test 123' },
     ];
 
     tests.forEach(test => {


### PR DESCRIPTION
Records don't support `...` spread operator, so the previous `combinedData` implementation broke usage of Records as the localization parameters.

This also changes the test case of overriding a default value with undefined as it would be difficult (and not very valuable)
to implement that with the current `getLastOfPath`.