### PR TITLE
Add missing `cleanCode` option to TypeScript def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,6 +229,12 @@ declare namespace i18next {
     lowerCaseLng?: boolean;
 
     /**
+     * Language will be lowercased EN --> en while leaving full locales like en-US
+     * @default false
+     */
+    cleanCode?: boolean;
+
+    /**
      * String or array of namespaces to load
      * @default 'translation'
      */


### PR DESCRIPTION
This PR adds the missing `cleanCode` option to the `initOptions` in the TypeScript definition.