### PR TITLE
Add option to always format interpolated values

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -78,17 +78,16 @@ class Interpolator {
     }
 
     const handleFormat = key => {
-      if (key.includes(this.formatSeparator)) {
-        const p = key.split(this.formatSeparator);
-        const k = p.shift().trim();
-        const f = p.join(this.formatSeparator).trim();
-
-        return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
+      if (key.indexOf(this.formatSeparator) < 0) {
+        const value = utils.getPathWithDefaults(data, defaultData, key);
+        return this.alwaysFormat ? this.format(value, undefined, lng) : value;
       }
 
-      const value = utils.getPathWithDefaults(data, defaultData, key);
+      const p = key.split(this.formatSeparator);
+      const k = p.shift().trim();
+      const f = p.join(this.formatSeparator).trim();
 
-      return this.alwaysFormat ? this.format(value, undefined, lng) : value;
+      return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
     };
 
     this.resetRegExp();

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -40,6 +40,8 @@ class Interpolator {
 
     this.maxReplaces = iOpts.maxReplaces ? iOpts.maxReplaces : 1000;
 
+    this.alwaysFormat = iOpts.alwaysFormat !== undefined ? iOpts.alwaysFormat : false;
+
     // the regexp
     this.resetRegExp();
   }
@@ -76,15 +78,15 @@ class Interpolator {
     }
 
     const handleFormat = key => {
-      if (key.indexOf(this.formatSeparator) < 0) {
-        return utils.getPathWithDefaults(data, defaultData, key);
+      if (this.alwaysFormat || key.includes(this.formatSeparator)) {
+        const p = key.split(this.formatSeparator);
+        const k = p.shift().trim();
+        const f = p.join(this.formatSeparator).trim();
+
+        return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
       }
 
-      const p = key.split(this.formatSeparator);
-      const k = p.shift().trim();
-      const f = p.join(this.formatSeparator).trim();
-
-      return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
+      return utils.getPathWithDefaults(data, defaultData, key);
     };
 
     this.resetRegExp();

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -79,8 +79,8 @@ class Interpolator {
 
     const handleFormat = key => {
       if (key.indexOf(this.formatSeparator) < 0) {
-        const value = utils.getPathWithDefaults(data, defaultData, key);
-        return this.alwaysFormat ? this.format(value, undefined, lng) : value;
+        const path = utils.getPathWithDefaults(data, defaultData, key);
+        return this.alwaysFormat ? this.format(path, undefined, lng) : path;
       }
 
       const p = key.split(this.formatSeparator);

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -78,7 +78,7 @@ class Interpolator {
     }
 
     const handleFormat = key => {
-      if (this.alwaysFormat || key.includes(this.formatSeparator)) {
+      if (key.includes(this.formatSeparator)) {
         const p = key.split(this.formatSeparator);
         const k = p.shift().trim();
         const f = p.join(this.formatSeparator).trim();
@@ -86,7 +86,9 @@ class Interpolator {
         return this.format(utils.getPathWithDefaults(data, defaultData, k), f, lng);
       }
 
-      return utils.getPathWithDefaults(data, defaultData, key);
+      const value = utils.getPathWithDefaults(data, defaultData, key);
+
+      return this.alwaysFormat ? this.format(value, undefined, lng) : value;
     };
 
     this.resetRegExp();

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -230,6 +230,33 @@ describe('Interpolator', () => {
     });
   });
 
+  describe('interpolate() - with formatter always', () => {
+    let ip;
+
+    before(() => {
+      ip = new Interpolator({
+        interpolation: {
+          alwaysFormat: true,
+          format: function(value, format, lng) {
+            if (format === 'uppercase') return value.toUpperCase();
+            return value.toLowerCase();
+          },
+        },
+      });
+    });
+
+    var tests = [
+      { args: ['test {{test, uppercase}}', { test: 'up' }], expected: 'test UP' },
+      { args: ['test {{test}}', { test: 'DOWN' }], expected: 'test down' },
+    ];
+
+    tests.forEach(test => {
+      it('correctly interpolates for ' + JSON.stringify(test.args) + ' args', () => {
+        expect(ip.interpolate.apply(ip, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+
   describe('interpolate() - unescape', () => {
     var ip;
 


### PR DESCRIPTION
Addresses #1384 

Although there isn't a compelling reason to be dependent on the old behaviour, this is technically a breaking change so I've added a new option `alwaysFormat` (not sure if this should also update the docs) which will, unimaginatively, always format values used for interpolation. This option defaults to `false` in order to preserve existing behaviour.