### PR TITLE
Could we use formatting functions in the nesting 't' function?

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "watchify": "3.9.0"
   },
   "scripts": {
+    "prepare": "npm run build",
     "pretest": "npm run test:typescript && npm run test:typescript:noninterop",
     "test": "npm run test:new && npm run test:compat",
     "test:new": "karma start karma.conf.js --singleRun",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "watchify": "3.9.0"
   },
   "scripts": {
-    "prepare": "npm run build",
     "pretest": "npm run test:typescript && npm run test:typescript:noninterop",
     "test": "npm run test:new && npm run test:compat",
     "test:new": "karma start karma.conf.js --singleRun",

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -185,6 +185,12 @@ class Interpolator {
 
     // regular escape on demand
     while ((match = this.nestingRegexp.exec(str))) {
+      let formatters = [];
+
+      if (match[0].includes(this.formatSeparator)) {
+        [match[1], ...formatters] = match[1].split(this.formatSeparator).map(elem => elem.trim());
+      }
+
       value = fc(handleHasOptions.call(this, match[1].trim(), clonedOptions), clonedOptions);
 
       // is only the nesting key (key1 = '$(key2)') return the value without stringify
@@ -196,6 +202,9 @@ class Interpolator {
         this.logger.warn(`missed to resolve ${match[1]} for nesting ${str}`);
         value = '';
       }
+
+      value = formatters.reduce((v, f) => this.format(v, f, options.lng, options), value.trim());
+
       // Nested keys should not be escaped by default #854
       // value = this.escapeValue ? regexSafe(utils.escape(value)) : regexSafe(value);
       str = str.replace(match[0], value);


### PR DESCRIPTION
For example:

```
{
    "key1": "The following text is uppercased: {{key2, uppercase}}",
    "key2": "some text"
}
```

```
i18next.t('key1');
// -> "The following text is uppercased: SOME TEXT"
```

If uppercase is defined as:
```
i18next.init({
    interpolation: {
        format: function(value, format, lng) {
            if (format === 'uppercase') return value.toUpperCase();
            return value;
        }
    }
});
```