### PR TITLE
Could we use formatting functions in the nesting 't' function?

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -185,6 +185,21 @@ class Interpolator {
 
     // regular escape on demand
     while ((match = this.nestingRegexp.exec(str))) {
+      let formatters = [];
+
+      /**
+       * If there is more than one parameter (contains the format separator). E.g.:
+       *   - t(a, b)
+       *   - t(a, b, c)
+       *
+       * And those parameters are not dynamic values (parameters do not include curly braces). E.g.:
+       *   - Not t(a, { "key": "{{variable}}" })
+       *   - Not t(a, b, {"keyA": "valueA", "keyB": "valueB"})
+       */
+      if (match[0].includes(this.formatSeparator) && !/{.*}/.test(match[1])) {
+        [match[1], ...formatters] = match[1].split(this.formatSeparator).map(elem => elem.trim());
+      }
+
       value = fc(handleHasOptions.call(this, match[1].trim(), clonedOptions), clonedOptions);
 
       // is only the nesting key (key1 = '$(key2)') return the value without stringify
@@ -196,6 +211,9 @@ class Interpolator {
         this.logger.warn(`missed to resolve ${match[1]} for nesting ${str}`);
         value = '';
       }
+
+      value = formatters.reduce((v, f) => this.format(v, f, options.lng, options), value.trim());
+
       // Nested keys should not be escaped by default #854
       // value = this.escapeValue ? regexSafe(utils.escape(value)) : regexSafe(value);
       str = str.replace(match[0], value);

--- a/test/i18next.translation.formatting.spec.js
+++ b/test/i18next.translation.formatting.spec.js
@@ -1,0 +1,82 @@
+import i18next from '../src/i18next.js';
+
+const instance = i18next.createInstance();
+
+describe('i18next.translation.formatting', () => {
+  before(done => {
+    instance.init(
+      {
+        lng: 'en',
+        resources: {
+          en: {
+            translation: {
+              oneFormatterTest: 'The following text is uppercased: $t(key5, uppercase)',
+              anotherOneFormatterTest: 'The following text is underscored: $t(key6, underscore)',
+              twoFormattersTest:
+                'The following text is uppercased: $t(key5, uppercase). The following text is underscored: $t(key5, underscore)',
+              twoFormattersTogetherTest:
+                'The following text is uppercased, underscored, then uri component encoded: $t(key7, uppercase, underscore, encodeuricomponent)',
+              oneFormatterUsingAnotherFormatterTest:
+                'The following text is lowercased: $t(twoFormattersTogetherTest, lowercase)',
+              missingTranslationTest:
+                'No text will be shown when the translation key is missing: $t(, uppercase)',
+              key5: 'Here is some text',
+              key6: 'Here is some text with numb3r5',
+              key7: 'Here is some: text? with, (punctuation)',
+            },
+          },
+        },
+        interpolation: {
+          format: function(value, format, lng) {
+            if (format === 'uppercase') return value.toUpperCase();
+            if (format === 'lowercase') return value.toLowerCase();
+            if (format === 'underscore') return value.replace(/\s+/g, '_');
+            if (format === 'encodeuricomponent') return encodeURIComponent(value);
+            return value;
+          },
+        },
+      },
+      () => {
+        done();
+      },
+    );
+  });
+
+  describe('formatting', () => {
+    var tests = [
+      {
+        args: ['oneFormatterTest'],
+        expected: 'The following text is uppercased: HERE IS SOME TEXT',
+      },
+      {
+        args: ['anotherOneFormatterTest'],
+        expected: 'The following text is underscored: Here_is_some_text_with_numb3r5',
+      },
+      {
+        args: ['twoFormattersTest'],
+        expected:
+          'The following text is uppercased: HERE IS SOME TEXT. The following text is underscored: Here_is_some_text',
+      },
+      {
+        args: ['twoFormattersTogetherTest'],
+        expected:
+          'The following text is uppercased, underscored, then uri component encoded: HERE_IS_SOME%3A_TEXT%3F_WITH%2C_(PUNCTUATION)',
+      },
+      {
+        args: ['oneFormatterUsingAnotherFormatterTest'],
+        expected:
+          'The following text is lowercased: the following text is uppercased, underscored, then uri component encoded: here_is_some%3a_text%3f_with%2c_(punctuation)',
+      },
+      {
+        args: ['missingTranslationTest'],
+        expected: 'No text will be shown when the translation key is missing: ',
+      },
+    ];
+
+    tests.forEach(test => {
+      it('correctly formats translations for ' + JSON.stringify(test.args), () => {
+        expect(instance.t.apply(instance, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
For example:

```
{
    "key1": "The following text is uppercased: $t(key2, uppercase)",
    "key2": "some text"
}
```

```
i18next.t('key1');
// -> "The following text is uppercased: SOME TEXT"
```

If uppercase is defined as:

```
i18next.init({
    interpolation: {
        format: function(value, format, lng) {
            if (format === 'uppercase') return value.toUpperCase();
            return value;
        }
    }
});
```