### PR TITLE
check if module passed to i18next.use() has correct signature

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -198,6 +198,9 @@ class I18n extends EventEmitter {
   }
 
   use(module) {
+    if (!module) throw new Error('You are passing an undefined module! Please check the object you are passing to i18next.use()')
+    if (!module.type) throw new Error('You are passing a wrong module! Please check the object you are passing to i18next.use()')
+
     if (module.type === 'backend') {
       this.modules.backend = module;
     }

--- a/test/i18next.use.spec.js
+++ b/test/i18next.use.spec.js
@@ -1,0 +1,17 @@
+import i18next from '../src/i18next.js';
+
+describe('i18next.use()', () => {
+  describe('passing an undefined module', () => {
+    it('it should throw accordingly', () => {
+      const badFn = () => i18next.use(undefined);
+      expect(badFn).to.throw(/undefined module/);
+    });
+  });
+
+  describe('passing a module with wrong interface', () => {
+    it('it should throw accordingly', () => {
+      const badFn = () => i18next.use({});
+      expect(badFn).to.throw(/wrong module/);
+    });
+  });
+});


### PR DESCRIPTION
should make this type of errors a bit more obvious: https://github.com/i18next/react-i18next/issues/1078