### PR TITLE
Update typescript definition for BackendModule callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -700,7 +700,7 @@ export interface Module {
 }
 
 export type CallbackError = Error | null | undefined;
-export type ReadCallback = (err: CallbackError, data: ResourceKey) => void;
+export type ReadCallback = (err: CallbackError, data: ResourceKey | null) => void;
 export type MultiReadCallback = (err: CallbackError, data: Resource) => void;
 
 /**


### PR DESCRIPTION
The docs specify that if there's an error, the second argument should be null, but the typescript types do not allow it.
Update the signature to allow `null` on the second argument.

Relevant snippet from docs:
```
    /* if method fails/returns an error, call this: */
    /* callback(truthyValue, null); */
```