### PR TITLE
Allow passing retry boolean to `ReadCallback`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -700,7 +700,7 @@ export interface Module {
 }
 
 export type CallbackError = Error | null | undefined;
-export type ReadCallback = (err: CallbackError, data: ResourceKey) => void;
+export type ReadCallback = (err: CallbackError, data: ResourceKey | boolean) => void;
 export type MultiReadCallback = (err: CallbackError, data: Resource) => void;
 
 /**


### PR DESCRIPTION
For `ReadCallback`, when `err` is an `Error`, the second argument should be a boolean indicating whether to retry.