### PR TITLE
Fix i18n.use() cannot pass module constructors in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -754,8 +754,16 @@ export interface Services {
   resourceStore: ResourceStore;
 }
 
+export type SupportedType =
+  | 'backend'
+  | 'logger'
+  | 'languageDetector'
+  | 'postProcessor'
+  | 'i18nFormat'
+  | '3rdParty';
+
 export interface Module {
-  type: 'backend' | 'logger' | 'languageDetector' | 'postProcessor' | 'i18nFormat' | '3rdParty';
+  type: SupportedType;
 }
 
 export type CallbackError = Error | null | undefined;
@@ -850,7 +858,13 @@ export interface Modules {
 }
 
 // helper to identify class https://stackoverflow.com/a/45983481/2363935
-export type Newable<T> = { new (...args: any[]): T };
+export interface Newable<T> {
+  new (...args: any[]): T;
+}
+
+export interface NewableModule<T extends Module> extends Newable<T> {
+  type: T['type'];
+}
 
 export interface i18n {
   // Expose parameterized t in the i18next interface hierarchy
@@ -872,11 +886,11 @@ export interface i18n {
    * The use function is there to load additional plugins to i18next.
    * For available module see the plugins page and don't forget to read the documentation of the plugin.
    *
-   * Accepts a class or object
+   * @param module Accepts a class or object
    */
-  use<T extends Module>(
-    module: T | Newable<T> | ThirdPartyModule[] | Newable<ThirdPartyModule>[],
-  ): i18n;
+  use<T extends Module>(module: T | NewableModule<T>): this;
+
+  use<T extends ThirdPartyModule>(module: T[] | Array<NewableModule<T>>): this;
 
   /**
    * List of modules used

--- a/index.d.ts
+++ b/index.d.ts
@@ -888,7 +888,7 @@ export interface i18n {
    *
    * @param module Accepts a class or object
    */
-  use<T extends Module>(module: T | NewableModule<T>): this;
+  use<T extends Module>(module: T | NewableModule<T> | Newable<T>): this;
 
   /**
    * List of modules used

--- a/index.d.ts
+++ b/index.d.ts
@@ -754,7 +754,7 @@ export interface Services {
   resourceStore: ResourceStore;
 }
 
-export type SupportedType =
+export type ModuleType =
   | 'backend'
   | 'logger'
   | 'languageDetector'
@@ -763,7 +763,7 @@ export type SupportedType =
   | '3rdParty';
 
 export interface Module {
-  type: SupportedType;
+  type: ModuleType;
 }
 
 export type CallbackError = Error | null | undefined;
@@ -889,8 +889,6 @@ export interface i18n {
    * @param module Accepts a class or object
    */
   use<T extends Module>(module: T | NewableModule<T>): this;
-
-  use<T extends ThirdPartyModule>(module: T[] | Array<NewableModule<T>>): this;
 
   /**
    * List of modules used

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -72,6 +72,7 @@ i18next.use(externalModules);
 
 // exercise class usage
 class MyLoggerModule implements LoggerModule {
+  static type: 'logger' = 'logger';
   type: 'logger' = 'logger';
   log = () => null;
   warn = () => null;

--- a/test/typescript/modules.test.ts
+++ b/test/typescript/modules.test.ts
@@ -68,9 +68,10 @@ i18next.use(backendModule);
 i18next.use(languageDetectorModule);
 i18next.use(loggerModule);
 i18next.use(i18nFormatModule);
-i18next.use(externalModules);
+i18next.use(thirdPartyModule);
 
 // exercise class usage
+// Need both static and member definitions of type to satisfy use() signature, see #1442
 class MyLoggerModule implements LoggerModule {
   static type: 'logger' = 'logger';
   type: 'logger' = 'logger';


### PR DESCRIPTION
Changes mentioned in https://github.com/i18next/i18next/issues/1440

@rosskevin 