### PR TITLE
Allow boolean on keySeparator and nsSeparator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -581,11 +581,11 @@ export interface TOptionsBase {
   /**
    * Override char to separate keys
    */
-  keySeparator?: string;
+  keySeparator?: false | string;
   /**
    * Override char to split namespace from key
    */
-  nsSeparator?: string;
+  nsSeparator?: false | string;
   /**
    * Accessing an object not a translation string (can be set globally too)
    */

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -140,4 +140,9 @@ function interpolation(t: TFunction) {
 
   t('arrayOfObjects.0.name');
   // -> "tom"
+
+  t('welcome here :)', { nsSeparator: false });
+  // -> "welcome here :)"
+  t('welcome ...', { keySeparator: false });
+  // -> "welcome ..."
 }


### PR DESCRIPTION
Add the ability to pass `false` as nsSeparator & keySeparator

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added