### PR TITLE
fix type declarion of exposed EventEmitter#off methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -688,6 +688,10 @@ export class ResourceStore {
    * Gets fired when resources got added or removed
    */
   on(event: 'added' | 'removed', callback: (lng: string, ns: string) => void): void;
+  /**
+   * Remove event listener
+   */
+  off(event: 'added' | 'removed', callback: (lng: string, ns: string) => void): void;
 }
 
 export interface Services {

--- a/index.d.ts
+++ b/index.d.ts
@@ -690,8 +690,9 @@ export class ResourceStore {
   on(event: 'added' | 'removed', callback: (lng: string, ns: string) => void): void;
   /**
    * Remove event listener
+   * removes all callback when callback not specified
    */
-  off(event: 'added' | 'removed', callback: (lng: string, ns: string) => void): void;
+  off(event: 'added' | 'removed', callback?: (lng: string, ns: string) => void): void;
 }
 
 export interface Services {
@@ -965,8 +966,9 @@ export interface i18n {
 
   /**
    * Remove event listener
+   * removes all callback when callback not specified
    */
-  off(event: string, listener: (...args: any[]) => void): void;
+  off(event: string, listener?: (...args: any[]) => void): void;
 
   /**
    * Gets one value by given key.

--- a/test/typescript/exposed.test.ts
+++ b/test/typescript/exposed.test.ts
@@ -16,4 +16,5 @@ const modules: Modules = { external: [] };
 const resourceStore: ResourceStore = i18next.services.resourceStore;
 resourceStore.on('added', console.log);
 resourceStore.off('added', console.log);
+resourceStore.off('added');
 resourceStore.data['en'];

--- a/test/typescript/exposed.test.ts
+++ b/test/typescript/exposed.test.ts
@@ -14,4 +14,6 @@ const mockWithT: WithT = {
 const modules: Modules = { external: [] };
 
 const resourceStore: ResourceStore = i18next.services.resourceStore;
+resourceStore.on('added', console.log);
+resourceStore.off('added', console.log);
 resourceStore.data['en'];


### PR DESCRIPTION
Hello there, I found that `off` method in ResourceStore and i18n had some incomplete TypeScript types (the method is inherited from parent EventEmitter)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added