### PR TITLE
detect if translations are flat instead of nested and warn

### DIFF
--- a/src/BackendConnector.js
+++ b/src/BackendConnector.js
@@ -199,8 +199,8 @@ class Connector extends EventEmitter {
       !this.services.utils.hasLoadedNamespace(namespace)
     ) {
       this.logger.warn(
-        `did not save key "${key}" for namespace "${namespace}" as the namespace was not yet loaded`,
-        'This means something IS WRONG in your application setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!',
+        `did not save key "${key}" as the namespace "${namespace}" was not yet loaded`,
+        'This means something IS WRONG in your setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!',
       );
       return;
     }

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -190,7 +190,7 @@ class Translator extends EventEmitter {
         );
         if (keySeparator) {
           const fk = this.resolve(key, { ...options, keySeparator: false });
-          if (fk && fk.res) this.logger.warn('Are translations flat instead of nested?');
+          if (fk && fk.res) this.logger.warn('Seems the loaded translations were in flat JSON format instead of nested. Either set keySeparator: false on init or make sure your translations are published in nested format.');
         }
 
         let lngs = [];

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -188,6 +188,10 @@ class Translator extends EventEmitter {
           key,
           updateMissing ? options.defaultValue : res,
         );
+        if (keySeparator) {
+          const fk = this.resolve(key, { ...options, keySeparator: false });
+          if (fk && fk.res) this.logger.warn('Are translations flat instead of nested?');
+        }
 
         let lngs = [];
         const fallbackLngs = this.languageUtils.getFallbackCodes(
@@ -354,10 +358,10 @@ class Translator extends EventEmitter {
         ) {
           checkedLoadedFor[`${codes[0]}-${ns}`] = true;
           this.logger.warn(
-            `key "${usedKey}" for namespace "${usedNS}" for languages "${codes.join(
+            `key "${usedKey}" for languages "${codes.join(
               ', ',
-            )}" won't get resolved as namespace was not yet loaded`,
-            'This means something IS WRONG in your application setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!',
+            )}" won't get resolved as namespace "${usedNS}" was not yet loaded`,
+            'This means something IS WRONG in your setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!',
           );
         }
 

--- a/test/i18next.hasLoadedNamespace.spec.js
+++ b/test/i18next.hasLoadedNamespace.spec.js
@@ -109,9 +109,9 @@ describe('i18next', () => {
         it('it should not call saveMissing create on backend if not loaded ns', () => {
           i18n.t('ns1:keyNotFound');
 
-          expect(Logger.entries.warn.length).to.equal(2);
+          expect(Logger.entries.warn.length).to.equal(3);
           expect(Logger.entries.warn[0]).to.equal(
-            'i18next::translator: key "keyNotFound" for namespace "ns1" for languages "en-US, en, dev" won\'t get resolved as namespace was not yet loaded',
+            'i18next::translator: key "keyNotFound" for languages "en-US, en, dev" won\'t get resolved as namespace "ns1" was not yet loaded',
           );
           Logger.reset();
         });
@@ -131,9 +131,9 @@ describe('i18next', () => {
           expect(Backend.created.length).to.equal(0);
           Backend.reset();
 
-          expect(Logger.entries.warn.length).to.equal(1);
-          expect(Logger.entries.warn[0]).to.equal(
-            'i18next::backendConnector: did not save key "keyNotFound" for namespace "ns1" as the namespace was not yet loaded',
+          expect(Logger.entries.warn.length).to.equal(2);
+          expect(Logger.entries.warn[1]).to.equal(
+            'i18next::backendConnector: did not save key "keyNotFound" as the namespace "ns1" was not yet loaded',
           );
           Logger.reset();
         });


### PR DESCRIPTION
- added additional log warn statement (useful i.e. for users using locize publishFormat = 'json_auto')
- rephrased some existing log statements