### PR TITLE
fix: getDataByLanguage typings & test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -857,7 +857,7 @@ export interface i18n {
   /**
    * Returns a resource data by language.
    */
-  getDataByLanguage(lng: string): { translation: { [key: string]: string } };
+  getDataByLanguage(lng: string): { translation: { [key: string]: string } } | undefined;
 
   /**
    * Returns a t function that defaults to given language or namespace.

--- a/test/typescript/init.test.ts
+++ b/test/typescript/init.test.ts
@@ -209,7 +209,7 @@ const z: string = de('myKey');
 const data = i18next.getDataByLanguage('de');
 
 // verify the data.translation field exists
-console.log(data.translation.myKey);
+console.log(data ? data.translation.myKey : 'data does not exist');
 
 // or fix the namespace to anotherNamespace
 const anotherNamespace = i18next.getFixedT(null, 'anotherNamespace');


### PR DESCRIPTION
Fixes an issue I had with checking whether a certain language is already loaded without passing a namespace through `instance.hasResourceBundle(lng, ns)`.

Currently, the typings act as if you'd always receive an object with key `translation` (which might have to be fixed too, but I guess its fine for now). But if that language is not loaded yet, as [the underlying implementation just returns whatever it finds on `this.data`](https://github.com/i18next/i18next/blob/master/src/ResourceStore.js#L126), it will be undefined.


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added