### PR TITLE
fix nesting interpolation with prepended namespace, fixes #1474

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -52,6 +52,13 @@ class Translator extends EventEmitter {
 
     let namespaces = options.ns || this.options.defaultNS;
     if (nsSeparator && key.indexOf(nsSeparator) > -1) {
+      const m = key.match(this.interpolator.nestingRegexp);
+      if (m && m.length > 0) {
+        return {
+          key,
+          namespaces,
+        };
+      }
       const parts = key.split(nsSeparator);
       if (
         nsSeparator !== keySeparator ||
@@ -190,7 +197,10 @@ class Translator extends EventEmitter {
         );
         if (keySeparator) {
           const fk = this.resolve(key, { ...options, keySeparator: false });
-          if (fk && fk.res) this.logger.warn('Seems the loaded translations were in flat JSON format instead of nested. Either set keySeparator: false on init or make sure your translations are published in nested format.');
+          if (fk && fk.res)
+            this.logger.warn(
+              'Seems the loaded translations were in flat JSON format instead of nested. Either set keySeparator: false on init or make sure your translations are published in nested format.',
+            );
         }
 
         let lngs = [];

--- a/test/i18next.interpolation.nesting.spec.js
+++ b/test/i18next.interpolation.nesting.spec.js
@@ -56,6 +56,22 @@ describe('i18next.interpolation.nesting', () => {
         args: ['test103'],
         expected: 'this test is full success',
       },
+      {
+        args: ['$t(test1)', { a: 'foo' }],
+        expected: 'test nest value foo',
+      },
+      {
+        args: ['$t(translation:test1)', { a: 'foo' }],
+        expected: 'test nest value foo',
+      },
+      {
+        args: ['something $t(test1)', { a: 'foo' }],
+        expected: 'something test nest value foo',
+      },
+      {
+        args: ['something $t(translation:test1)', { a: 'foo' }],
+        expected: 'something test nest value foo',
+      },
     ];
 
     tests.forEach(test => {

--- a/test/interpolation.spec.js
+++ b/test/interpolation.spec.js
@@ -354,6 +354,15 @@ describe('Interpolator', () => {
         ],
         expected: 'test, is, ok',
       },
+      {
+        args: [
+          '$t(ns:test)',
+          function() {
+            return 'test from ns';
+          },
+        ],
+        expected: 'test from ns',
+      },
     ];
 
     tests.forEach(test => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixes: https://github.com/i18next/i18next/issues/1474
as documented here: https://www.i18next.com/translation-function/nesting#basic
![image](https://user-images.githubusercontent.com/1086194/86167937-b1367700-bb17-11ea-83da-9946f66e4ad9.png)


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added