### PR TITLE
fix: Macedonian plural formula - *11 (11, 111, 211, 311, 58711...) is plural

### DIFF
--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -55,7 +55,7 @@ let _rulesPluralsTypes = {
   14: function(n) {return Number((n==1) ? 0 : (n==2) ? 1 : (n == 3) ? 2 : 3);},
   15: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);},
   16: function(n) {return Number(n%10==1 && n%100!=11 ? 0 : n !== 0 ? 1 : 2);},
-  17: function(n) {return Number(n==1 || n%10==1 ? 0 : 1);},
+  17: function(n) {return Number(n==1 || n%10==1 && n%100!=11 ? 0 : 1);},
   18: function(n) {return Number(n==0 ? 0 : n==1 ? 1 : 2);},
   19: function(n) {return Number(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);},
   20: function(n) {return Number(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);},

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -166,6 +166,10 @@ describe('PluralResolver', () => {
       { args: ['mk', 1], expected: '' },
       { args: ['mk', 2], expected: 'plural' },
       { args: ['mk', 0], expected: 'plural' },
+      { args: ['mk', 11], expected: 'plural' },
+      { args: ['mk', 21], expected: '' },
+      { args: ['mk', 31], expected: '' },
+      { args: ['mk', 311], expected: 'plural' },
 
       // mnk
       { args: ['mnk', 0], expected: '0' },


### PR DESCRIPTION
The problem noticed on https://treker.mk/mk/stats, fixed for the project with https://github.com/treker-mk/website/pull/28
according to https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#mk

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [ ] documentation is changed or added