### PR TITLE
possibility to disable nestingPrefix or nestingSuffix

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -31,12 +31,14 @@ class Interpolator {
     this.unescapePrefix = iOpts.unescapeSuffix ? '' : iOpts.unescapePrefix || '-';
     this.unescapeSuffix = this.unescapePrefix ? '' : iOpts.unescapeSuffix || '';
 
-    this.nestingPrefix = iOpts.nestingPrefix
-      ? utils.regexEscape(iOpts.nestingPrefix)
-      : iOpts.nestingPrefixEscaped || utils.regexEscape('$t(');
-    this.nestingSuffix = iOpts.nestingSuffix
-      ? utils.regexEscape(iOpts.nestingSuffix)
-      : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
+    if (iOpts.nestingPrefix !== false)
+      this.nestingPrefix = iOpts.nestingPrefix
+        ? utils.regexEscape(iOpts.nestingPrefix)
+        : iOpts.nestingPrefixEscaped || utils.regexEscape('$t(');
+    if (iOpts.nestingSuffix !== false)
+      this.nestingSuffix = iOpts.nestingSuffix
+        ? utils.regexEscape(iOpts.nestingSuffix)
+        : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
 
     this.nestingOptionsSeparator = iOpts.nestingOptionsSeparator
       ? iOpts.nestingOptionsSeparator
@@ -64,8 +66,10 @@ class Interpolator {
     }`;
     this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
 
-    const nestingRegexpStr = `${this.nestingPrefix}(.+?)${this.nestingSuffix}`;
-    this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
+    if (this.nestingPrefix !== false || this.nestingSuffix !== false) {
+      const nestingRegexpStr = `${this.nestingPrefix}(.+?)${this.nestingSuffix}`;
+      this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
+    }
   }
 
   interpolate(str, data, lng, options) {
@@ -182,6 +186,8 @@ class Interpolator {
       delete clonedOptions.defaultValue;
       return key;
     }
+
+    if (!this.nestingRegexp) return str;
 
     // regular escape on demand
     while ((match = this.nestingRegexp.exec(str))) {

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -31,14 +31,16 @@ class Interpolator {
     this.unescapePrefix = iOpts.unescapeSuffix ? '' : iOpts.unescapePrefix || '-';
     this.unescapeSuffix = this.unescapePrefix ? '' : iOpts.unescapeSuffix || '';
 
-    if (iOpts.nestingPrefix !== false)
+    if (iOpts.nestingPrefix !== false) {
       this.nestingPrefix = iOpts.nestingPrefix
         ? utils.regexEscape(iOpts.nestingPrefix)
         : iOpts.nestingPrefixEscaped || utils.regexEscape('$t(');
-    if (iOpts.nestingSuffix !== false)
+    }
+    if (iOpts.nestingSuffix !== false) {
       this.nestingSuffix = iOpts.nestingSuffix
         ? utils.regexEscape(iOpts.nestingSuffix)
         : iOpts.nestingSuffixEscaped || utils.regexEscape(')');
+    }
 
     this.nestingOptionsSeparator = iOpts.nestingOptionsSeparator
       ? iOpts.nestingOptionsSeparator

--- a/test/i18next.interpolation.without.nestingPrefix.spec.js
+++ b/test/i18next.interpolation.without.nestingPrefix.spec.js
@@ -1,0 +1,98 @@
+import i18next from '../src/i18next.js';
+
+const instance = i18next.createInstance();
+
+describe('i18next.interpolation.without.nestingPrefix', () => {
+  before(done => {
+    instance.init(
+      {
+        interpolation: {
+          nestingPrefix: false,
+        },
+        lng: 'en',
+        resources: {
+          en: {
+            translation: {
+              test1: 'test $t(nest1) {{a}}',
+              nest1: 'nest value',
+              // options
+              test2: 'test $t(nest2, { "b": "{{a}}" })',
+              nest2: 'nest {{b}}',
+              // 2 options
+              test3: 'test $t(nest3, { "b": "{{a}}", "c": "{{b}}" })',
+              nest3: 'nest {{b}} {{c}}',
+              // , in key
+              test102: '$t(test102, is, {"key": "success"})',
+              'test102, is': 'this test is {{key}}',
+              // , in key and two options , separated
+              test103: '$t(test103, is, {"key": "success", "key2": "full"})',
+              'test103, is': 'this test is {{key2}} {{key}}',
+              keyA1: '{{text}} interpolated',
+              keyB1: 'Text to interpolate => $t(keyA1, { "text": "foo" })',
+              keyA1rec: '{{text}} interpolated | $t(keyB1rec)',
+              keyB1rec: 'Text to interpolate => $t(keyA1rec, { "text": "foo" })',
+            },
+          },
+        },
+      },
+      () => {
+        done();
+      },
+    );
+  });
+
+  describe('nesting', () => {
+    var tests = [
+      {
+        args: ['test1', { a: 'foo' }],
+        expected: 'test $t(nest1) foo',
+      },
+      {
+        args: ['test2', { a: 'foo' }],
+        expected: 'test $t(nest2, { "b": "foo" })',
+      },
+      {
+        args: ['test3', { a: 'foo', b: 'bar' }],
+        expected: 'test $t(nest3, { "b": "foo", "c": "bar" })',
+      },
+      {
+        args: ['test102'],
+        expected: '$t(test102, is, {"key": "success"})',
+      },
+      {
+        args: ['test103'],
+        expected: '$t(test103, is, {"key": "success", "key2": "full"})',
+      },
+      {
+        args: ['$t(test1)', { a: 'foo' }],
+        expected: '$t(test1)',
+      },
+      // {
+      //   args: ['$t(translation:test1)', { a: 'foo' }],
+      //   expected: 'test1)',
+      // },
+      {
+        args: ['something $t(test1)', { a: 'foo' }],
+        expected: 'something $t(test1)',
+      },
+      // {
+      //   args: ['something $t(translation:test1)', { a: 'foo' }],
+      //   expected: 'test1)',
+      // },
+      {
+        args: ['keyB1'],
+        expected: 'Text to interpolate => $t(keyA1, { "text": "foo" })',
+      },
+      {
+        args: ['keyB1rec'],
+        expected: 'Text to interpolate => $t(keyA1rec, { "text": "foo" })',
+      },
+    ];
+
+    tests.forEach(test => {
+      it('correctly nests for ' + JSON.stringify(test.args) + ' args', () => {
+        expect(instance.t.apply(instance, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
should fix #1479

adds possibility to set nestingPrefix or nestingSuffix to false, which results in not trying to interpolate $t() stuff.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added