### PR TITLE
introduce new option skipOnVariables to fix #1479

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -290,6 +290,15 @@ class Translator extends EventEmitter {
           ...options,
           ...{ interpolation: { ...this.options.interpolation, ...options.interpolation } },
         });
+      const skipOnVariables =
+        (options.interpolation && options.interpolation.skipOnVariables) ||
+        this.options.interpolation.skipOnVariables;
+      let nestBef;
+      if (skipOnVariables) {
+        const nb = res.match(this.interpolator.nestingRegexp);
+        // has nesting aftbeforeer interpolation
+        nestBef = nb && nb.length;
+      }
 
       // interpolate
       let data = options.replace && typeof options.replace !== 'string' ? options.replace : options;
@@ -298,6 +307,12 @@ class Translator extends EventEmitter {
       res = this.interpolator.interpolate(res, data, options.lng || this.language, options);
 
       // nesting
+      if (skipOnVariables) {
+        const na = res.match(this.interpolator.nestingRegexp);
+        // has nesting after interpolation
+        const nestAft = na && na.length;
+        if (nestBef < nestAft) options.nest = false;
+      }
       if (options.nest !== false)
         res = this.interpolator.nest(
           res,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -73,6 +73,7 @@ export function get() {
       // nestingSuffixEscaped: ')',
       // defaultVariables: undefined // object that can have values to interpolate on - extends passed in interpolation data
       maxReplaces: 1000, // max replaces to prevent endless loop
+      skipOnVariables: false,
     },
   };
 }

--- a/test/i18next.interpolation.skipOnVariables.spec.js
+++ b/test/i18next.interpolation.skipOnVariables.spec.js
@@ -1,0 +1,58 @@
+import i18next from '../src/i18next.js';
+
+const instance = i18next.createInstance();
+
+describe('i18next.interpolation.nesting', () => {
+  before(done => {
+    instance.init(
+      {
+        lng: 'en',
+        interpolation: {
+          skipOnVariables: true,
+        },
+        resources: {
+          en: {
+            translation: {
+              key: 'value {{a}}',
+              keyWithoutVar: 'value',
+              nested: 'nested stuff',
+              keyWithNest: '$t(nested2) value',
+              keyWithNestAndVar: '$t(nested2) value {{a}}',
+              nested2: 'HI',
+            },
+          },
+        },
+      },
+      () => {
+        done();
+      },
+    );
+  });
+
+  describe('nesting', () => {
+    var tests = [
+      {
+        args: ['keyWithoutVar'],
+        expected: 'value',
+      },
+      {
+        args: ['key', { a: 'hahaha' }],
+        expected: 'value hahaha',
+      },
+      {
+        args: ['keyWithNest'],
+        expected: 'HI value',
+      },
+      {
+        args: ['keyWithNestAndVar', { a: '$t(nested)' }],
+        expected: '$t(nested2) value $t(nested)',
+      },
+    ];
+
+    tests.forEach(test => {
+      it('correctly nests for ' + JSON.stringify(test.args) + ' args', () => {
+        expect(instance.t.apply(instance, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
```javascript
const i18next = require('i18next')

i18next.init({
  lng: 'en',
  interpolation: {
    skipOnVariables: true
  },
  resources: {
    en: {
      translation: {
        key: 'value {{a}}',
        keyWithoutVar: 'value',
        nested: 'nested stuff',
        keyWithNest: '$t(nested2) value',
        keyWithNestAndVar: '$t(nested2) value {{a}}',
        nested2: 'HI'
      }
    }
  }
})

console.log('-----------')
console.log(i18next.t('keyWithoutVar')) // value
console.log('-----------')
console.log(i18next.t('key', { a: 'hahaha' })) // value hahaha
console.log('-----------')
console.log(i18next.t('key', { a: '$t(nested)' })) // value $t(nested)
console.log('-----------')
console.log(i18next.t('key', { a: i18next.t('nested') })) // value nested stuff
console.log('-----------')
console.log(i18next.t('keyWithNest')) // HI value
console.log('-----------')
// be careful to this:
console.log(i18next.t('keyWithNestAndVar', { a: '$t(nested)' })) // $t(nested2) value $t(nested)
console.log('-----------')

```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added