### PR TITLE
Change bindStore to bindI18nStore in ReactOptions type and update default values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ export interface ReactOptions {
    * Set which events on store trigger a re-render, can be set to false or string of events
    * @default 'added removed'
    */
-  bindStore?: string | false;
+  bindI18nStore?: string | false;
   /**
    * Set fallback value for Trans components without children
    * @default undefined

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,12 +119,12 @@ export interface ReactOptions {
   defaultTransParent?: string;
   /**
    * Set which events trigger a re-render, can be set to false or string of events
-   * @default 'languageChanged loaded'
+   * @default 'languageChanged'
    */
   bindI18n?: string | false;
   /**
    * Set which events on store trigger a re-render, can be set to false or string of events
-   * @default 'added removed'
+   * @default ''
    */
   bindI18nStore?: string | false;
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

This resolves https://github.com/i18next/i18next/issues/1486. It also updates the default values of `bindI18n` and `bindI18nStore` attributes in `ReactOptions` type as they are described [here](https://github.com/i18next/react-i18next/blob/master/src/context.js#L3).
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added