### PR TITLE
updated @babel/runtime to ^7.12.0 to resolve runtime file extensions issue in webpack 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,17 +1143,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.1.tgz",
-      "integrity": "sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.0.tgz",
+      "integrity": "sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/i18next/i18next.git"
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.1"
+    "@babel/runtime": "^7.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.1",


### PR DESCRIPTION
Hello,

@babel/runtime was not specifying file extensions ([discussed originally here](https://github.com/babel/babel/issues/8462) and [recently here](https://github.com/babel/babel/issues/12058)) which wasn't a problem until webpack 5, which was released this week, started enforcing file extensions "`where the package.json contains '"type": "module"'`" as you can see in the error snippet below

This PR addresses this error (below).

```shell
ERROR in ./node_modules/i18next/node_modules/@babel/runtime/helpers/esm/inherits.js 1:0-46
Module not found: Error: Can't resolve './setPrototypeOf' in '/Users/mustafa/code/un/foodloss-portal/node_modules/i18next/node_modules/@babel/runtime/helpers/esm'
Did you mean 'setPrototypeOf.js'?
BREAKING CHANGE: The request './setPrototypeOf' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./node_modules/i18next/dist/esm/i18next.js 8:0-60 285:2-11 462:2-11 1451:2-11 1765:2-11
 @ ./src/shared/services/i18n.ts
 @ ./src/app/index.tsx 13:0-31
```

#### Checklist

- [x ] only relevant code is changed (make a diff before you submit the PR)
- [x ] run tests `npm run test`
- [n/a ] tests are included
- [ n/a] documentation is changed or added