### PR TITLE
Add ability to type translation keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,11 @@ export interface FallbackLngObjList {
   [language: string]: string[];
 }
 
+/**
+ * Augment this with a 'keys' key where you can add all the available translation keys
+ */
+export interface I18nTranslationKeys {}
+
 export type FallbackLng = string | string[] | FallbackLngObjList | ((code:string) => string | string[] | FallbackLngObjList);
 
 export type FormatFunction = (value: any, format?: string, lng?: string, options?: InterpolationOptions & { [key: string]: any }) => string;
@@ -639,7 +644,7 @@ export type Callback = (error: any, t: TFunction) => void;
  * Uses similar args as the t function and returns true if a key exists.
  */
 export interface ExistsFunction<
-  TKeys extends string = string,
+  TKeys extends TranslationKeys = TranslationKeys,
   TInterpolationMap extends object = StringMap
 > {
   (key: TKeys | TKeys[], options?: TOptions<TInterpolationMap>): boolean;
@@ -652,11 +657,16 @@ export interface WithT {
 
 export type TFunctionResult = string | object | Array<string | object> | undefined | null;
 export type TFunctionKeys = string | TemplateStringsArray;
+
+/**
+ * Gets the defined translation keys if they have been overridden, 'string' type otherwise
+ */
+type TranslationKeys = I18nTranslationKeys['keys'] extends string ? I18nTranslationKeys['keys'] : TFunctionKeys;
 export interface TFunction {
   // basic usage
   <
     TResult extends TFunctionResult = string,
-    TKeys extends TFunctionKeys = string,
+    TKeys extends TranslationKeys = TranslationKeys,
     TInterpolationMap extends object = StringMap
   >(
     key: TKeys | TKeys[],
@@ -665,7 +675,7 @@ export interface TFunction {
   // overloaded usage
   <
     TResult extends TFunctionResult = string,
-    TKeys extends TFunctionKeys = string,
+    TKeys extends TranslationKeys = TranslationKeys,
     TInterpolationMap extends object = StringMap
   >(
     key: TKeys | TKeys[],


### PR DESCRIPTION
This is a first step towards solving https://github.com/i18next/i18next/issues/1504
It allows you to type your translation keys freely. Which allows you to type them using the template literals of Typescript 4.1 for nested keys 😉  (see #1504).


# Usage

In my project, I augment the module definition in a type definition file`typings/i18next.d.ts`.

```typescript
import 'i18next';

declare module 'i18next' {
  export interface TranslationKeys {
    keys: 'a' | 'b' | 'c';
  }
}
```

Then in the whole project, I may use the `t` function like this:

```typescript
t('a'); // OK
t('wrong'); // Fails!
```

Same if I use `react-i18next`.

```typescript
const Component = () => {
  const { t } = useTranslation();
  t('a'); // OK
  t('wrong'); // Fails!
  // ...
}
```

## Advanced usage

<details>
  <summary>Deeply typed keys using Typescript 4.1</summary>

```typescript
import 'i18next';

import fr from 'src/i18n/translations/fr.json'

type PathOf<T extends object> = {
  [K in keyof T]: T[K] extends object ? [K, ...PathOf<T[K]>] : [K]
}[keyof T];

type SerializedPathOf<T extends object> = Join<Extract<PathOf<T>, string[]>, '.'>;

type Join<T extends string[], D extends string> =
    T extends [] ? '' :
    T extends [unknown] ? `${T[0]}` :
    T extends [unknown, ...infer U] ? `${T[0]}${D}${Join<U, D>}` :
    string;


declare module 'i18next' {
  export interface I18nTranslationKeys {
    keys: SerializedPathOf<typeof fr>;
  }
}
```

</details>

# What's left to do

Well, it's just a first step. I'm open to suggestions: overriding the interface this way feels hacky, but I found no other way.

It also needs documentation somewhere.

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
  - I would love to write a test, but adding an augmentation breaks the other tests since it's only done globally :cry: 

- [ ] documentation is changed or added
