### PR TITLE
instead of returning a new function as changeLanguage/init result, return the "original" t function

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -270,8 +270,9 @@ class I18n extends EventEmitter {
         this.isLanguageChangingTo = undefined;
       }
 
-      deferred.resolve((...args) => this.t(...args));
-      if (callback) callback(err, (...args) => this.t(...args));
+      const tFn = this.t.bind(this);
+      deferred.resolve(tFn);
+      if (callback) callback(err, tFn);
     };
 
     const setLng = lngs => {


### PR DESCRIPTION
should maybe fix #1528