### PR TITLE
Update i18next homepage and sample documentation links

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "globalization",
     "gettext"
   ],
-  "homepage": "http://i18next.com",
+  "homepage": "https://www.i18next.com",
   "bugs": "https://github.com/i18next/i18next/issues",
   "repository": {
     "type": "git",

--- a/sample.html
+++ b/sample.html
@@ -10,7 +10,8 @@
 
     <script>
       // use plugins and options as needed, for options, detail see
-      // http://i18next.com/docs/
+      // - https://www.i18next.com/overview/plugins-and-utils
+      // - https://www.i18next.com/overview/configuration-options
       i18next
       .use(window.i18nextBrowserLanguageDetector)
       .init({

--- a/test/backward/v1.11.1.compat.js
+++ b/test/backward/v1.11.1.compat.js
@@ -1,7 +1,7 @@
 // i18next, v1.10.2
 // Copyright (c)2015 Jan Mühlemann (jamuhl).
 // Distributed under MIT license
-// http://i18next.com
+// https://www.i18next.com
 // import i18n from '../../i18next.js';
 import i18n from '../../src/i18next.js';
 import XHR from 'i18next-xhr-backend';


### PR DESCRIPTION
Updates a few hyperlinks in the `i18next` package definition and documentation to point directly to the HTTPS-enabled homepage.

#### Checklist

- [x] documentation is changed or added