### PR TITLE
Updated changeLanguage signature to match codebase

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -882,7 +882,7 @@ export interface i18n {
    * Changes the language. The callback will be called as soon translations were loaded or an error occurs while loading.
    * HINT: For easy testing - setting lng to 'cimode' will set t function to always return the key.
    */
-  changeLanguage(lng: string, callback?: Callback): Promise<TFunction>;
+  changeLanguage(lng?: string, callback?: Callback): Promise<TFunction>;
 
   /**
    * Is set to the current detected or set language.


### PR DESCRIPTION
Fix #1550 

The `lng` parameter must be optional, to be able to run the function without any parameter to use the language detector.