### PR TITLE
Improve updateMissing default plural behavior

### DIFF
--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -102,18 +102,17 @@ class PluralResolver {
   }
 
   getPluralFormsOfKey(code, key) {
-    const ret = [];
+    return this.getSuffixes(code).map((suffix) => key + suffix)
+  }
 
+  getSuffixes(code) {
     const rule = this.getRule(code);
 
-    if (!rule) return ret;
+    if (!rule) {
+      return [];
+    }
 
-    rule.numbers.forEach((n) => {
-      const suffix = this.getSuffix(code, n);
-      ret.push(`${key}${suffix}`);
-    });
-
-    return ret;
+    return rule.numbers.map((number) => this.getSuffix(code, number))
   }
 
   getSuffix(code, count) {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -171,7 +171,7 @@ class Translator extends EventEmitter {
       let usedKey = false;
 
       const needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
-      const hasDefaultValue = this.hasDefaultValue(options);
+      const hasDefaultValue = Translator.hasDefaultValue(options);
       const defaultValueSuffix = needsPluralHandling
         ? this.pluralResolver.getSuffix(lng, options.count)
         : '';
@@ -220,38 +220,38 @@ class Translator extends EventEmitter {
           lngs.push(options.lng || this.language);
         }
 
-        const send = (lng, key, fallbackValue = defaultValue) => {
+        const send = (l, k, fallbackValue) => {
           if (this.options.missingKeyHandler) {
             this.options.missingKeyHandler(
-              lng,
+              l,
               namespace,
-              key,
+              k,
               updateMissing ? fallbackValue : res,
               updateMissing,
               options,
             );
           } else if (this.backendConnector && this.backendConnector.saveMissing) {
             this.backendConnector.saveMissing(
-              lng,
+              l,
               namespace,
-              key,
+              k,
               updateMissing ? fallbackValue : res,
               updateMissing,
               options,
             );
           }
-          this.emit('missingKey', lng, namespace, key, res);
+          this.emit('missingKey', l, namespace, k, res);
         };
 
         if (this.options.saveMissing) {
           if (this.options.saveMissingPlurals && needsPluralHandling) {
-            lngs.forEach(lng => {
-              this.pluralResolver.getSuffixes(lng).forEach(suffix => {
-                send([lng], key + suffix, options[`defaultValue${suffix}`]);
+            lngs.forEach(language => {
+              this.pluralResolver.getSuffixes(language).forEach(suffix => {
+                send([language], key + suffix, options[`defaultValue${suffix}`]);
               });
             });
           } else {
-            send(lngs, key);
+            send(lngs, key, defaultValue);
           }
         }
       }
@@ -458,12 +458,12 @@ class Translator extends EventEmitter {
     return this.resourceStore.getResource(code, ns, key, options);
   }
 
-  hasDefaultValue(options) {
+  static hasDefaultValue(options) {
     const prefix = 'defaultValue';
 
     for (const option in options) {
       if (
-        options.hasOwnProperty(option) &&
+        Object.prototype.hasOwnProperty.call(options, option) &&
         prefix === option.substring(0, prefix.length) &&
         undefined !== options[option]
       ) {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -170,15 +170,17 @@ class Translator extends EventEmitter {
       let usedDefault = false;
       let usedKey = false;
 
-      // fallback value
-      if (!this.isValidLookup(res) && options.defaultValue !== undefined) {
-        usedDefault = true;
+      const needsPluralHandling = options.count !== undefined && typeof options.count !== 'string';
+      const hasDefaultValue = this.hasDefaultValue(options);
+      const defaultValueSuffix = needsPluralHandling
+        ? this.pluralResolver.getSuffix(lng, options.count)
+        : '';
+      const defaultValue = options[`defaultValue${defaultValueSuffix}`];
 
-        if (options.count !== undefined) {
-          const suffix = this.pluralResolver.getSuffix(lng, options.count);
-          res = options[`defaultValue${suffix}`];
-        }
-        if (!res) res = options.defaultValue;
+      // fallback value
+      if (!this.isValidLookup(res) && hasDefaultValue) {
+        usedDefault = true;
+        res = defaultValue;
       }
       if (!this.isValidLookup(res)) {
         usedKey = true;
@@ -186,15 +188,14 @@ class Translator extends EventEmitter {
       }
 
       // save missing
-      const updateMissing =
-        options.defaultValue && options.defaultValue !== res && this.options.updateMissing;
+      const updateMissing = hasDefaultValue && defaultValue !== res && this.options.updateMissing;
       if (usedKey || usedDefault || updateMissing) {
         this.logger.log(
           updateMissing ? 'updateKey' : 'missingKey',
           lng,
           namespace,
           key,
-          updateMissing ? options.defaultValue : res,
+          updateMissing ? defaultValue : res,
         );
         if (keySeparator) {
           const fk = this.resolve(key, { ...options, keySeparator: false });
@@ -219,37 +220,35 @@ class Translator extends EventEmitter {
           lngs.push(options.lng || this.language);
         }
 
-        const send = (l, k) => {
+        const send = (lng, key, fallbackValue = defaultValue) => {
           if (this.options.missingKeyHandler) {
             this.options.missingKeyHandler(
-              l,
+              lng,
               namespace,
-              k,
-              updateMissing ? options.defaultValue : res,
+              key,
+              updateMissing ? fallbackValue : res,
               updateMissing,
               options,
             );
           } else if (this.backendConnector && this.backendConnector.saveMissing) {
             this.backendConnector.saveMissing(
-              l,
+              lng,
               namespace,
-              k,
-              updateMissing ? options.defaultValue : res,
+              key,
+              updateMissing ? fallbackValue : res,
               updateMissing,
               options,
             );
           }
-          this.emit('missingKey', l, namespace, k, res);
+          this.emit('missingKey', lng, namespace, key, res);
         };
 
         if (this.options.saveMissing) {
-          const needsPluralHandling =
-            options.count !== undefined && typeof options.count !== 'string';
           if (this.options.saveMissingPlurals && needsPluralHandling) {
-            lngs.forEach(l => {
-              const plurals = this.pluralResolver.getPluralFormsOfKey(l, key);
-
-              plurals.forEach(p => send([l], p));
+            lngs.forEach(lng => {
+              this.pluralResolver.getSuffixes(lng).forEach(suffix => {
+                send([lng], key + suffix, options[`defaultValue${suffix}`]);
+              });
             });
           } else {
             send(lngs, key);
@@ -457,6 +456,22 @@ class Translator extends EventEmitter {
     if (this.i18nFormat && this.i18nFormat.getResource)
       return this.i18nFormat.getResource(code, ns, key, options);
     return this.resourceStore.getResource(code, ns, key, options);
+  }
+
+  hasDefaultValue(options) {
+    const prefix = 'defaultValue';
+
+    for (const option in options) {
+      if (
+        options.hasOwnProperty(option) &&
+        prefix === option.substring(0, prefix.length) &&
+        undefined !== options[option]
+      ) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }
 

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -262,4 +262,28 @@ describe('PluralResolver', () => {
       );
     });
   });
+
+  describe('getSuffixes()', () => {
+    let pr;
+
+    before(() => {
+      let lu = new LanguageUtils({ fallbackLng: 'en' });
+      pr = new PluralResolver(lu, { simplifyPluralSuffix: true, prepend: '_' });
+    });
+
+    var tests = [
+      { args: [], expected: [] },
+      { args: ['en'], expected: ['', '_plural'] },
+      { args: ['ar'], expected: ['_0', '_1', '_2', '_3', '_4', '_5'] },
+    ];
+
+    tests.forEach(test => {
+      it(
+        'correctly returns pluralforms of a given key for ' + JSON.stringify(test.args) + ' args',
+        () => {
+          expect(pr.getSuffixes.apply(pr, test.args)).to.eql(test.expected);
+        },
+      );
+    });
+  });
 });

--- a/test/translator/translator.translate.missing.spec.js
+++ b/test/translator/translator.translate.missing.spec.js
@@ -1,126 +1,132 @@
-import Translator from '../../src/Translator';
-import ResourceStore from '../../src/ResourceStore.js';
+import Interpolator from '../../src/Interpolator';
 import LanguageUtils from '../../src/LanguageUtils';
 import PluralResolver from '../../src/PluralResolver';
-import Interpolator from '../../src/Interpolator';
+import ResourceStore from '../../src/ResourceStore.js';
+import Translator from '../../src/Translator';
+
+const NB_PLURALS_ARABIC = 6;
 
 describe('Translator', () => {
-  describe('translate() using missing', () => {
-    var t;
+  let t;
+  let tServices;
+  let missingKeyHandler;
 
-    before(() => {
-      const rs = new ResourceStore({
-        en: {
-          translation: {
-            test: 'test_en',
-            deep: {
-              test: 'deep_en',
-            },
+  beforeEach(() => {
+    const rs = new ResourceStore({
+      en: {
+        translation: {
+          test: 'test_en',
+          deep: {
+            test: 'deep_en',
           },
         },
-        de: {
-          translation: {
-            test: 'test_de',
-          },
+      },
+      de: {
+        translation: {
+          test: 'test_de',
+        },
+      },
+    });
+
+    const lu = new LanguageUtils({ fallbackLng: 'en' });
+
+    tServices = {
+      resourceStore: rs,
+      languageUtils: lu,
+      pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+      interpolator: new Interpolator(),
+    };
+
+    missingKeyHandler = sinon.spy();
+  });
+
+  describe('translate() saveMissing', () => {
+    beforeEach(() => {
+      t = new Translator(tServices, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        saveMissing: true,
+        missingKeyHandler,
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true,
         },
       });
-      const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator(
-        {
-          resourceStore: rs,
-          languageUtils: lu,
-          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
-          interpolator: new Interpolator(),
-        },
-        {
-          defaultNS: 'translation',
-          ns: 'translation',
-          saveMissing: true,
-          interpolation: {
-            interpolateResult: true,
-            interpolateDefaultValue: true,
-            interpolateKey: true,
-          },
-        },
-      );
       t.changeLanguage('en');
     });
 
-    var tests = [{ args: ['translation:test.missing'], expected: 'test.missing' }];
+    it('correctly sends missing', () => {
+      expect(t.translate('translation:test.missing')).to.eql('test.missing');
+      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test.missing', 'test.missing')).to
+        .be.true;
+    });
+  });
 
-    tests.forEach(test => {
+  describe('translate() saveMissing with saveMissingPlurals options', () => {
+    beforeEach(() => {
+      t = new Translator(tServices, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        saveMissing: true,
+        saveMissingPlurals: true,
+        missingKeyHandler,
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true,
+        },
+      });
+      t.changeLanguage('ar');
+    });
+
+    [
+      { args: ['translation:test.missing', { count: 10 }], expected: NB_PLURALS_ARABIC },
+      { args: ['translation:test.missing', { count: 0 }], expected: NB_PLURALS_ARABIC },
+    ].forEach(test => {
       it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
-        t.options.missingKeyHandler = (lngs, namespace, key, res) => {
-          expect(lngs).to.eql(['en']);
-          expect(namespace).to.eql('translation');
-          expect(key).to.eql(test.expected);
-          expect(res).to.eql(test.expected);
-        };
-
-        expect(t.translate.apply(t, test.args)).to.eql(test.expected);
+        t.translate.apply(t, test.args);
+        expect(missingKeyHandler.callCount).to.eql(test.expected);
+        expect(
+          missingKeyHandler
+            .getCall(0)
+            .calledWith(['ar'], 'translation', 'test.missing_0', 'test.missing'),
+        ).to.be.true;
       });
     });
   });
 
-  describe('translate() using missing with saveMissingPlurals options', () => {
-    const NB_PLURALS_ARABIC = 6;
-    var t;
-
-    before(() => {
-      const rs = new ResourceStore({
-        en: {
-          translation: {
-            test: 'test_en',
-            deep: {
-              test: 'deep_en',
-            },
-          },
-        },
-        de: {
-          translation: {
-            test: 'test_de',
-          },
+  describe('translate() saveMissing with saveMissingPlurals and defaults', () => {
+    beforeEach(() => {
+      t = new Translator(tServices, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        saveMissing: true,
+        saveMissingPlurals: true,
+        missingKeyHandler,
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true,
         },
       });
-      const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator(
-        {
-          resourceStore: rs,
-          languageUtils: lu,
-          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
-          interpolator: new Interpolator(),
-        },
-        {
-          defaultNS: 'translation',
-          ns: 'translation',
-          saveMissing: true,
-          saveMissingPlurals: true,
-          interpolation: {
-            interpolateResult: true,
-            interpolateDefaultValue: true,
-            interpolateKey: true,
-          },
-        },
-      );
       t.changeLanguage('ar');
+
+      t.translate('translation:test.missing', {
+        count: 0,
+        defaultValue_0: 'default0',
+        defaultValue_1: 'default1', // ignored
+      });
     });
 
-    var tests = [
-      { args: ['translation:test.missing', { count: 10 }], expected: NB_PLURALS_ARABIC },
-      { args: ['translation:test.missing', { count: 0 }], expected: NB_PLURALS_ARABIC },
-    ];
-
-    tests.forEach(test => {
-      it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
-        let todo = test.expected;
-        t.options.missingKeyHandler = (lngs, namespace, key, res) => {
-          // console.warn(lngs, namespace, key, res);
-          todo--;
-        };
-
-        t.translate.apply(t, test.args);
-        expect(todo).to.eql(0);
-      });
+    it('correctly sends missing resolved value', () => {
+      expect(missingKeyHandler.callCount).to.eql(NB_PLURALS_ARABIC);
+      expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_0', 'default0')).to
+        .be.true;
+      expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_1', 'default0')).to
+        .be.true;
+      expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_2', 'default0')).to
+        .be.true;
     });
   });
 });

--- a/test/translator/translator.translate.missing.spec.js
+++ b/test/translator/translator.translate.missing.spec.js
@@ -56,7 +56,7 @@ describe('Translator', () => {
       t.changeLanguage('en');
     });
 
-    it('correctly sends missing', () => {
+    it('correctly sends missing for "translation:test.missing"', () => {
       expect(t.translate('translation:test.missing')).to.eql('test.missing');
       expect(missingKeyHandler.calledWith(['en'], 'translation', 'test.missing', 'test.missing')).to
         .be.true;

--- a/test/translator/translator.translate.updateMissing.spec.js
+++ b/test/translator/translator.translate.updateMissing.spec.js
@@ -52,14 +52,31 @@ describe('Translator', () => {
           interpolateKey: true,
         },
       });
+
       t.changeLanguage('en');
     });
 
-    it('correctly sends missing', () => {
-      expect(t.translate('translation:test', { defaultValue: 'new value' })).to.eql('test_en');
-      expect(missingKeyHandler.calledOnce).to.be.true;
-      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
-        .true;
+    describe('without default value', () => {
+      it('does not invoke missingKeyHandler', () => {
+        expect(t.translate('translation:test')).to.eql('test_en');
+        expect(missingKeyHandler.notCalled).to.be.true;
+      });
+    });
+
+    describe('with an unchanged default value', () => {
+      it('does not invoke missingKeyHandler', () => {
+        expect(t.translate('translation:test', { defaultValue: 'test_en' })).to.eql('test_en');
+        expect(missingKeyHandler.notCalled).to.be.true;
+      });
+    });
+
+    describe('with a new default value', () => {
+      it('correctly sends missing', () => {
+        expect(t.translate('translation:test', { defaultValue: 'new value' })).to.eql('test_en');
+        expect(missingKeyHandler.calledOnce).to.be.true;
+        expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
+          .true;
+      });
     });
   });
 
@@ -81,19 +98,49 @@ describe('Translator', () => {
       t.changeLanguage('en');
     });
 
-    it('correctly sends missing', () => {
-      expect(
-        t.translate('translation:test', {
-          count: 1,
-          defaultValue: 'new value',
-          defaultValue_plural: 'new values',
-        }),
-      ).to.eql('test_en');
-      expect(missingKeyHandler.calledTwice).to.be.true;
-      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
-        .true;
-      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test_plural', 'new values', true))
-        .to.be.true;
+    describe('without a count option', () => {
+      it('only sends one missing key', () => {
+        expect(
+          t.translate('translation:test', {
+            defaultValue: 'new value',
+            defaultValue_plural: 'new values',
+          }),
+        ).to.eql('test_en');
+        expect(missingKeyHandler.calledOnce).to.be.true;
+        expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
+          .true;
+      });
+    });
+
+    describe('with a non-numeric count option', () => {
+      it('only sends one missing key', () => {
+        expect(
+          t.translate('translation:test', {
+            count: 'foo',
+            defaultValue: 'new value',
+            defaultValue_plural: 'new values',
+          }),
+        ).to.eql('test_en');
+        expect(missingKeyHandler.calledOnce).to.be.true;
+      });
+    });
+
+    describe('with a numeric count option', () => {
+      it('sends correct missing keys per default plural values', () => {
+        expect(
+          t.translate('translation:test', {
+            count: 1,
+            defaultValue: 'new value',
+            defaultValue_plural: 'new values',
+          }),
+        ).to.eql('test_en');
+        expect(missingKeyHandler.calledTwice).to.be.true;
+        expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
+          .true;
+        expect(
+          missingKeyHandler.calledWith(['en'], 'translation', 'test_plural', 'new values', true),
+        ).to.be.true;
+      });
     });
   });
 });

--- a/test/translator/translator.translate.updateMissing.spec.js
+++ b/test/translator/translator.translate.updateMissing.spec.js
@@ -1,73 +1,99 @@
-import Translator from '../../src/Translator';
-import ResourceStore from '../../src/ResourceStore.js';
+import Interpolator from '../../src/Interpolator';
 import LanguageUtils from '../../src/LanguageUtils';
 import PluralResolver from '../../src/PluralResolver';
-import Interpolator from '../../src/Interpolator';
+import ResourceStore from '../../src/ResourceStore.js';
+import Translator from '../../src/Translator';
 
 describe('Translator', () => {
-  describe('translate() using updateMissing', () => {
-    var t;
+  let t;
+  let tServices;
+  let missingKeyHandler;
 
-    before(() => {
-      const rs = new ResourceStore({
-        en: {
-          translation: {
-            test: 'test_en',
-            deep: {
-              test: 'deep_en',
-            },
+  beforeEach(() => {
+    const rs = new ResourceStore({
+      en: {
+        translation: {
+          test: 'test_en',
+          deep: {
+            test: 'deep_en',
           },
         },
-        de: {
-          translation: {
-            test: 'test_de',
-          },
+      },
+      de: {
+        translation: {
+          test: 'test_de',
+        },
+      },
+    });
+
+    const lu = new LanguageUtils({ fallbackLng: 'en' });
+
+    tServices = {
+      resourceStore: rs,
+      languageUtils: lu,
+      pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+      interpolator: new Interpolator(),
+    };
+
+    missingKeyHandler = sinon.spy();
+  });
+
+  describe('translate() using updateMissing', () => {
+    beforeEach(() => {
+      t = new Translator(tServices, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        saveMissing: true,
+        updateMissing: true,
+        missingKeyHandler,
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true,
         },
       });
-      const lu = new LanguageUtils({ fallbackLng: 'en' });
-      t = new Translator(
-        {
-          resourceStore: rs,
-          languageUtils: lu,
-          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
-          interpolator: new Interpolator(),
-        },
-        {
-          defaultNS: 'translation',
-          ns: 'translation',
-          saveMissing: true,
-          updateMissing: true,
-          interpolation: {
-            interpolateResult: true,
-            interpolateDefaultValue: true,
-            interpolateKey: true,
-          },
-        },
-      );
       t.changeLanguage('en');
     });
 
-    var tests = [
-      { args: ['translation:test', { defaultValue: 'new value' }], expected: 'test_en' },
-    ];
+    it('correctly sends missing', () => {
+      expect(t.translate('translation:test', { defaultValue: 'new value' })).to.eql('test_en');
+      expect(missingKeyHandler.calledOnce).to.be.true;
+      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
+        .true;
+    });
+  });
 
-    tests.forEach(test => {
-      it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
-        let wasCalled = false;
-
-        t.options.missingKeyHandler = (lngs, namespace, key, res, wasUpdate) => {
-          expect(lngs).to.eql(['en']);
-          expect(namespace).to.eql('translation');
-          expect(key).to.eql('test');
-          expect(res).to.eql('new value');
-          expect(wasUpdate).to.equal(true);
-
-          wasCalled = true;
-        };
-
-        expect(t.translate.apply(t, test.args)).to.eql(test.expected);
-        expect(wasCalled).to.equal(true);
+  describe('translate() using updateMissing with saveMissingPlurals', () => {
+    beforeEach(() => {
+      t = new Translator(tServices, {
+        defaultNS: 'translation',
+        ns: 'translation',
+        saveMissing: true,
+        saveMissingPlurals: true,
+        updateMissing: true,
+        missingKeyHandler,
+        interpolation: {
+          interpolateResult: true,
+          interpolateDefaultValue: true,
+          interpolateKey: true,
+        },
       });
+      t.changeLanguage('en');
+    });
+
+    it('correctly sends missing', () => {
+      expect(
+        t.translate('translation:test', {
+          count: 1,
+          defaultValue: 'new value',
+          defaultValue_plural: 'new values',
+        }),
+      ).to.eql('test_en');
+      expect(missingKeyHandler.calledTwice).to.be.true;
+      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to.be
+        .true;
+      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test_plural', 'new values', true))
+        .to.be.true;
     });
   });
 });


### PR DESCRIPTION
Fixes #1549

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

* This should at least fix default plural values sent to the backend when `updateMissing` is enabled. I'm not sure if this will _also_ fix the interpolation result described in #1549.
* Remove some test duplication

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added