### PR TITLE
fix: type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -729,8 +729,8 @@ export interface Module {
 }
 
 export type CallbackError = Error | null | undefined;
-export type ReadCallback = (err: CallbackError, data: ResourceKey | boolean) => void;
-export type MultiReadCallback = (err: CallbackError, data: Resource) => void;
+export type ReadCallback = (err: CallbackError, data: ResourceKey | boolean | null | undefined) => void;
+export type MultiReadCallback = (err: CallbackError, data: Resource | null | undefined) => void;
 
 /**
  * Used to load data for i18next.
@@ -742,9 +742,9 @@ export interface BackendModule<TOptions = object> extends Module {
   init(services: Services, backendOptions: TOptions, i18nextOptions: InitOptions): void;
   read(language: string, namespace: string, callback: ReadCallback): void;
   /** Save the missing translation */
-  create(languages: string[], namespace: string, key: string, fallbackValue: string): void;
+  create?(languages: string[], namespace: string, key: string, fallbackValue: string): void;
   /** Load multiple languages and namespaces. For backends supporting multiple resources loading */
-  readMulti?(languages: string[], namespaces: string[], callback: ReadCallback): void;
+  readMulti?(languages: string[], namespaces: string[], callback: MultiReadCallback): void;
   /** Store the translation. For backends acting as cache layer */
   save?(language: string, namespace: string, data: ResourceLanguage): void;
 }


### PR DESCRIPTION
- Allow nullable "data" in BackendModule.read callback. According to the docs, callback(err, null) is valid.
- BackendModule.create is optional.
- BackendModule.readMulti should use MultiReadCallback instead of ReadCallback.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included        <- Not needed (in my opinion)
- [ ] documentation is changed or added  <- Not needed (in my opinion)