### PR TITLE
Fallback on singular defaultValue

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -175,7 +175,7 @@ class Translator extends EventEmitter {
       const defaultValueSuffix = needsPluralHandling
         ? this.pluralResolver.getSuffix(lng, options.count)
         : '';
-      const defaultValue = options[`defaultValue${defaultValueSuffix}`];
+      const defaultValue = options[`defaultValue${defaultValueSuffix}`] || options.defaultValue;
 
       // fallback value
       if (!this.isValidLookup(res) && hasDefaultValue) {
@@ -247,7 +247,7 @@ class Translator extends EventEmitter {
           if (this.options.saveMissingPlurals && needsPluralHandling) {
             lngs.forEach(language => {
               this.pluralResolver.getSuffixes(language).forEach(suffix => {
-                send([language], key + suffix, options[`defaultValue${suffix}`]);
+                send([language], key + suffix, options[`defaultValue${suffix}`] || defaultValue);
               });
             });
           } else {

--- a/test/translator/translator.translate.updateMissing.spec.js
+++ b/test/translator/translator.translate.updateMissing.spec.js
@@ -125,6 +125,25 @@ describe('Translator', () => {
       });
     });
 
+    describe('without a default plural value', () => {
+      [1, 2].forEach(count => {
+        it(`count=${count}: sends falls back on singular default value`, () => {
+          expect(
+            t.translate('translation:test', {
+              count,
+              defaultValue: 'new value',
+            }),
+          ).to.eql('test_en');
+          expect(missingKeyHandler.calledTwice).to.be.true;
+          expect(missingKeyHandler.calledWith(['en'], 'translation', 'test', 'new value', true)).to
+            .be.true;
+          expect(
+            missingKeyHandler.calledWith(['en'], 'translation', 'test_plural', 'new value', true),
+          ).to.be.true;
+        });
+      });
+    });
+
     describe('with a numeric count option', () => {
       it('sends correct missing keys per default plural values', () => {
         expect(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Relates to https://github.com/i18next/i18next/issues/1549

Minor followup to https://github.com/i18next/i18next/pull/1558 that fallbacks to the singular `defaultValue` if the plural variant is undefined, which resembles the previous behavior. This at least supports scenarios in which the singular and plural strings are the same.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added