### PR TITLE
introduce ignoreJSONStructure flag, to automatically lookup for a flat key if a nested key is not found an vice-versa

### DIFF
--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -1,6 +1,41 @@
 import EventEmitter from './EventEmitter.js';
 import * as utils from './utils.js';
 
+function deepFind(obj, path, keySeparator = '.') {
+  if (!obj) return undefined;
+  if (obj[path]) return obj[path];
+  const paths = path.split(keySeparator);
+  let current = obj;
+  for (let i = 0; i < paths.length; ++i) {
+    if (typeof current[paths[i]] === 'string' && i + 1 < paths.length) {
+      return undefined;
+    }
+    if (current[paths[i]] === undefined) {
+      let j = 2;
+      let mix = current;
+      let p = paths.slice(i, i + j).join(keySeparator);
+      while (
+        paths.length > i + j &&
+        (p = paths.slice(i, i + j).join(keySeparator)) &&
+        (mix = mix[p]) &&
+        !mix
+      ) {
+        j++;
+      }
+      if (mix) {
+        if (typeof mix === 'string') return mix;
+        if (p && typeof mix[p] === 'string') return mix[p];
+        const joinedPath = paths.slice(i + j).join(keySeparator);
+        if (joinedPath) return deepFind(mix, joinedPath, keySeparator);
+      }
+      return undefined;
+    } else {
+      current = current[paths[i]];
+    }
+  }
+  return current;
+}
+
 class ResourceStore extends EventEmitter {
   constructor(data, options = { ns: ['translation'], defaultNS: 'translation' }) {
     super();
@@ -12,6 +47,9 @@ class ResourceStore extends EventEmitter {
     this.options = options;
     if (this.options.keySeparator === undefined) {
       this.options.keySeparator = '.';
+    }
+    if (this.options.ignoreJSONStructure === undefined) {
+      this.options.ignoreJSONStructure = true;
     }
   }
 
@@ -32,6 +70,11 @@ class ResourceStore extends EventEmitter {
     const keySeparator =
       options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
 
+    const ignoreJSONStructure =
+      options.ignoreJSONStructure !== undefined
+        ? options.ignoreJSONStructure
+        : this.options.ignoreJSONStructure;
+
     let path = [lng, ns];
     if (key && typeof key !== 'string') path = path.concat(key);
     if (key && typeof key === 'string')
@@ -41,7 +84,10 @@ class ResourceStore extends EventEmitter {
       path = lng.split('.');
     }
 
-    return utils.getPath(this.data, path);
+    const result = utils.getPath(this.data, path);
+    if (result || !ignoreJSONStructure || typeof key !== 'string') return result;
+
+    return deepFind(this.data && this.data[lng] && this.data[lng][ns], key, keySeparator);
   }
 
   addResource(lng, ns, key, value, options = { silent: false }) {

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -12,26 +12,21 @@ function deepFind(obj, path, keySeparator = '.') {
     }
     if (current[paths[i]] === undefined) {
       let j = 2;
-      let mix = current;
       let p = paths.slice(i, i + j).join(keySeparator);
-      while (
-        paths.length > i + j &&
-        (p = paths.slice(i, i + j).join(keySeparator)) &&
-        (mix = mix[p]) &&
-        !mix
-      ) {
+      let mix = current[p];
+      while (mix === undefined && paths.length > i + j) {
         j++;
+        p = paths.slice(i, i + j).join(keySeparator);
+        mix = current[p];
       }
-      if (mix) {
-        if (typeof mix === 'string') return mix;
-        if (p && typeof mix[p] === 'string') return mix[p];
-        const joinedPath = paths.slice(i + j).join(keySeparator);
-        if (joinedPath) return deepFind(mix, joinedPath, keySeparator);
-      }
+      if (mix === undefined) return undefined;
+      if (typeof mix === 'string') return mix;
+      if (p && typeof mix[p] === 'string') return mix[p];
+      const joinedPath = paths.slice(i + j).join(keySeparator);
+      if (joinedPath) return deepFind(mix, joinedPath, keySeparator);
       return undefined;
-    } else {
-      current = current[paths[i]];
     }
+    current = current[paths[i]];
   }
   return current;
 }

--- a/test/resourceStore.fallback.spec.js
+++ b/test/resourceStore.fallback.spec.js
@@ -1,0 +1,61 @@
+import ResourceStore from '../src/ResourceStore.js';
+
+describe('ResourceStore', () => {
+  describe('nestedFlatFallback', () => {
+    it('it should find the resource in various flat/nested combinations', () => {
+      const data = {
+        en: {
+          translation: {
+            a: {
+              nested: 'a nested value',
+            },
+            'a.flat': 'a flat value',
+            'b.flat': {
+              nested: 'mix value',
+              more: {
+                nesting: 'deep',
+                'flat.again': 'deep flat',
+              },
+              more2: {
+                'flat.again': 'deep flat',
+                deeper: {
+                  key: 'very deep',
+                },
+              },
+            },
+            str: 'whatever',
+          },
+        },
+      };
+      const rs = new ResourceStore(data);
+      expect(rs.toJSON()).to.equal(data);
+
+      let ret = rs.getResource('en', 'translation', 'a.nested');
+      expect(ret).to.equal('a nested value');
+
+      ret = rs.getResource('en', 'translation', 'a.flat');
+      expect(ret).to.equal('a flat value');
+
+      ret = rs.getResource('en', 'translation', 'b.flat.nested');
+      expect(ret).to.equal('mix value');
+
+      ret = rs.getResource('en', 'translation', 'b.flat.more.nesting');
+      expect(ret).to.equal('deep');
+
+      ret = rs.getResource('en', 'translation', 'b.flat.more.flat.again');
+      expect(ret).to.equal('deep flat');
+
+      ret = rs.getResource('en', 'translation', 'b.flat.more2.flat.again');
+      expect(ret).to.equal('deep flat');
+
+      ret = rs.getResource('en', 'translation', 'b.flat.more2.deeper.key');
+      expect(ret).to.equal('very deep');
+
+      ret = rs.getResource('en', 'translation', 'a.wrong');
+      expect(ret).to.equal(undefined);
+
+      ret = rs.getResource('en', 'translation', 'str.wrong');
+      expect(ret).to.equal(undefined);
+    });
+  });
+});

--- a/test/resourceStore.fallback.spec.js
+++ b/test/resourceStore.fallback.spec.js
@@ -8,6 +8,16 @@ describe('ResourceStore', () => {
           translation: {
             a: {
               nested: 'a nested value',
+              'more.of': {
+                nested: {
+                  here: {
+                    wow: 'cool',
+                  },
+                  'and.even.more': {
+                    gaga: 'strange',
+                  },
+                },
+              },
             },
             'a.flat': 'a flat value',
             'b.flat': {
@@ -50,6 +60,12 @@ describe('ResourceStore', () => {
 
       ret = rs.getResource('en', 'translation', 'b.flat.more2.deeper.key');
       expect(ret).to.equal('very deep');
+
+      ret = rs.getResource('en', 'translation', 'a.more.of.nested.here.wow');
+      expect(ret).to.equal('cool');
+
+      ret = rs.getResource('en', 'translation', 'a.more.of.nested.and.even.more.gaga');
+      expect(ret).to.equal('strange');
 
       ret = rs.getResource('en', 'translation', 'a.wrong');
       expect(ret).to.equal(undefined);

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -34,4 +34,48 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('#deepFind', () => {
+    it('should get nested and flat values', () => {
+      const obj = {
+        a: {
+          nested: 'a nested value',
+        },
+        'a.flat': 'a flat value',
+        'b.flat': {
+          nested: 'mix value',
+          more: {
+            nesting: 'deep',
+            'flat.again': 'deep flat',
+          },
+          more2: {
+            'flat.again': 'deep flat',
+            deeper: {
+              key: 'very deep',
+            },
+          },
+        },
+        str: 'whatever',
+      };
+
+      // const n = deepFind(obj, 'a.nested')
+      // should(n).eql('a nested value')
+      // const f = deepFind(obj, 'a.flat')
+      // should(f).eql('a flat value')
+      // const m = deepFind(obj, 'b.flat.nested')
+      // should(m).eql('mix value')
+      // const d = deepFind(obj, 'b.flat.more.nesting')
+      // should(d).eql('deep')
+      // const df = deepFind(obj, 'b.flat.more.flat.again')
+      // should(df).eql('deep flat')
+      // const df2 = deepFind(obj, 'b.flat.more2.flat.again')
+      // should(df2).eql('deep flat')
+      // const v = deepFind(obj, 'b.flat.more2.deeper.key')
+      // should(v).eql('very deep')
+      // const fls = deepFind(obj, 'a.wrong')
+      // should(fls).eql(undefined)
+      // const fls2 = deepFind(obj, 'str.wrong')
+      // should(fls2).eql(undefined)
+    });
+  });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -34,48 +34,4 @@ describe('utils', () => {
       });
     });
   });
-
-  describe('#deepFind', () => {
-    it('should get nested and flat values', () => {
-      const obj = {
-        a: {
-          nested: 'a nested value',
-        },
-        'a.flat': 'a flat value',
-        'b.flat': {
-          nested: 'mix value',
-          more: {
-            nesting: 'deep',
-            'flat.again': 'deep flat',
-          },
-          more2: {
-            'flat.again': 'deep flat',
-            deeper: {
-              key: 'very deep',
-            },
-          },
-        },
-        str: 'whatever',
-      };
-
-      // const n = deepFind(obj, 'a.nested')
-      // should(n).eql('a nested value')
-      // const f = deepFind(obj, 'a.flat')
-      // should(f).eql('a flat value')
-      // const m = deepFind(obj, 'b.flat.nested')
-      // should(m).eql('mix value')
-      // const d = deepFind(obj, 'b.flat.more.nesting')
-      // should(d).eql('deep')
-      // const df = deepFind(obj, 'b.flat.more.flat.again')
-      // should(df).eql('deep flat')
-      // const df2 = deepFind(obj, 'b.flat.more2.flat.again')
-      // should(df2).eql('deep flat')
-      // const v = deepFind(obj, 'b.flat.more2.deeper.key')
-      // should(v).eql('very deep')
-      // const fls = deepFind(obj, 'a.wrong')
-      // should(fls).eql(undefined)
-      // const fls2 = deepFind(obj, 'str.wrong')
-      // should(fls2).eql(undefined)
-    });
-  });
 });


### PR DESCRIPTION
This PR is just for discussion...

It is not breaking anything, but increments a bit of code size and by default sets the ignoreJSONStructure flag to true (tbd).

This functionality, helps in cases where the json data is mixed nested and flat or the json data is changing, like when using auto mode for the publishFormat in locize...

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added