### PR TITLE
Add alwaysFormat into the types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,12 @@ export interface InterpolationOptions {
    */
   escape?(str: string): string;
 
+
+  /**
+   * Always format interpolated values.
+   * @default false
+   */
+   alwaysFormat?: boolean;
   /**
    * Escape passed in values to avoid xss injection
    * @default true


### PR DESCRIPTION
There is the config alwaysFormat that works fine, but is missing from the types.


#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added