### PR TITLE
`includes` is not supported on older browsers

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -59,7 +59,9 @@ class Interpolator {
     const regexpStr = `${this.prefix}(.+?)${this.suffix}`;
     this.regexp = new RegExp(regexpStr, 'g');
 
-    const regexpUnescapeStr = `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${this.suffix}`;
+    const regexpUnescapeStr = `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${
+      this.suffix
+    }`;
     this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
 
     const nestingRegexpStr = `${this.nestingPrefix}(.+?)${this.nestingSuffix}`;
@@ -197,7 +199,7 @@ class Interpolator {
        *   - Not t(a, b, {"keyA": "valueA", "keyB": "valueB"})
        */
       let doReduce = false;
-      if (match[0].includes(this.formatSeparator) && !/{.*}/.test(match[1])) {
+      if (match[0].indexOf(this.formatSeparator) !== -1 && !/{.*}/.test(match[1])) {
         const r = match[1].split(this.formatSeparator).map(elem => elem.trim());
         match[1] = r.shift();
         formatters = r;


### PR DESCRIPTION
Because of https://github.com/i18next/i18next/issues/1596
I'm issueing a PR to address `includes` not being supported on older browsers.

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added