### PR TITLE
1618 - Add 'ns' to the 'returnedObjectHandler' options

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -133,7 +133,7 @@ class Translator extends EventEmitter {
       if (!options.returnObjects && !this.options.returnObjects) {
         this.logger.warn('accessing an object - but returnObjects options is not enabled!');
         return this.options.returnedObjectHandler
-          ? this.options.returnedObjectHandler(resUsedKey, res, options)
+          ? this.options.returnedObjectHandler(resUsedKey, res, { ...options, ns: namespaces })
           : `key '${key} (${this.language})' returned an object instead of string.`;
       }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Add 'ns' to the 'returnedObjectHandler' options

I've used the same base code from https://github.com/i18next/i18next/pull/1617 to add tests for the `returnObject = false` case

closes #1618

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added