### PR TITLE
change to return false when a nullable argument is passed

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -2,6 +2,7 @@ import baseLogger from './logger.js';
 import EventEmitter from './EventEmitter.js';
 import postProcessor from './postProcessor.js';
 import * as utils from './utils.js';
+import { isOptional } from './utils.js';
 
 const checkedLoadedFor = {};
 
@@ -39,6 +40,10 @@ class Translator extends EventEmitter {
   }
 
   exists(key, options = { interpolation: {} }) {
+    if (isOptional(key)) {
+      return false;
+    }
+
     const resolved = this.resolve(key, options);
     return resolved && resolved.res !== undefined;
   }
@@ -84,7 +89,7 @@ class Translator extends EventEmitter {
     if (!options) options = {};
 
     // non valid keys handling
-    if (keys === undefined || keys === null /* || keys === ''*/) return '';
+    if (isOptional(keys) /* || keys === ''*/) return '';
     if (!Array.isArray(keys)) keys = [String(keys)];
 
     // separators
@@ -364,8 +369,7 @@ class Translator extends EventEmitter {
     let usedLng;
     let usedNS;
 
-    if (!keys) keys = [];
-    else if (typeof keys === 'string') keys = [keys];
+    if (typeof keys === 'string') keys = [keys];
 
     // forEach possible key
     keys.forEach(k => {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -364,7 +364,8 @@ class Translator extends EventEmitter {
     let usedLng;
     let usedNS;
 
-    if (typeof keys === 'string') keys = [keys];
+    if (!keys) keys = [];
+    else if (typeof keys === 'string') keys = [keys];
 
     // forEach possible key
     keys.forEach(k => {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -2,7 +2,6 @@ import baseLogger from './logger.js';
 import EventEmitter from './EventEmitter.js';
 import postProcessor from './postProcessor.js';
 import * as utils from './utils.js';
-import { isOptional } from './utils.js';
 
 const checkedLoadedFor = {};
 
@@ -40,7 +39,7 @@ class Translator extends EventEmitter {
   }
 
   exists(key, options = { interpolation: {} }) {
-    if (isOptional(key)) {
+    if (key === undefined || key === null) {
       return false;
     }
 
@@ -89,7 +88,7 @@ class Translator extends EventEmitter {
     if (!options) options = {};
 
     // non valid keys handling
-    if (isOptional(keys) /* || keys === ''*/) return '';
+    if (keys === undefined || keys === null /* || keys === ''*/) return '';
     if (!Array.isArray(keys)) keys = [String(keys)];
 
     // separators

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,3 +139,7 @@ export const isIE10 =
   window.navigator &&
   window.navigator.userAgent &&
   window.navigator.userAgent.indexOf('MSIE') > -1;
+
+export function isOptional(str) {
+  return str === undefined || str === null;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,7 +139,3 @@ export const isIE10 =
   window.navigator &&
   window.navigator.userAgent &&
   window.navigator.userAgent.indexOf('MSIE') > -1;
-
-export function isOptional(str) {
-  return str === undefined || str === null;
-}

--- a/test/translator/translator.exists.spec.js
+++ b/test/translator/translator.exists.spec.js
@@ -62,5 +62,13 @@ describe('Translator', () => {
         expect(t.exists.apply(t, test.args)).to.eql(test.expected);
       });
     });
+
+    const nullishArgs = ['', undefined, null];
+
+    nullishArgs.forEach(nullishArg => {
+      it(`should return false if a "${nullishArg}" key is passed as an argument`, () => {
+        expect(t.exists(nullishArg)).to.false;
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

I have used i18next, react-i18next.
However, when using the i18n object to determine the existence of the key, I found that passing one `nullish factor(undefined or null, or '')` results in the error below:

```js
TypeError
Cannot read property 'forEach' of undefined
```

I think `i18n.exist(undefined or null, or '')` should return` false`.

Similar to mine, there will be many cases that deliver nullish factors, and I think it is obvious that nullish factors do not exist as keys in the resource.


#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided