### PR TITLE
Feature: key prefix option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -940,9 +940,15 @@ export interface i18n {
    * Returns a t function that defaults to given language or namespace.
    * Both params could be arrays of languages or namespaces and will be treated as fallbacks in that case.
    * On the returned function you can like in the t function override the languages or namespaces by passing them in options or by prepending namespace.
+   *
+   * Accepts optional keyPrefix that will be automatically applied to returned t function.
    */
-  getFixedT(lng: string | readonly string[], ns?: string | readonly string[]): TFunction;
-  getFixedT(lng: null, ns: string | readonly string[]): TFunction;
+  getFixedT(
+    lng: string | readonly string[],
+    ns?: string | readonly string[],
+    keyPrefix?: string,
+  ): TFunction;
+  getFixedT(lng: null, ns: string | readonly string[], keyPrefix?: string): TFunction;
 
   /**
    * Changes the language. The callback will be called as soon translations were loaded or an error occurs while loading.

--- a/index.d.ts
+++ b/index.d.ts
@@ -948,7 +948,7 @@ export interface i18n {
     ns?: string | readonly string[],
     keyPrefix?: string,
   ): TFunction;
-  getFixedT(lng: null, ns: string | readonly string[], keyPrefix?: string): TFunction;
+  getFixedT(lng: null, ns: string | readonly string[] | null, keyPrefix?: string): TFunction;
 
   /**
    * Changes the language. The callback will be called as soon translations were loaded or an error occurs while loading.

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -310,7 +310,7 @@ class I18n extends EventEmitter {
     return deferred;
   }
 
-  getFixedT(lng, ns) {
+  getFixedT(lng, ns, keyPrefix) {
     const fixedT = (key, opts, ...rest) => {
       let options;
       if (typeof opts !== 'object') {
@@ -322,7 +322,10 @@ class I18n extends EventEmitter {
       options.lng = options.lng || fixedT.lng;
       options.lngs = options.lngs || fixedT.lngs;
       options.ns = options.ns || fixedT.ns;
-      return this.t(key, options);
+
+      const keySeparator = this.options.keySeparator || '.';
+      const resultKey = keyPrefix ? `${keyPrefix}${keySeparator}${key}` : key;
+      return this.t(resultKey, options);
     };
     if (typeof lng === 'string') {
       fixedT.lng = lng;
@@ -330,6 +333,7 @@ class I18n extends EventEmitter {
       fixedT.lngs = lng;
     }
     fixedT.ns = ns;
+    fixedT.keyPrefix = keyPrefix;
     return fixedT;
   }
 

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -92,6 +92,7 @@ describe('i18next', () => {
         i18next.addResource('fr', 'translation', 'deeply.nested.key', 'ici!');
         const t = i18next.getFixedT('fr', null, 'deeply.nested');
         expect(t('key')).to.equal('ici!');
+        expect(t.keyPrefix).to.equal('deeply.nested');
       });
     });
   });

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -88,6 +88,11 @@ describe('i18next', () => {
         expect(translatedKey).to.equal('default');
         expect(translatedSecondKey).to.equal('default');
       });
+      it('should apply keyPrefix', () => {
+        i18next.addResource('fr', 'translation', 'deeply.nested.key', 'ici!');
+        const t = i18next.getFixedT('fr', null, 'deeply.nested');
+        expect(t('key')).to.equal('ici!');
+      });
     });
   });
 


### PR DESCRIPTION
Adds optional `keyPrefix` parameter to `getFixedT` function in order to allows for improved developer experience when querying deeply nested keys with common prefix.

```
i18next.addResource('fr', 'translation', 'very.deeply.nested.key', 'ici!');
const t = i18next.getFixedT('fr', null, 'very.deeply.nested');
const test = t('key'); // "ici!"
```

Original GH issue (from react-i18next): https://github.com/i18next/react-i18next/issues/1359 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided