### PR TITLE
conditional logging of missingKey if using natural language

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -200,13 +200,20 @@ class Translator extends EventEmitter {
       // save missing
       const updateMissing = hasDefaultValue && defaultValue !== res && this.options.updateMissing;
       if (usedKey || usedDefault || updateMissing) {
-        this.logger.log(
-          updateMissing ? 'updateKey' : 'missingKey',
-          lng,
-          namespace,
-          key,
-          updateMissing ? defaultValue : res,
-        );
+        if (
+          this.options.saveMissing ||
+          this.options.updateMissing ||
+          !this.resourceStore.hasResourceBundle(lng, namespace) ||
+          Object.keys(this.resourceStore.getDataByLanguage(lng)[namespace]).length > 0
+        ) {
+          this.logger.log(
+            updateMissing ? 'updateKey' : 'missingKey',
+            lng,
+            namespace,
+            key,
+            updateMissing ? defaultValue : res,
+          );
+        }
         if (keySeparator) {
           const fk = this.resolve(key, { ...options, keySeparator: false });
           if (fk && fk.res)


### PR DESCRIPTION
conditional logging of missingKey if using natural language, should fix #1634

having the resources initialized like this should not create the log:

```javascript
i18next.init({
  resources: {
    en: { translation: {} },
    de: { translation: {
      some: 'translation'
    } }
  }
})
i18next.t('some')
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [-] tests are included
