### PR TITLE
introduce new i18next.resolvedLanguage property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `skipOnVariables` by default now is true
 - automatically detect natural language keys (no need to set nsSeparator or keySeparator to false)
 - remove deprecated whitelist features
+- introduce new i18next.resolvedLanguage property
 
 ### 20.6.1
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -963,6 +963,12 @@ export interface i18n {
   languages: readonly string[];
 
   /**
+   * Is set to the current resolved language.
+   * It can be used as primary used language, for example in a language switcher.
+   */
+  resolvedLanguage: string;
+
+  /**
    * Loads additional namespaces not defined in init options.
    */
   loadNamespaces(ns: string | readonly string[], callback?: Callback): Promise<void>;

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -168,6 +168,12 @@ class ResourceStore extends EventEmitter {
     return this.data[lng];
   }
 
+  hasLanguageSomeTranslations(lng) {
+    const data = this.getDataByLanguage(lng);
+    const n = (data && Object.keys(data)) || [];
+    return !!n.find(v => data[v] && Object.keys(data[v]).length > 0);
+  }
+
   toJSON() {
     return this.data;
   }

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -521,7 +521,7 @@ class I18n extends EventEmitter {
   cloneInstance(options = {}, callback = noop) {
     const mergedOptions = { ...this.options, ...options, ...{ isClone: true } };
     const clone = new I18n(mergedOptions);
-    const membersToCopy = ['store', 'services', 'language', 'resolvedLanguage'];
+    const membersToCopy = ['store', 'services', 'language'];
     membersToCopy.forEach(m => {
       clone[m] = this[m];
     });

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -177,9 +177,88 @@ describe('i18next', () => {
             },
             language: 'en',
             languages: ['en', 'dev'],
+            resolvedLanguage: 'en',
           }),
         );
         done();
+      });
+    });
+  });
+
+  describe('language properties', () => {
+    let newInstance;
+    before(done => {
+      newInstance = i18next.createInstance({
+        fallbackLng: 'en',
+        resources: {
+          en: {
+            translation: {
+              key: 'value in en',
+            },
+          },
+          de: {
+            translation: {
+              key: 'value in de',
+            },
+          },
+          fr: {
+            translation: {},
+          },
+        },
+      });
+      newInstance.init({}, done);
+    });
+
+    describe('after init', () => {
+      it('it should have the appropriate language properties', () => {
+        expect(newInstance).to.have.property('language', 'en');
+        expect(newInstance).to.have.property('languages');
+        expect(newInstance.languages).to.have.lengthOf(1);
+        expect(newInstance.languages[0]).to.equal('en');
+        expect(newInstance).to.have.property('resolvedLanguage', 'en');
+      });
+    });
+
+    describe('after changeLanguage with a non available language', () => {
+      before(() => {
+        newInstance.changeLanguage('it');
+      });
+      it('it should have the appropriate language properties', () => {
+        expect(newInstance).to.have.property('language', 'it');
+        expect(newInstance).to.have.property('languages');
+        expect(newInstance.languages).to.have.lengthOf(2);
+        expect(newInstance.languages[0]).to.equal('it');
+        expect(newInstance.languages[1]).to.equal('en');
+        expect(newInstance).to.have.property('resolvedLanguage', 'en');
+      });
+    });
+
+    describe('after changeLanguage with a region specific language', () => {
+      before(() => {
+        newInstance.changeLanguage('de-CH');
+      });
+      it('it should have the appropriate language properties', () => {
+        expect(newInstance).to.have.property('language', 'de-CH');
+        expect(newInstance).to.have.property('languages');
+        expect(newInstance.languages).to.have.lengthOf(3);
+        expect(newInstance.languages[0]).to.equal('de-CH');
+        expect(newInstance.languages[1]).to.equal('de');
+        expect(newInstance.languages[2]).to.equal('en');
+        expect(newInstance).to.have.property('resolvedLanguage', 'de');
+      });
+    });
+
+    describe('after changeLanguage with an empty loaded language', () => {
+      before(() => {
+        newInstance.changeLanguage('fr');
+      });
+      it('it should have the appropriate language properties', () => {
+        expect(newInstance).to.have.property('language', 'fr');
+        expect(newInstance).to.have.property('languages');
+        expect(newInstance.languages).to.have.lengthOf(2);
+        expect(newInstance.languages[0]).to.equal('fr');
+        expect(newInstance.languages[1]).to.equal('en');
+        expect(newInstance).to.have.property('resolvedLanguage', 'en');
       });
     });
   });


### PR DESCRIPTION
It can be used as primary used language, for example in a language switcher.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

