### PR TITLE
Updated i18next compat dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6314,10 +6314,30 @@
       "dev": true
     },
     "i18next-browser-languagedetector": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-1.0.1.tgz",
-      "integrity": "sha1-c+Q6pG/ByQnKxheLnRuAPQJhD6o=",
-      "dev": true
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.2.tgz",
+      "integrity": "sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.14.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+          "dev": true
+        }
+      }
     },
     "i18next-http-backend": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6329,9 +6329,9 @@
       }
     },
     "i18next-localstorage-cache": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/i18next-localstorage-cache/-/i18next-localstorage-cache-0.3.0.tgz",
-      "integrity": "sha1-EkzItikRYOK9RBJ/82GHkAAxQ4U=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/i18next-localstorage-cache/-/i18next-localstorage-cache-1.1.1.tgz",
+      "integrity": "sha1-V1JWzDXoyy2IFI91R2b90tJLsbc=",
       "dev": true
     },
     "i18next-sprintf-postprocessor": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "husky": "^7.0.2",
     "i18next-browser-languagedetector": "1.0.1",
     "i18next-http-backend": "^1.3.1",
-    "i18next-localstorage-cache": "0.3.0",
+    "i18next-localstorage-cache": "1.1.1",
     "i18next-sprintf-postprocessor": "0.2.2",
     "karma": "6.3.4",
     "karma-browserify": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.9.0",
     "husky": "^7.0.2",
-    "i18next-browser-languagedetector": "1.0.1",
+    "i18next-browser-languagedetector": "6.1.2",
     "i18next-http-backend": "^1.3.1",
     "i18next-localstorage-cache": "1.1.1",
     "i18next-sprintf-postprocessor": "0.2.2",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Following #1651, this PR contains only the update of `i18next-localstorage-cache` and `i18next-browser-languagedetector`

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] ~~tests are included~~

#### Checklist (for documentation change)

- [ ] ~~only relevant documentation part is changed (make a diff before you submit the PR)~~
- [x] motivation/reason is provided