### PR TITLE
Bind i18n.t

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,10 @@
 //const istanbul = require( 'browserify-istanbul' );
 
 module.exports = function (karma) {
+  // Ensure consistent conversion of timestamps to date strings (has no effect
+  // on Windows)
+  process.env.TZ = 'UTC';
+
   karma.set({
     frameworks: ['mocha', 'chai', 'sinon', 'browserify'],
 

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -25,6 +25,9 @@ class I18n extends EventEmitter {
     this.logger = baseLogger;
     this.modules = { external: [] };
 
+    // Allow using t via destructuring or callback
+    this.t = this.t.bind(this);
+
     if (callback && !this.isInitialized && !options.isClone) {
       // https://github.com/i18next/i18next/issues/879
       if (!this.options.initImmediate) {

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -13,6 +13,17 @@ import { defer, isIE10 } from './utils.js';
 
 function noop() { }
 
+// Binds the member functions of the given class instance so that they can be
+// destructured or used as callbacks.
+function bindMemberFunctions(inst) {
+  const mems = Object.getOwnPropertyNames(Object.getPrototypeOf(inst))
+  mems.forEach((mem) => {
+    if (typeof inst[mem] === 'function') {
+      inst[mem] = inst[mem].bind(inst)
+    }
+  })
+}
+
 class I18n extends EventEmitter {
   constructor(options = {}, callback) {
     super();
@@ -25,8 +36,7 @@ class I18n extends EventEmitter {
     this.logger = baseLogger;
     this.modules = { external: [] };
 
-    // Allow using t via destructuring or callback
-    this.t = this.t.bind(this);
+    bindMemberFunctions(this);
 
     if (callback && !this.isInitialized && !options.isClone) {
       // https://github.com/i18next/i18next/issues/879

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -17,7 +17,7 @@ describe('i18next', () => {
         newInstance = i18next.createInstance({ bar: 'foo' });
       });
 
-      it('it should not inherit options from inital i18next', () => {
+      it('it should not inherit options from initial i18next', () => {
         expect(newInstance.options.foo).to.not.be.ok;
         expect(newInstance.options.bar).to.equal('foo');
       });
@@ -33,7 +33,7 @@ describe('i18next', () => {
         newInstance = i18next.cloneInstance({ bar: 'foo' });
       });
 
-      it('it should inherit options from inital i18next', () => {
+      it('it should inherit options from initial i18next', () => {
         expect(newInstance.options.foo).to.equal('bar');
         expect(newInstance.options.bar).to.equal('foo');
       });
@@ -99,7 +99,7 @@ describe('i18next', () => {
 
   describe('chained resource manipulation', () => {
     describe('can add resources', () => {
-      it('it adds resouces by addResource', () => {
+      it('it adds resources by addResource', () => {
         i18next
           .addResource('de', 'translation', 'test', 'test')
           .addResource('de', 'translation', 'nest.test', 'test_nest');
@@ -107,7 +107,7 @@ describe('i18next', () => {
         expect(i18next.getResource('de', 'translation', 'nest.test')).to.equal('test_nest');
       });
 
-      it('it adds resouces by addResources', () => {
+      it('it adds resources by addResources', () => {
         i18next
           .addResources('fr', 'translation', {
             hi: 'salut',
@@ -120,7 +120,7 @@ describe('i18next', () => {
         expect(i18next.getResource('fr', 'translation', 'hello')).to.equal('bonjour');
       });
 
-      it('it adds resouces by addResourceBundle', () => {
+      it('it adds resources by addResourceBundle', () => {
         i18next
           .addResourceBundle('en.translation', { something1: 'deeper1' })
           .addResourceBundle('en.translation', { something2: 'deeper2' });
@@ -131,7 +131,7 @@ describe('i18next', () => {
       });
 
       describe('can remove resources bundle', () => {
-        it('it removes resouces by removeResourceBundle', () => {
+        it('it removes resources by removeResourceBundle', () => {
           i18next.removeResourceBundle('en', 'translation');
           expect(i18next.getResourceBundle('en', 'translation')).to.be.not.ok;
         });

--- a/test/i18next.spec.js
+++ b/test/i18next.spec.js
@@ -75,6 +75,13 @@ describe('i18next', () => {
   });
 
   describe('i18next - functions', () => {
+    describe('t', () => {
+      it('is usable as a free function', () => {
+        const { t } = i18next;
+        expect(t('key')).to.equal('key');
+      });
+    });
+
     describe('getFixedT', () => {
       it('it should have lng, ns on t', () => {
         const t = i18next.getFixedT('de', 'common');


### PR DESCRIPTION
I recently ran into #1287, and based on comments there, I saw that I'm not the only one. (In my case, I was trying to write a lower-level function that could take a `t` function either from `useTranslation` or from a I18n instance.) Since this does seem to be a somewhat common error, and since destructuring `t` or trying to use it as a callback can be useful, I believe it would make sense to bind the `t` function within the I18n constructor (similar to how React class components can bind their callbacks) so that `this` is always defined, regardless of how the `t` function is used.

While working on this PR, I fixed some typos, and I noticed that tests were failing, so I set a fixed timezone to help address that. (I can split these changes into separate PRs if you prefer.)

Thank you.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
