### PR TITLE
fix-1703

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -237,13 +237,15 @@ class Translator extends EventEmitter {
           lngs.push(options.lng || this.language);
         }
 
-        const send = (l, k, fallbackValue) => {
+        const send = (l, k, specificDefaultValue) => {
+          const defaultForMissing =
+            hasDefaultValue && specificDefaultValue !== res ? specificDefaultValue : resForMissing;
           if (this.options.missingKeyHandler) {
             this.options.missingKeyHandler(
               l,
               namespace,
               k,
-              updateMissing ? fallbackValue : resForMissing,
+              defaultForMissing,
               updateMissing,
               options,
             );
@@ -252,7 +254,7 @@ class Translator extends EventEmitter {
               l,
               namespace,
               k,
-              updateMissing ? fallbackValue : resForMissing,
+              defaultForMissing,
               updateMissing,
               options,
             );

--- a/test/translator/translator.translate.missing.spec.js
+++ b/test/translator/translator.translate.missing.spec.js
@@ -115,7 +115,7 @@ describe('Translator', () => {
       t.translate('translation:test.missing', {
         count: 0,
         defaultValue_zero: 'default0',
-        defaultValue_one: 'default1', // ignored
+        defaultValue_one: 'default1',
       });
     });
 
@@ -123,7 +123,7 @@ describe('Translator', () => {
       expect(missingKeyHandler.callCount).to.eql(NB_PLURALS_ARABIC);
       expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_zero', 'default0'))
         .to.be.true;
-      expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_one', 'default0')).to
+      expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_one', 'default1')).to
         .be.true;
       expect(missingKeyHandler.calledWith(['ar'], 'translation', 'test.missing_two', 'default0')).to
         .be.true;


### PR DESCRIPTION
Fixed `Translator` to supply correct defaults for plural forms (if supplied) to `saveMissing`. (Fixes https://github.com/i18next/i18next/issues/1703 .)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included (or rather the existing test is modified)