### PR TITLE
Add _zero suffix lookup if count === 0

### DIFF
--- a/test/translator/translator.translate.combination.spec.js
+++ b/test/translator/translator.translate.combination.spec.js
@@ -30,6 +30,15 @@ describe('Translator', () => {
               { a: 'b', c: 'd' },
               { a: 'b', c: 'd' },
             ],
+
+            friends:
+              '$t(friend, {"context": "male", "count": {{maleCount}} }) & $t(friend, {"context": "female", "count": {{femaleCount}} })',
+            friend_male_zero: 'No boyfriend',
+            friend_male_one: 'A boyfriend',
+            friend_male_other: '{{count}} boyfriends',
+            friend_female_zero: 'no girlfriend',
+            friend_female_one: 'a girlfriend',
+            friend_female_other: '{{count}} girlfriends',
           },
         },
       });
@@ -75,6 +84,26 @@ describe('Translator', () => {
             { a: 'b', c: 'd' },
           ],
         },
+      },
+      {
+        args: ['friends', { maleCount: 0, femaleCount: 0 }],
+        expected: 'No boyfriend & no girlfriend',
+      },
+      {
+        args: ['friends', { maleCount: 0, femaleCount: 5 }],
+        expected: 'No boyfriend & 5 girlfriends',
+      },
+      {
+        args: ['friends', { maleCount: 5, femaleCount: 0 }],
+        expected: '5 boyfriends & no girlfriend',
+      },
+      {
+        args: ['friends', { maleCount: 1, femaleCount: 2 }],
+        expected: 'A boyfriend & 2 girlfriends',
+      },
+      {
+        args: ['friends', { maleCount: 2, femaleCount: 1 }],
+        expected: '2 boyfriends & a girlfriend',
       },
 
       // interpolation and nesting on defaultValue

--- a/test/translator/translator.translate.plural.spec.js
+++ b/test/translator/translator.translate.plural.spec.js
@@ -15,6 +15,11 @@ describe('Translator', () => {
             test_one: 'test_en',
             test_other: 'tests_en',
           },
+          translationWithZero: {
+            test_zero: 'test_zero',
+            test_one: 'test_en',
+            test_other: 'tests_en',
+          },
         },
         de: {
           translation: {
@@ -69,6 +74,8 @@ describe('Translator', () => {
     var tests = [
       { args: ['translation:test', { count: 1 }], expected: 'test_en' },
       { args: ['translation:test', { count: 2 }], expected: 'tests_en' },
+      { args: ['translation:test', { count: 0 }], expected: 'tests_en' },
+      { args: ['translationWithZero:test', { count: 0 }], expected: 'test_zero' },
       { args: ['translation:test', { count: 1, lngs: ['en-US', 'en'] }], expected: 'test_en' },
       { args: ['translation:test', { count: 2, lngs: ['en-US', 'en'] }], expected: 'tests_en' },
       { args: ['translation:test', { count: 1, lngs: ['de'] }], expected: 'test_de' },


### PR DESCRIPTION
Localizing in a specific way 0 count is a very common case.
There was a related [issue](https://github.com/i18next/i18next/issues/1220).
Also unicode documentation says: _"implementations are encouraged to provide the ability to have special plural messages for 0 in particular, so that more natural language can be used"_ https://cldr.unicode.org/index/cldr-spec/plural-rules

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided