### PR TITLE
Fix ResourceStore Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -737,12 +737,23 @@ export class ResourceStore {
   /**
    * Gets fired when resources got added or removed
    */
-  on(event: 'added' | 'removed', callback: (lng: string, ns: string) => void): void;
+  on(event: 'added' | 'removed', callback: (lng: string, ns: string, resources: any) => void): void;
+  on(
+    event: 'added' | 'removed',
+    callback: (lng: string, ns: string, key: string, value: string) => void,
+  ): void;
   /**
    * Remove event listener
    * removes all callback when callback not specified
    */
-  off(event: 'added' | 'removed', callback?: (lng: string, ns: string) => void): void;
+  off(
+    event: 'added' | 'removed',
+    callback?: (lng: string, ns: string, resources: any) => void,
+  ): void;
+  off(
+    event: 'added' | 'removed',
+    callback?: (lng: string, ns: string, key: string, value: string) => void,
+  ): void;
 }
 
 export interface Formatter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -735,25 +735,26 @@ export class ResourceStore {
   public options: InitOptions;
 
   /**
-   * Gets fired when resources got added or removed
+   * Gets fired when resources got added
    */
-  on(event: 'added' | 'removed', callback: (lng: string, ns: string, resources: any) => void): void;
-  on(
-    event: 'added' | 'removed',
-    callback: (lng: string, ns: string, key: string, value: string) => void,
-  ): void;
+  on(event: 'added', callback: (lng: string, ns: string, resources: any) => void): void;
+  on(event: 'added', callback: (lng: string, ns: string, key: string, value: string) => void): void;
+
+  /**
+   * Gets fired when resources got removed
+   */
+  on(event: 'removed', callback: (lng: string, ns: string) => void): void;
+
   /**
    * Remove event listener
    * removes all callback when callback not specified
    */
+  off(event: 'added', callback?: (lng: string, ns: string, resources: any) => void): void;
   off(
-    event: 'added' | 'removed',
-    callback?: (lng: string, ns: string, resources: any) => void,
-  ): void;
-  off(
-    event: 'added' | 'removed',
+    event: 'added',
     callback?: (lng: string, ns: string, key: string, value: string) => void,
   ): void;
+  off(event: 'removed', callback?: (lng: string, ns: string, resources: any) => void): void;
 }
 
 export interface Formatter {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!--

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included

-->

Fixed `ResourceStore.on` & `ResourceStore.off` typings. Currently I have to use `@ts-ignore` for `added` events, since its type description wasn't complete.

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided