### PR TITLE
fix: defaultVariables were not accessible inside plugin `parse` function

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -300,7 +300,7 @@ class Translator extends EventEmitter {
     if (this.i18nFormat && this.i18nFormat.parse) {
       res = this.i18nFormat.parse(
         res,
-        options,
+        { ...this.options.interpolation.defaultVariables, ...options },
         resolved.usedLng,
         resolved.usedNS,
         resolved.usedKey,

--- a/test/i18next.extendTranslation.spec.js
+++ b/test/i18next.extendTranslation.spec.js
@@ -1,0 +1,70 @@
+import i18next from '../src/i18next.js';
+
+const instance = i18next.createInstance();
+
+describe('extendTranslation', () => {
+  describe('parse function should access globals defaultVariables', () => {
+    const tests = [
+      {
+        name: 'should have no impact when no options and no defaultVariables',
+        options: {},
+        defaultVariables: {},
+        expected: {},
+      },
+      {
+        name: 'should have no impact when no defaultVariables is given',
+        options: { foo: 'bar' },
+        defaultVariables: {},
+        expected: { foo: 'bar' },
+      },
+      {
+        name: 'should work when no options are provided',
+        options: {},
+        defaultVariables: { foo: 'baz' },
+        expected: { foo: 'baz' },
+      },
+      {
+        name: 'should be merged with provided options',
+        options: { foo: 'bar' },
+        defaultVariables: { foo2: 'baz' },
+        expected: { foo: 'bar', foo2: 'baz' },
+      },
+      {
+        name: 'should not override provided options',
+        options: { foo: 'bar' },
+        defaultVariables: { foo: 'baz' },
+        expected: { foo: 'bar' },
+      },
+    ];
+
+    tests.forEach((test, i) => {
+      it('it ' + test.name, () => {
+        instance
+          .use({
+            type: 'i18nFormat',
+            parse: (_res, options) => {
+              expect(options).to.deep.equals(test.expected);
+            },
+          })
+          .init(
+            {
+              lng: 'en',
+              interpolation: {
+                defaultVariables: test.defaultVariables,
+              },
+              resources: {
+                en: {
+                  translation: {
+                    test1: '',
+                  },
+                },
+              },
+            },
+            (err, t) => {
+              t('translation:test1', test.options);
+            },
+          );
+      });
+    });
+  });
+});


### PR DESCRIPTION
`i18next-icu` were unable to access [defaultVariables](https://www.i18next.com/translation-function/interpolation#all-interpolation-options) options.

When **not** using ICU: 
```typescript
import i18next from 'i18next';

async function main() {
  const t = await i18next
    .init({
    resources: {
      fr: {
        ns: {
          a: 'hello {{foo}}',
        },
      },
    },
    interpolation: {
      defaultVariables: {
        foo: 'BAR',
      },
    },
    lng: 'fr',
  });

  console.log(t('ns:a')); // ✅ print `hello BAR`
}

main();
```

When using ICU: 
```typescript
import i18next from 'i18next';
import ICU from 'i18next-icu';

async function main() {
  const t = await i18next
    .use(ICU)
    .init({
      interpolation: {
        defaultVariables: {
          foo: 'BAR',
        },
      },
      resources: {
        fr: {
          ns: {
            a: 'hello {foo}',
          },
        },
      },
      lng: 'fr',
    });

  console.log(t('ns:a')); // ❌ print hello {foo}
}

main();

```


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided