### PR TITLE
introduce returnResolved t option that pratically exposes the result of the resolve function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -690,10 +690,25 @@ export interface WithT {
  * Object returned from t() function when passed returnDetails: true option.
  */
 export type TFunctionDetailedResult<T = string> = {
+  /**
+   * The plain used key
+   */
   usedKey: string;
+  /**
+   * The translation result.
+   */
   res: T;
+  /**
+   * The key with context / plural
+   */
   exactUsedKey: string;
+  /**
+   * The used language for this translation.
+   */
   usedLng: string;
+  /**
+   * The used namespace for this translation.
+   */
   usedNS: string;
 };
 export type TFunctionResult =

--- a/index.d.ts
+++ b/index.d.ts
@@ -689,7 +689,7 @@ export interface WithT {
 /**
  * Object returned from t() function when passed returnDetails: true option.
  */
-export type TFunctionResolvedResult<T = string> = {
+export type TFunctionDetailedResult<T = string> = {
   usedKey: string;
   res: T;
   exactUsedKey: string;
@@ -699,7 +699,7 @@ export type TFunctionResolvedResult<T = string> = {
 export type TFunctionResult =
   | string
   | object
-  | TFunctionResolvedResult
+  | TFunctionDetailedResult
   | Array<string | object>
   | undefined
   | null;
@@ -714,7 +714,7 @@ export interface TFunction {
     key: TKeys | TKeys[],
   ): TResult;
   <
-    TResult extends TFunctionResult = TFunctionResolvedResult<object>,
+    TResult extends TFunctionResult = TFunctionDetailedResult<object>,
     TKeys extends TFunctionKeys = string,
     TInterpolationMap extends object = StringMap,
   >(
@@ -722,7 +722,7 @@ export interface TFunction {
     options?: TOptions<TInterpolationMap> & { returnDetails: true; returnObjects: true },
   ): TResult;
   <
-    TResult extends TFunctionResult = TFunctionResolvedResult,
+    TResult extends TFunctionResult = TFunctionDetailedResult,
     TKeys extends TFunctionKeys = string,
     TInterpolationMap extends object = StringMap,
   >(

--- a/index.d.ts
+++ b/index.d.ts
@@ -686,7 +686,23 @@ export interface WithT {
   t: TFunction;
 }
 
-export type TFunctionResult = string | object | Array<string | object> | undefined | null;
+/**
+ * Object returned from t() function when passed returnResolved: true option.
+ */
+export type TFunctionResolvedResult = {
+  usedKey: string;
+  res: TFunctionResult;
+  exactUsedKey: string;
+  usedLng: string;
+  usedNS: string;
+};
+export type TFunctionResult =
+  | string
+  | object
+  | TFunctionResolvedResult
+  | Array<string | object>
+  | undefined
+  | null;
 export type TFunctionKeys = string | TemplateStringsArray;
 export interface TFunction {
   // basic usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -655,7 +655,7 @@ export interface TOptionsBase {
   /**
    * Returning an object that includes information about the used language, namespace, key and value
    */
-  // returnResolved?: boolean;
+  returnResolved?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -689,9 +689,9 @@ export interface WithT {
 /**
  * Object returned from t() function when passed returnResolved: true option.
  */
-export type TFunctionResolvedResult = {
+export type TFunctionResolvedResult<T = string> = {
   usedKey: string;
-  res: TFunctionResult;
+  res: T;
   exactUsedKey: string;
   usedLng: string;
   usedNS: string;
@@ -712,6 +712,14 @@ export interface TFunction {
     TInterpolationMap extends object = StringMap,
   >(
     key: TKeys | TKeys[],
+  ): TResult;
+  <
+    TResult extends TFunctionResult = TFunctionResolvedResult<object>,
+    TKeys extends TFunctionKeys = string,
+    TInterpolationMap extends object = StringMap,
+  >(
+    key: TKeys | TKeys[],
+    options?: TOptions<TInterpolationMap> & { returnResolved: true; returnObjects: true },
   ): TResult;
   <
     TResult extends TFunctionResult = TFunctionResolvedResult,

--- a/index.d.ts
+++ b/index.d.ts
@@ -655,7 +655,7 @@ export interface TOptionsBase {
   /**
    * Returning an object that includes information about the used language, namespace, key and value
    */
-  returnResolved?: boolean;
+  returnDetails?: boolean;
 }
 
 /**
@@ -687,7 +687,7 @@ export interface WithT {
 }
 
 /**
- * Object returned from t() function when passed returnResolved: true option.
+ * Object returned from t() function when passed returnDetails: true option.
  */
 export type TFunctionResolvedResult<T = string> = {
   usedKey: string;
@@ -719,7 +719,7 @@ export interface TFunction {
     TInterpolationMap extends object = StringMap,
   >(
     key: TKeys | TKeys[],
-    options?: TOptions<TInterpolationMap> & { returnResolved: true; returnObjects: true },
+    options?: TOptions<TInterpolationMap> & { returnDetails: true; returnObjects: true },
   ): TResult;
   <
     TResult extends TFunctionResult = TFunctionResolvedResult,
@@ -727,7 +727,7 @@ export interface TFunction {
     TInterpolationMap extends object = StringMap,
   >(
     key: TKeys | TKeys[],
-    options?: TOptions<TInterpolationMap> & { returnResolved: true },
+    options?: TOptions<TInterpolationMap> & { returnDetails: true },
   ): TResult;
   <
     TResult extends TFunctionResult = object,

--- a/index.d.ts
+++ b/index.d.ts
@@ -652,6 +652,10 @@ export interface TOptionsBase {
    * Override interpolation options
    */
   interpolation?: InterpolationOptions;
+  /**
+   * Returning an object that includes information about the used language, namespace, key and value
+   */
+  returnResolved?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -655,7 +655,7 @@ export interface TOptionsBase {
   /**
    * Returning an object that includes information about the used language, namespace, key and value
    */
-  returnResolved?: boolean;
+  // returnResolved?: boolean;
 }
 
 /**
@@ -706,6 +706,21 @@ export type TFunctionResult =
 export type TFunctionKeys = string | TemplateStringsArray;
 export interface TFunction {
   // basic usage
+  <
+    TResult extends TFunctionResult = string,
+    TKeys extends TFunctionKeys = string,
+    TInterpolationMap extends object = StringMap,
+  >(
+    key: TKeys | TKeys[],
+  ): TResult;
+  <
+    TResult extends TFunctionResult = TFunctionResolvedResult,
+    TKeys extends TFunctionKeys = string,
+    TInterpolationMap extends object = StringMap,
+  >(
+    key: TKeys | TKeys[],
+    options?: TOptions<TInterpolationMap> & { returnResolved: true },
+  ): TResult;
   <
     TResult extends TFunctionResult = string,
     TKeys extends TFunctionKeys = string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -722,6 +722,14 @@ export interface TFunction {
     options?: TOptions<TInterpolationMap> & { returnResolved: true },
   ): TResult;
   <
+    TResult extends TFunctionResult = object,
+    TKeys extends TFunctionKeys = string,
+    TInterpolationMap extends object = StringMap,
+  >(
+    key: TKeys | TKeys[],
+    options?: TOptions<TInterpolationMap> & { returnObjects: true },
+  ): TResult;
+  <
     TResult extends TFunctionResult = string,
     TKeys extends TFunctionKeys = string,
     TInterpolationMap extends object = StringMap,

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -98,6 +98,9 @@ class Translator extends EventEmitter {
     if (keys === undefined || keys === null /* || keys === ''*/) return '';
     if (!Array.isArray(keys)) keys = [String(keys)];
 
+    const returnResolved =
+      options.returnResolved !== undefined ? options.returnResolved : this.options.returnResolved;
+
     // separators
     const keySeparator =
       options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
@@ -113,14 +116,14 @@ class Translator extends EventEmitter {
     if (lng && lng.toLowerCase() === 'cimode') {
       if (appendNamespaceToCIMode) {
         const nsSeparator = options.nsSeparator || this.options.nsSeparator;
-        if (options.returnResolved) {
+        if (returnResolved) {
           resolved.res = `${namespace}${nsSeparator}${key}`;
           return resolved;
         }
         return `${namespace}${nsSeparator}${key}`;
       }
 
-      if (options.returnResolved) {
+      if (returnResolved) {
         resolved.res = key;
         return resolved;
       }
@@ -156,7 +159,7 @@ class Translator extends EventEmitter {
         const r = this.options.returnedObjectHandler
           ? this.options.returnedObjectHandler(resUsedKey, res, { ...options, ns: namespaces })
           : `key '${key} (${this.language})' returned an object instead of string.`;
-        if (options.returnResolved) {
+        if (returnResolved) {
           resolved.res = r;
           return resolved;
         }
@@ -306,7 +309,7 @@ class Translator extends EventEmitter {
     }
 
     // return
-    if (options.returnResolved) {
+    if (returnResolved) {
       resolved.res = res;
       return resolved;
     }

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -114,10 +114,10 @@ class Translator extends EventEmitter {
       if (appendNamespaceToCIMode) {
         const nsSeparator = options.nsSeparator || this.options.nsSeparator;
         if (options.returnResolved) {
-          resolved.res = namespace + nsSeparator + key;
+          resolved.res = `${namespace}${nsSeparator}${key}`;
           return resolved;
         }
-        return namespace + nsSeparator + key;
+        return `${namespace}${nsSeparator}${key}`;
       }
 
       if (options.returnResolved) {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -98,8 +98,8 @@ class Translator extends EventEmitter {
     if (keys === undefined || keys === null /* || keys === ''*/) return '';
     if (!Array.isArray(keys)) keys = [String(keys)];
 
-    const returnResolved =
-      options.returnResolved !== undefined ? options.returnResolved : this.options.returnResolved;
+    const returnDetails =
+      options.returnDetails !== undefined ? options.returnDetails : this.options.returnDetails;
 
     // separators
     const keySeparator =
@@ -116,14 +116,14 @@ class Translator extends EventEmitter {
     if (lng && lng.toLowerCase() === 'cimode') {
       if (appendNamespaceToCIMode) {
         const nsSeparator = options.nsSeparator || this.options.nsSeparator;
-        if (returnResolved) {
+        if (returnDetails) {
           resolved.res = `${namespace}${nsSeparator}${key}`;
           return resolved;
         }
         return `${namespace}${nsSeparator}${key}`;
       }
 
-      if (returnResolved) {
+      if (returnDetails) {
         resolved.res = key;
         return resolved;
       }
@@ -159,7 +159,7 @@ class Translator extends EventEmitter {
         const r = this.options.returnedObjectHandler
           ? this.options.returnedObjectHandler(resUsedKey, res, { ...options, ns: namespaces })
           : `key '${key} (${this.language})' returned an object instead of string.`;
-        if (returnResolved) {
+        if (returnDetails) {
           resolved.res = r;
           return resolved;
         }
@@ -309,7 +309,7 @@ class Translator extends EventEmitter {
     }
 
     // return
-    if (returnResolved) {
+    if (returnDetails) {
       resolved.res = res;
       return resolved;
     }

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -113,9 +113,17 @@ class Translator extends EventEmitter {
     if (lng && lng.toLowerCase() === 'cimode') {
       if (appendNamespaceToCIMode) {
         const nsSeparator = options.nsSeparator || this.options.nsSeparator;
+        if (options.returnResolved) {
+          resolved.res = namespace + nsSeparator + key;
+          return resolved;
+        }
         return namespace + nsSeparator + key;
       }
 
+      if (options.returnResolved) {
+        resolved.res = key;
+        return resolved;
+      }
       return key;
     }
 
@@ -145,9 +153,14 @@ class Translator extends EventEmitter {
         if (!this.options.returnedObjectHandler) {
           this.logger.warn('accessing an object - but returnObjects options is not enabled!');
         }
-        return this.options.returnedObjectHandler
+        const r = this.options.returnedObjectHandler
           ? this.options.returnedObjectHandler(resUsedKey, res, { ...options, ns: namespaces })
           : `key '${key} (${this.language})' returned an object instead of string.`;
+        if (options.returnResolved) {
+          resolved.res = r;
+          return resolved;
+        }
+        return r;
       }
 
       // if we got a separator we loop over children - else we just return object as is
@@ -293,6 +306,10 @@ class Translator extends EventEmitter {
     }
 
     // return
+    if (options.returnResolved) {
+      resolved.res = res;
+      return resolved;
+    }
     return res;
   }
 

--- a/test/translator/translator.translate.spec.js
+++ b/test/translator/translator.translate.spec.js
@@ -63,10 +63,10 @@ describe('Translator', () => {
       });
     });
 
-    describe('with returnResolved option', () => {
+    describe('with returnDetails option', () => {
       var tests = [
         {
-          args: ['translation:test', { returnResolved: true }],
+          args: ['translation:test', { returnDetails: true }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -76,7 +76,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['test', { returnResolved: true }],
+          args: ['test', { returnDetails: true }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -86,7 +86,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation:test', { returnResolved: true, lngs: ['en-US', 'en'] }],
+          args: ['translation:test', { returnDetails: true, lngs: ['en-US', 'en'] }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -96,7 +96,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation:test', { returnResolved: true, lngs: ['de'] }],
+          args: ['translation:test', { returnDetails: true, lngs: ['de'] }],
           expected: {
             usedKey: 'test',
             res: 'test_de',
@@ -106,7 +106,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation:test', { returnResolved: true, lng: 'de' }],
+          args: ['translation:test', { returnDetails: true, lng: 'de' }],
           expected: {
             usedKey: 'test',
             res: 'test_de',
@@ -116,7 +116,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation:test', { returnResolved: true, lng: 'fr' }],
+          args: ['translation:test', { returnDetails: true, lng: 'fr' }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -126,7 +126,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation:test', { returnResolved: true, lng: 'en-US' }],
+          args: ['translation:test', { returnDetails: true, lng: 'en-US' }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -136,7 +136,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          args: ['translation.test', { returnDetails: true, lng: 'en-US', nsSeparator: '.' }],
           expected: {
             usedKey: 'test',
             res: 'test_en',
@@ -146,7 +146,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['translation.deep.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          args: ['translation.deep.test', { returnDetails: true, lng: 'en-US', nsSeparator: '.' }],
           expected: {
             usedKey: 'deep.test',
             res: 'deep_en',
@@ -156,7 +156,7 @@ describe('Translator', () => {
           },
         },
         {
-          args: ['deep.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          args: ['deep.test', { returnDetails: true, lng: 'en-US', nsSeparator: '.' }],
           expected: {
             usedKey: 'deep.test',
             res: 'deep_en',

--- a/test/translator/translator.translate.spec.js
+++ b/test/translator/translator.translate.spec.js
@@ -62,5 +62,116 @@ describe('Translator', () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });
+
+    describe('with returnResolved option', () => {
+      var tests = [
+        {
+          args: ['translation:test', { returnResolved: true }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['test', { returnResolved: true }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation:test', { returnResolved: true, lngs: ['en-US', 'en'] }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation:test', { returnResolved: true, lngs: ['de'] }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_de',
+            exactUsedKey: 'test',
+            usedLng: 'de',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation:test', { returnResolved: true, lng: 'de' }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_de',
+            exactUsedKey: 'test',
+            usedLng: 'de',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation:test', { returnResolved: true, lng: 'fr' }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation:test', { returnResolved: true, lng: 'en-US' }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['translation.deep.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          expected: {
+            usedKey: 'deep.test',
+            res: 'deep_en',
+            exactUsedKey: 'deep.test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+        {
+          args: ['deep.test', { returnResolved: true, lng: 'en-US', nsSeparator: '.' }],
+          expected: {
+            usedKey: 'deep.test',
+            res: 'deep_en',
+            exactUsedKey: 'deep.test',
+            usedLng: 'en',
+            usedNS: 'translation',
+          },
+        },
+      ];
+
+      tests.forEach((test) => {
+        it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+          expect(t.translate.apply(t, test.args)).to.eql(test.expected);
+        });
+      });
+    });
   });
 });

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -1,4 +1,4 @@
-import i18next, { TFunction, TFunctionResolvedResult } from 'i18next';
+import i18next, { TFunction } from 'i18next';
 
 function basicUsage(t: TFunction) {
   t('friend');
@@ -132,7 +132,7 @@ function interpolation(t: TFunction) {
   t('arrayJoin', { joinArrays: '+' });
   // -> "line1+line2+line3"
 
-  const resolved = t('key', { returnResolved: true });
+  const resolved = t('key', { returnDetails: true });
   resolved.res;
   resolved.res.substring(2, 1);
   resolved.usedKey;
@@ -140,7 +140,7 @@ function interpolation(t: TFunction) {
   resolved.usedNS;
   resolved.usedLng;
 
-  const r2 = t('keyTwo', { returnResolved: false });
+  const r2 = t('keyTwo', { returnDetails: false });
   r2.substring(0, 2); // make sure it is a string
   const r3 = t('keyThree');
   r3.substring(0, 2); // make sure it is a string

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -134,6 +134,7 @@ function interpolation(t: TFunction) {
 
   const resolved = t('key', { returnResolved: true });
   resolved.res;
+  resolved.res.substring(2, 1);
   resolved.usedKey;
   resolved.exactUsedKey;
   resolved.usedNS;

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -1,4 +1,4 @@
-import i18next, { TFunction } from 'i18next';
+import i18next, { TFunction, TFunctionResolvedResult } from 'i18next';
 
 function basicUsage(t: TFunction) {
   t('friend');
@@ -131,6 +131,18 @@ function interpolation(t: TFunction) {
   // -> ['a', 'b', 'c']
   t('arrayJoin', { joinArrays: '+' });
   // -> "line1+line2+line3"
+
+  const resolved = t<TFunctionResolvedResult>('key', { returnResolved: true });
+  resolved.res;
+  resolved.usedKey;
+  resolved.exactUsedKey;
+  resolved.usedNS;
+  resolved.usedLng;
+
+  const r2 = t('keyTwo', { returnResolved: false });
+  r2.substring(0, 2); // make sure it is a string
+  const r3 = t('keyThree');
+  r3.substring(0, 2); // make sure it is a string
 
   t('arrayJoinWithInterpolation', {
     myVar: 'interpolate',

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -132,7 +132,7 @@ function interpolation(t: TFunction) {
   t('arrayJoin', { joinArrays: '+' });
   // -> "line1+line2+line3"
 
-  const resolved = t<TFunctionResolvedResult>('key', { returnResolved: true });
+  const resolved = t('key', { returnResolved: true });
   resolved.res;
   resolved.usedKey;
   resolved.exactUsedKey;
@@ -143,6 +143,8 @@ function interpolation(t: TFunction) {
   r2.substring(0, 2); // make sure it is a string
   const r3 = t('keyThree');
   r3.substring(0, 2); // make sure it is a string
+  const r4 = t('keyTwo', { ns: 'whatever' });
+  r4.substring(0, 2); // make sure it is a string
 
   t('arrayJoinWithInterpolation', {
     myVar: 'interpolate',


### PR DESCRIPTION
usage: 

```js
i18next.t('key', { returnResolved: true })
// returns {
//   usedKey: 'key',
//   res: 'translation value,
//   exactUsedKey: 'key',
//   usedLng: 'en',
//   usedNS: 'translation',
// }
```

While this PR technically works to help in use cases like #1763 I'm not sure if we should offer this kind of interface...

Normally the lang HTML attribute is set to the [i18next.resolvedLanguage](https://www.i18next.com/overview/api#resolvedlanguage) value.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included

