### PR TITLE
fix: getDataByLanguage type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1033,7 +1033,7 @@ export interface i18n {
   /**
    * Returns a resource data by language.
    */
-  getDataByLanguage(lng: string): { translation: { [key: string]: string } } | undefined;
+  getDataByLanguage(lng: string): { [key: string]: { [key: string]: string } } | undefined;
 
   /**
    * Returns a t function that defaults to given language or namespace.

--- a/test/typescript/init.test.ts
+++ b/test/typescript/init.test.ts
@@ -213,6 +213,9 @@ const data = i18next.getDataByLanguage('de');
 // verify the data.translation field exists
 console.log(data ? data.translation.myKey : 'data does not exist');
 
+// verify the field for a specific namespace exists
+console.log(data ? data.common.myKey : 'data does not exist');
+
 // or fix the namespace to anotherNamespace
 const anotherNamespace = i18next.getFixedT(null, 'anotherNamespace');
 const x: string = anotherNamespace('anotherNamespaceKey'); // no need to prefix ns i18n.t('anotherNamespace:anotherNamespaceKey');


### PR DESCRIPTION
Fix an issue where the value and type could be different when getting Data with getDataByLanguage.

If namespace is customized, key may be other than `translation`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)