### PR TITLE
More `BackendConnector.load` failure tests

### DIFF
--- a/test/backend/backendConnector.load.retry.spec.js
+++ b/test/backend/backendConnector.load.retry.spec.js
@@ -60,7 +60,7 @@ describe('BackendConnector load all fail - 1 namespace', () => {
   });
 });
 
-describe.only('BackendConnector load all fail - 10 namespaces', () => {
+describe('BackendConnector load all fail - 10 namespaces', () => {
   let connector;
 
   before(() => {

--- a/test/backend/backendConnector.load.retry.spec.js
+++ b/test/backend/backendConnector.load.retry.spec.js
@@ -33,7 +33,7 @@ describe('BackendConnector load retry', () => {
   });
 });
 
-describe('BackendConnector load all fail', () => {
+describe('BackendConnector load all fail - 1 namespace', () => {
   let connector;
 
   before(() => {
@@ -56,6 +56,48 @@ describe('BackendConnector load all fail', () => {
         expect(connector.store.getResourceBundle('en', 'fail')).to.eql({});
         done();
       });
+    }).timeout(12000);
+  });
+});
+
+describe.only('BackendConnector load all fail - 10 namespaces', () => {
+  let connector;
+
+  before(() => {
+    connector = new BackendConnector(
+      new BackendMock(),
+      new ResourceStore(),
+      {
+        interpolator: new Interpolator(),
+      },
+      {
+        backend: { loadPath: 'http://localhost:9876/locales/{{lng}}/{{ns}}.json' },
+      },
+    );
+  });
+
+  describe('#load', () => {
+    it('should call callback on complete failure - taking no longer than 1 namespace', (done) => {
+      connector.load(
+        ['en'],
+        ['fail1', 'fail2', 'fail3', 'fail4', 'fail5', 'fail6', 'fail7', 'fail8', 'fail9', 'fail10'],
+        function (err) {
+          expect(err).to.eql([
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+            'failed loading',
+          ]);
+          expect(connector.store.getResourceBundle('en', 'fail1')).to.eql({});
+          done();
+        },
+      );
     }).timeout(12000);
   });
 });


### PR DESCRIPTION
- Confirm that the callback is called even when some namespaces fail completely
- While writing these tests it became very clear that there is an inability to set the retry delay etc of `read` when using `BackendConnector.load`, as noted in #1809
- All of these tests pass with the code as-is :+1:

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)