### PR TITLE
FallbackLng function argument should also return false

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export type FallbackLng =
   | string
   | readonly string[]
   | FallbackLngObjList
-  | ((code: string) => string | readonly string[] | FallbackLngObjList);
+  | ((code: string) => string | readonly string[] | FallbackLngObjList | false);
 
 export type FormatFunction = (
   value: any,


### PR DESCRIPTION
This PR fixes a minor type issue where the fallbackLng property from `InitOptions` accepts the following types:

``` 
false | string | readonly string[] | FallbackLngObjList
````

The fallbackLng property also accepts a function that returns a value of type:

```
(code: string) => string | readonly string[] | FallbackLngObjList
```

I'm doing some work in my dev environment where I want to disable the fallbackLng based on some condition ie. I want to extend the function return type to allow us to return `false`.

```
(code: string) => string | readonly string[] | FallbackLngObjList | false
```

This will fix what I think is an inconsistency with the fallbackLng type in InitOptions.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)