### PR TITLE
Add formatter cache

### DIFF
--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -39,27 +39,45 @@ function parseFormatStr(formatStr) {
   };
 }
 
+function createCachedFormatter(fn) {
+  const cache = Object.create(null);
+  return function (val, lng, options) {
+    const key = lng + JSON.stringify(options);
+    let formatter = cache[key];
+    if (!formatter) {
+      formatter = fn(lng, options);
+      cache[key] = formatter;
+    }
+    return formatter(val);
+  };
+}
+
 class Formatter {
   constructor(options = {}) {
     this.logger = baseLogger.create('formatter');
 
     this.options = options;
     this.formats = {
-      number: (val, lng, options) => {
-        return new Intl.NumberFormat(lng, options).format(val);
-      },
-      currency: (val, lng, options) => {
-        return new Intl.NumberFormat(lng, { ...options, style: 'currency' }).format(val);
-      },
-      datetime: (val, lng, options) => {
-        return new Intl.DateTimeFormat(lng, { ...options }).format(val);
-      },
-      relativetime: (val, lng, options) => {
-        return new Intl.RelativeTimeFormat(lng, { ...options }).format(val, options.range || 'day');
-      },
-      list: (val, lng, options) => {
-        return new Intl.ListFormat(lng, { ...options }).format(val);
-      },
+      number: createCachedFormatter((lng, options) => {
+        const formatter = new Intl.NumberFormat(lng, options);
+        return (val) => formatter.format(val);
+      }),
+      currency: createCachedFormatter((lng, options) => {
+        const formatter = new Intl.NumberFormat(lng, { ...options, style: 'currency' });
+        return (val) => formatter.format(val);
+      }),
+      datetime: createCachedFormatter((lng, options) => {
+        const formatter = new Intl.DateTimeFormat(lng, { ...options });
+        return (val) => formatter.format(val);
+      }),
+      relativetime: createCachedFormatter((lng, options) => {
+        const formatter = new Intl.RelativeTimeFormat(lng, { ...options });
+        return (val) => formatter.format(val, options.range || 'day');
+      }),
+      list: createCachedFormatter((lng, options) => {
+        const formatter = new Intl.ListFormat(lng, { ...options });
+        return (val) => formatter.format(val);
+      }),
     };
     this.init(options);
   }

--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -41,7 +41,7 @@ function parseFormatStr(formatStr) {
 
 function createCachedFormatter(fn) {
   const cache = Object.create(null);
-  return function (val, lng, options) {
+  return function invokeFormatter(val, lng, options) {
     const key = lng + JSON.stringify(options);
     let formatter = cache[key];
     if (!formatter) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
This PR resolves #1841. 

Few considerations:
- maybe we should export `createCachedFormatter` as a utility function so that others may reuse it when creating custom formatters?
- I had no idea how to test that functionality apart from somehow stubbing Intl constructors and verifying that they are not called multiple times - I can try to add this test if you would like to have it
- as cache keys are always strings I decided to use object as caching structure instead of Map (which might cause compatibility issues in older browsers)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)