### PR TITLE
Change `DefaultTFuncReturn` to return `null` if `returnNull` typeOption is true

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -860,7 +860,7 @@ type NormalizeMultiReturn<T, V> = V extends `${infer N}:${infer R}`
     : never
   : never;
 
-export type DefaultTFuncReturn = string | undefined | null;
+export type DefaultTFuncReturn = string | (TypeOptions['returnNull'] extends true ? null : never);
 
 export type DefaultTFuncReturnWithObject = DefaultTFuncReturn | object | Array<string | object>;
 

--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -3,6 +3,7 @@ import 'i18next';
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
+    returnNull: false;
     resources: {
       custom: {
         foo: 'foo';

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -48,6 +48,7 @@ function i18nextTPluralsUsage() {
 
 // @ts-expect-error
 function returnNullWithFalseValue(t: TFunction<string>) {
+  function fn(value: null) {}
   // @ts-expect-error
-  const foo: null = t('foo') as null;
+  fn(t('foo'));
 }

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -45,3 +45,9 @@ function i18nextTPluralsUsage() {
   i18next.t('plurals:foo', { count: 1 });
   i18next.t('plurals:foo_many', { count: 10 });
 }
+
+// @ts-expect-error
+function returnNullWithFalseValue(t: TFunction<string>) {
+  // @ts-expect-error
+  const foo: null = t('foo') as null;
+}

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -43,13 +43,6 @@ function callsMethodWithOptionalNullArg(t: TFunction) {
   displayHint(t('friend'));
 }
 
-function callsMethodWithOptionalArg(t: TFunction) {
-  function displayHint(hint?: string) {
-    return String(hint);
-  }
-  displayHint(t('friend'));
-}
-
 function callsMethodWithRequiredNullArg(t: TFunction) {
   function displayHint(hint: string | null) {
     return String(hint);


### PR DESCRIPTION
Closes https://github.com/i18next/react-i18next/issues/1559, https://github.com/i18next/react-i18next/issues/1576, https://github.com/i18next/react-i18next/issues/1574

Since `returnNull` option is `true` by default, `t` function can return `string` or `null`. By declaring the `resources` type, we can infer the exact return type, so this is only useful to people who can't declare the `resource` type .

This PR allows to change this ☝️  behaviour if to set the `returnNull` type to `false`.
```ts
// i18next.d.ts
import 'i18next';

declare module 'i18next' {
  interface CustomTypeOptions {
    returnNull: false;
  }
}
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)