### PR TITLE
Update global t function TypeScript type to support DefaultNamespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1130,7 +1130,7 @@ export interface ExistsFunction<
 
 export interface i18n {
   // Expose parameterized t in the i18next interface hierarchy
-  t: TFunction<FallbackOrNS<string>[]>;
+  t: TFunction<Namespace | DefaultNamespace>;
 
   /**
    * The default of the i18next module is an i18next instance ready to be initialized by calling init.


### PR DESCRIPTION
Update TypeScript type of `t` function when used directly from i18n module.

The behaviour of `t` is unchanged, this is simply a change to the types to reflect the underlying logic of `t` (accepting of either a namespace, or no namespace with a fallback to the default namespace).

Fixes #1855

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)