### PR TITLE
types: Rework TFunction and translation key suggestions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,13 @@
 // Helpers
 type MergeBy<T, K> = Omit<T, keyof K> & K;
-export type StringMap = { [key: string]: any };
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
-  ? I
-  : never;
-type LastOf<T> = UnionToIntersection<T extends any ? () => T : never> extends () => infer R
-  ? R
-  : never;
+export type StringMap = Record<string, any>;
+// like 'keyof T', but by using 'T extends' will be applied to each member of a union individually:
+// keyof ({a: 1} | {b: 2}) is never
+// DistributiveKeyOf<({a: 1} | {b: 2})> is "a" | "b"
+type DistributiveKeyOf<T> = T extends StringMap ? keyof T : never;
+type Unpack<A> = A extends ReadonlyArray<infer E> ? E : A;
+// a hackish way of not suggesting literal values in T; unfortunately allows versions of T with additional uppercase strings as a prefix
+type DisableSuggestion<T extends string> = `${Uppercase<string>}${T}`;
 
 /**
  * This interface can be augmented by users to add types to `i18next` default TypeOptions.
@@ -749,12 +750,12 @@ type Normalize2<T, K = keyof T> = K extends keyof T
   : never;
 type Normalize<T> = WithOrWithoutPlural<keyof T> | Normalize2<T>;
 
-// Normalize multiple namespaces
-type KeyWithNSSeparator<N, K, S extends string = TypeOptions['nsSeparator']> = `${N &
-  string}${S}${K & string}`;
-type NormalizeMulti<T, U extends keyof T, L = LastOf<U>> = L extends U
-  ? KeyWithNSSeparator<L, Normalize<T[L]>> | NormalizeMulti<T, Exclude<U, L>>
-  : never;
+// Normalize prefixed versions for all namespaces
+type KeyWithNSSeparator<
+  T = Resources,
+  N = keyof T,
+  S extends string = TypeOptions['nsSeparator'],
+> = N extends keyof T ? `${N & string}${S}${Normalize<T[N]> & string}` : never;
 
 // Normalize single namespace with key prefix
 type NormalizeWithKeyPrefix<
@@ -779,13 +780,16 @@ export type TFuncKey<
   N extends Namespace = DefaultNamespace,
   TKPrefix = undefined,
   T = Resources,
-> = N extends (keyof T)[] | Readonly<(keyof T)[]>
-  ? NormalizeMulti<T, N[number]>
-  : N extends keyof T
-  ? TKPrefix extends undefined
-    ? Normalize<T[N]>
-    : NormalizeWithKeyPrefix<T[N], TKPrefix>
-  : string;
+  FlatN = Unpack<N>,
+> = object extends T // 'resources' not set in CustomTypeOptions
+  ? string
+  : FlatN extends keyof T
+  ?
+      | (TKPrefix extends undefined
+          ? Normalize<T[FlatN]>
+          : NormalizeWithKeyPrefix<T[FlatN], TKPrefix>)
+      | DisableSuggestion<KeyWithNSSeparator<T>>
+  : never;
 
 export interface WithT<N extends Namespace = DefaultNamespace> {
   // Expose parameterized t in the i18next interface hierarchy
@@ -844,17 +848,17 @@ export type NormalizeReturn<
   T,
   V,
   S extends string | false = TypeOptions['keySeparator'],
-> = V extends keyof T
+> = V extends DistributiveKeyOf<T>
   ? NormalizeByTypeOptions<T[V]>
   : S extends false
   ? V
   : V extends `${infer K}${S}${infer R}`
-  ? K extends keyof T
+  ? K extends DistributiveKeyOf<T>
     ? NormalizeReturn<T[K], R>
     : never
   : StringIfPlural<keyof T>;
 
-type NormalizeMultiReturn<T, V> = V extends `${infer N}:${infer R}`
+type NormalizeNamespacedReturn<T, V> = V extends `${infer N}:${infer R}`
   ? N extends keyof T
     ? NormalizeReturn<T[N], R>
     : never
@@ -870,13 +874,14 @@ export type TFuncReturn<
   TDefaultResult,
   TKPrefix = undefined,
   T = Resources,
-> = N extends (keyof T)[]
-  ? NormalizeMultiReturn<T, TKeys>
-  : N extends keyof T
-  ? TKPrefix extends undefined
-    ? NormalizeReturn<T[N], TKeys>
-    : NormalizeReturn<T[N], KeysWithSeparator<TKPrefix, TKeys>>
-  : TDefaultResult;
+  FlatN = Unpack<N>,
+> =
+  | NormalizeNamespacedReturn<Resources, TKeys>
+  | (FlatN extends keyof T
+      ? TKPrefix extends undefined
+        ? NormalizeReturn<T[FlatN], TKeys>
+        : NormalizeReturn<T[FlatN], KeysWithSeparator<TKPrefix, TKeys>>
+      : TDefaultResult);
 
 export interface TFunction<
   N extends Namespace = DefaultNamespace,
@@ -972,11 +977,8 @@ export interface TFunction<
     TKeys extends TFuncKey<UsedNS, TKPrefix>,
     TDefaultResult extends DefaultTFuncReturn = string,
     TInterpolationMap extends object = StringMap,
-    PassedNS extends Namespace = N extends string ? N : N extends null ? DefaultNamespace : N,
     PassedOpt extends TOptions<TInterpolationMap> = TOptions<TInterpolationMap>,
-    UsedNS extends Namespace = Pick<PassedOpt, 'ns'> extends { ns: string }
-      ? PassedNS
-      : ActualNS | DefaultNamespace,
+    UsedNS extends ActualNS = PassedOpt extends { ns: any } ? never : ActualNS,
   >(
     key: TKeys | TKeys[],
     options: PassedOpt,

--- a/test/typescript/custom-types/getFixedT.test.ts
+++ b/test/typescript/custom-types/getFixedT.test.ts
@@ -1,20 +1,33 @@
 import i18next from 'i18next';
 
+declare function expect<A extends string>(
+  a: A,
+): [A] extends [never] ? { never: true } : { toBeString: true; toBe(expected: A): void };
+
+const tbaz = i18next.getFixedT(null, null, 'baz');
+tbaz('bing');
+// @ts-expect-error
+tbaz('inter');
+
 const t1 = i18next.getFixedT(null, null, 'foo');
+// @ts-expect-error
+t1('foo');
+// @ts-expect-error
+t1('bing');
 
 const t2 = i18next.getFixedT(null, 'alternate', 'foobar.deep');
-t2('deeper.deeeeeper');
+expect(t2('deeper.deeeeeper')).toBe('foobar');
 // t2('deeper').deeeeeper; // i18next would say: "key 'deeper (en)' returned an object instead of string."
 t2('deeper', { returnObjects: true }).deeeeeper;
 
 const t3 = i18next.getFixedT('en');
-t3('foo');
+expect(t3('foo')).toBeString;
 
-// t3('alternate:foobar.deep.deeper.deeeeeper');
-t3('foobar.deep.deeper.deeeeeper', { ns: 'alternate' });
+expect(t3('alternate:foobar.deep.deeper.deeeeeper')).toBe('foobar');
+expect(t3('foobar.deep.deeper.deeeeeper', { ns: 'alternate' })).toBe('foobar');
 
 const t4 = i18next.getFixedT('en', 'alternate', 'foobar');
-t4('barfoo');
+expect(t4('barfoo')).toBe('barfoo');
 
 // @ts-expect-error
 const t5 = i18next.getFixedT(null, null, 'xxx');
@@ -24,7 +37,51 @@ const t6 = i18next.getFixedT(null, 'alternate', 'foobar');
 t6('xxx');
 
 const t7 = i18next.getFixedT('en');
-t7('bar');
-t7('alternate:foobar.barfoo');
-t7('foobar.barfoo');
-t7('foobar.barfoo', { ns: 'alternate' });
+expect(t7('bar')).toBeString;
+expect(t7('alternate:foobar.barfoo')).toBe('barfoo');
+expect(t7('foobar.barfoo')).toBe('barfoo');
+expect(t7('foobar.barfoo', { ns: 'alternate' })).toBe('barfoo');
+expect(t7('inter', { ns: 'custom', val: 'thing' })).toBe('some {{val}}');
+// @ts-expect-error
+t7('foobar.barfoo', { ns: 'custom' });
+// @ts-expect-error
+t7('invalid:bar');
+
+const t8 = i18next.getFixedT('en', 'alternate');
+expect(t8('foobar.barfoo')).toBe('barfoo');
+// not the most useful call, but still allowed:
+expect(t8('alternate:foobar.barfoo')).toBe('barfoo');
+// other namespaces via key prefix:
+expect(t8('custom:foo')).toBe('foo');
+expect(
+  t8('foo', {
+    ns: 'custom',
+  }),
+).toBe('foo');
+// @ts-expect-error
+t8('custom:invalid');
+// @ts-expect-error
+t8('foo');
+// @ts-expect-error
+t8('invalid:baz');
+
+const t9 = i18next.getFixedT('en', ['alternate', 'custom']);
+expect(t9('foo')).toBe('foo');
+expect(t9('custom:foo')).toBe('foo');
+// keys from both namespaces should be allowed in TS:
+expect(t9('foobar.barfoo')).toBe('barfoo');
+expect(t9('alternate:foobar.barfoo')).toBe('barfoo');
+expect(t9('inter', { val: 'thing' })).toBe('some {{val}}');
+expect(t9('inter', { ns: 'custom', val: 'thing' })).toBe('some {{val}}');
+expect(t9('plurals:foo_zero')).toBe('foo');
+expect(
+  t9('foo_zero', {
+    ns: 'plurals',
+  }),
+).toBe('foo');
+// @ts-expect-error
+t9('plurals:invalid');
+// @ts-expect-error
+t9('foo_zero');
+// @ts-expect-error
+t9('invalid:baz');


### PR DESCRIPTION
Allow 'other-ns:some.key' syntax regardless of current namespace(s). However, we no longer provide these keys via TS autosuggestion, to not flood the suggestion box with these.
This uses the 'DisableSuggestion' helper type, which unfortunately allows any capital case prefix to the actual 'other-ns:' prefix.

For getFixedT with multiple namespaces, all the keys in these namespaces are now suggested without 'ns:' prefix. Using such a prefix is still possible, though.

Technically, we treat cases with a fixed single namespace and multiple namespaces the same in `TFuncKey` by flattening an array of namespaces into a union of namespace strings. Using this we can use distributive conditional types to handle each namespace individually. See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types

For `NormalizeReturn` we use a new `DistributiveKeyOf<T>` helper. This finds keys that are available in only one/some of the namespaces, whereas 'keyof T' would only find them if they were in all of the namespaces.

We simplify and rework the "with options" overload of TFunction. This no longer allows passing the namespace. That use case is already covered by other overloads before that. This overload was the reason for erroneously suggesting unprefixed keys for not currently active namespaces.

The probably helps with #1887, too.
fixes #1889

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
