### PR TITLE
prefixed ordinal keys

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@ rules:
   no-continue: 0
   no-constructor-return: 0
   consistent-return: 0
+  no-nested-ternary: 0
   react/prop-types:
     - 0
     - ignore: #coming from hoc
@@ -35,5 +36,7 @@ globals:
   describe: true
   it: true
   before: true
+  beforeEach: true
   after: true
   window: true
+  sinon: true

--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -64,7 +64,8 @@ let _rulesPluralsTypes = {
 };
 /* eslint-enable */
 
-const deprecatedJsonVersions = ['v1', 'v2', 'v3'];
+const nonIntlVersions = ['v1', 'v2', 'v3'];
+const intlVersions = ['v4'];
 const suffixesOrder = {
   zero: 0,
   one: 1,
@@ -94,7 +95,7 @@ class PluralResolver {
 
     this.logger = baseLogger.create('pluralResolver');
 
-    if ((!this.options.compatibilityJSON || this.options.compatibilityJSON === 'v4') && (typeof Intl === 'undefined' || !Intl.PluralRules)) {
+    if ((!this.options.compatibilityJSON || intlVersions.includes(this.options.compatibilityJSON)) && (typeof Intl === 'undefined' || !Intl.PluralRules)) {
       this.options.compatibilityJSON = 'v3';
       this.logger.error('Your environment seems not to be Intl API compatible, use an Intl.PluralRules polyfill. Will fallback to the compatibilityJSON v3 format handling.');
     }
@@ -142,7 +143,7 @@ class PluralResolver {
     if (this.shouldUseIntlApi()) {
       return rule.resolvedOptions().pluralCategories
         .sort((pluralCategory1, pluralCategory2) => suffixesOrder[pluralCategory1] - suffixesOrder[pluralCategory2])
-        .map(pluralCategory => `${this.options.prepend}${pluralCategory}`);
+        .map(pluralCategory => `${this.options.prepend}${options.ordinal ? `ordinal${this.options.prepend}` : ''}${pluralCategory}`);
     }
 
     return rule.numbers.map((number) => this.getSuffix(code, number, options));
@@ -153,7 +154,7 @@ class PluralResolver {
 
     if (rule) {
       if (this.shouldUseIntlApi()) {
-        return `${this.options.prepend}${rule.select(count)}`;
+        return `${this.options.prepend}${options.ordinal ? `ordinal${this.options.prepend}` : ''}${rule.select(count)}`;
       }
 
       return this.getSuffixRetroCompatible(rule, count);
@@ -196,7 +197,7 @@ class PluralResolver {
   }
 
   shouldUseIntlApi() {
-    return !deprecatedJsonVersions.includes(this.options.compatibilityJSON);
+    return !nonIntlVersions.includes(this.options.compatibilityJSON);
   }
 }
 

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -209,7 +209,14 @@ class Translator extends EventEmitter {
       const defaultValueSuffix = needsPluralHandling
         ? this.pluralResolver.getSuffix(lng, options.count, options)
         : '';
-      const defaultValue = options[`defaultValue${defaultValueSuffix}`] || options.defaultValue;
+      const defaultValueSuffixOrdinalFallback =
+        options.ordinal && needsPluralHandling
+          ? this.pluralResolver.getSuffix(lng, options.count, { ordinal: false })
+          : '';
+      const defaultValue =
+        options[`defaultValue${defaultValueSuffix}`] ||
+        options[`defaultValue${defaultValueSuffixOrdinalFallback}`] ||
+        options.defaultValue;
 
       // fallback value
       if (!this.isValidLookup(res) && hasDefaultValue) {
@@ -476,10 +483,15 @@ class Translator extends EventEmitter {
             if (needsPluralHandling)
               pluralSuffix = this.pluralResolver.getSuffix(code, options.count, options);
             const zeroSuffix = `${this.options.pluralSeparator}zero`;
-
+            const ordinalPrefix = `${this.options.pluralSeparator}ordinal${this.options.pluralSeparator}`;
             // get key for plural if needed
             if (needsPluralHandling) {
               finalKeys.push(key + pluralSuffix);
+              if (options.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+                finalKeys.push(
+                  key + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator),
+                );
+              }
               if (needsZeroSuffixLookup) {
                 finalKeys.push(key + zeroSuffix);
               }
@@ -493,6 +505,11 @@ class Translator extends EventEmitter {
               // get key for context + plural if needed
               if (needsPluralHandling) {
                 finalKeys.push(contextKey + pluralSuffix);
+                if (options.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+                  finalKeys.push(
+                    contextKey + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator),
+                  );
+                }
                 if (needsZeroSuffixLookup) {
                   finalKeys.push(contextKey + zeroSuffix);
                 }

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -174,6 +174,7 @@ describe('PluralResolver', () => {
       { compatibilityJSON: 'v2', expected: false },
       { compatibilityJSON: 'v3', expected: false },
       { compatibilityJSON: 'v4', expected: true },
+      { compatibilityJSON: 'v5', expected: true },
       { expected: true },
     ];
 

--- a/test/pluralResolver.spec.js
+++ b/test/pluralResolver.spec.js
@@ -174,7 +174,6 @@ describe('PluralResolver', () => {
       { compatibilityJSON: 'v2', expected: false },
       { compatibilityJSON: 'v3', expected: false },
       { compatibilityJSON: 'v4', expected: true },
-      { compatibilityJSON: 'v5', expected: true },
       { expected: true },
     ];
 

--- a/test/translator/translator.translate.missing.spec.js
+++ b/test/translator/translator.translate.missing.spec.js
@@ -86,7 +86,7 @@ describe('Translator', () => {
       { args: ['translation:test.missing', { count: 10 }], expected: NB_PLURALS_ARABIC },
       { args: ['translation:test.missing', { count: 0 }], expected: NB_PLURALS_ARABIC },
     ].forEach((test) => {
-      it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
+      it(`correctly sends missing for ${JSON.stringify(test.args)} args`, () => {
         t.translate.apply(t, test.args);
         expect(missingKeyHandler.callCount).to.eql(test.expected);
         expect(
@@ -159,13 +159,13 @@ describe('Translator', () => {
         expected: NB_PLURALS_ENGLISH_ORDINAL,
       },
     ].forEach((test) => {
-      it('correctly sends missing for ' + JSON.stringify(test.args) + ' args', () => {
+      it(`correctly sends missing for ${JSON.stringify(test.args)} args`, () => {
         t.translate.apply(t, test.args);
         expect(missingKeyHandler.callCount).to.eql(test.expected);
         expect(
           missingKeyHandler
             .getCall(0)
-            .calledWith(['en'], 'translation', 'test.missing_one', 'test.missing'),
+            .calledWith(['en'], 'translation', 'test.missing_ordinal_one', 'test.missing'),
         ).to.be.true;
       });
     });
@@ -190,20 +190,31 @@ describe('Translator', () => {
       t.translate('translation:test.missing', {
         count: 0,
         ordinal: true,
-        defaultValue_one: 'default1',
-        defaultValue_other: 'defaultOther',
+        defaultValue_ordinal_one: 'default1',
+        defaultValue_ordinal_other: 'defaultOther',
       });
     });
 
     it('correctly sends missing resolved value', () => {
       expect(missingKeyHandler.callCount).to.eql(NB_PLURALS_ENGLISH_ORDINAL);
       expect(
-        missingKeyHandler.calledWith(['en'], 'translation', 'test.missing_other', 'defaultOther'),
+        missingKeyHandler.calledWith(
+          ['en'],
+          'translation',
+          'test.missing_ordinal_other',
+          'defaultOther',
+        ),
       ).to.be.true;
-      expect(missingKeyHandler.calledWith(['en'], 'translation', 'test.missing_one', 'default1')).to
-        .be.true;
       expect(
-        missingKeyHandler.calledWith(['en'], 'translation', 'test.missing_two', 'defaultOther'),
+        missingKeyHandler.calledWith(['en'], 'translation', 'test.missing_ordinal_one', 'default1'),
+      ).to.be.true;
+      expect(
+        missingKeyHandler.calledWith(
+          ['en'],
+          'translation',
+          'test.missing_ordinal_two',
+          'defaultOther',
+        ),
       ).to.be.true;
     });
   });

--- a/test/translator/translator.translate.plural.spec.js
+++ b/test/translator/translator.translate.plural.spec.js
@@ -6,7 +6,7 @@ import Interpolator from '../../src/Interpolator';
 
 describe('Translator', () => {
   describe('translate() with plural', () => {
-    var t;
+    let t;
 
     before(() => {
       const rs = new ResourceStore({
@@ -14,6 +14,10 @@ describe('Translator', () => {
           translation: {
             test_one: 'test_en',
             test_other: 'tests_en',
+            pos_test_ordinal_one: 'pos_test_en_one',
+            pos_test_ordinal_two: 'pos_test_en_two',
+            pos_test_ordinal_few: 'pos_test_en_few',
+            pos_test_ordinal_other: 'pos_test_en_other',
           },
           translationWithZero: {
             test_zero: 'test_zero',
@@ -72,10 +76,21 @@ describe('Translator', () => {
       t.changeLanguage('en');
     });
 
-    var tests = [
+    const tests = [
       { args: ['translation:test', { count: 1 }], expected: 'test_en' },
       { args: ['translation:test', { count: 2 }], expected: 'tests_en' },
       { args: ['translation:test', { count: 0 }], expected: 'tests_en' },
+      {
+        args: ['translation:pos_test', { count: 0, ordinal: true }],
+        expected: 'pos_test_en_other',
+      },
+      { args: ['translation:pos_test', { count: 1, ordinal: true }], expected: 'pos_test_en_one' },
+      { args: ['translation:pos_test', { count: 2, ordinal: true }], expected: 'pos_test_en_two' },
+      { args: ['translation:pos_test', { count: 3, ordinal: true }], expected: 'pos_test_en_few' },
+      {
+        args: ['translation:pos_test', { count: 4, ordinal: true }],
+        expected: 'pos_test_en_other',
+      },
       { args: ['translationWithZero:test', { count: 0 }], expected: 'test_zero' },
       { args: ['translation:test', { count: 1, lngs: ['en-US', 'en'] }], expected: 'test_en' },
       { args: ['translation:test', { count: 2, lngs: ['en-US', 'en'] }], expected: 'tests_en' },
@@ -98,23 +113,23 @@ describe('Translator', () => {
       { args: ['translation:test', { count: 101, lng: 'ar' }], expected: 'tests_ar_other' },
       {
         args: ['translation:test', { count: 0, lng: 'ar', ordinal: true }],
-        expected: 'tests_ar_other',
+        expected: 'tests_ar_other', // fallback
       },
       {
         args: ['translation:test', { count: 1, lng: 'ar', ordinal: true }],
-        expected: 'tests_ar_other',
+        expected: 'tests_ar_other', // fallback
       },
       {
         args: ['translation:test', { count: 2, lng: 'ar', ordinal: true }],
-        expected: 'tests_ar_other',
+        expected: 'tests_ar_other', // fallback
       },
       {
         args: ['translation:test', { count: 3, lng: 'ar', ordinal: true }],
-        expected: 'tests_ar_other',
+        expected: 'tests_ar_other', // fallback
       },
       {
         args: ['translation:test', { count: 15, lng: 'ar', ordinal: true }],
-        expected: 'tests_ar_other',
+        expected: 'tests_ar_other', // fallback
       },
       { args: ['translation:test', { count: 0, lng: 'it' }], expected: 'tests_it_other' },
       { args: ['translation:test', { count: 1, lng: 'it' }], expected: 'test_it' },
@@ -122,24 +137,24 @@ describe('Translator', () => {
       { args: ['translation:test', { count: 11, lng: 'it' }], expected: 'tests_it_other' },
       {
         args: ['translation:test', { count: 0, lng: 'it', ordinal: true }],
-        expected: 'tests_it_other',
+        expected: 'tests_it_other', // fallback
       },
       {
         args: ['translation:test', { count: 1, lng: 'it', ordinal: true }],
-        expected: 'tests_it_other',
+        expected: 'tests_it_other', // fallback
       },
       {
         args: ['translation:test', { count: 2, lng: 'it', ordinal: true }],
-        expected: 'tests_it_other',
+        expected: 'tests_it_other', // fallback
       },
       {
         args: ['translation:test', { count: 11, lng: 'it', ordinal: true }],
-        expected: 'tests_it_many',
+        expected: 'tests_it_many', // fallback
       },
     ];
 
     tests.forEach((test) => {
-      it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+      it(`correctly translates for ${JSON.stringify(test.args)} args`, () => {
         expect(t.translate.apply(t, test.args)).to.eql(test.expected);
       });
     });


### PR DESCRIPTION
instead of:


```js
// i.e. english
{
  "key_one": "{{count}}st place", // 1st, 21st, 31st
  "key_two": "{{count}}nd place", // 2nd, 22nd, 32nd
  "key_few": "{{count}}rd place", // 3rd, 23rd, 33rd
  "key_other": "{{count}}th place" // 4th, 5th, 24th, 11th
}
// ...
i18next.t('key', { count: 1, ordinal: true }); // -> "1st place"
i18next.t('key', { count: 21, ordinal: true }); // -> "21st place"
i18next.t('key', { count: 2, ordinal: true }); // -> "2nd place"
i18next.t('key', { count: 11, ordinal: true }); // -> "11th place"
i18next.t('key', { count: 32, ordinal: true }); // -> "32nd place"
```


new:


```js
// i.e. english
{
  "key_ordinal_one": "{{count}}st place", // 1st, 21st, 31st
  "key_ordinal_two": "{{count}}nd place", // 2nd, 22nd, 32nd
  "key_ordinal_few": "{{count}}rd place", // 3rd, 23rd, 33rd
  "key_ordinal_other": "{{count}}th place" // 4th, 5th, 24th, 11th
}
// ...
i18next.t('key', { count: 1, ordinal: true }); // -> "1st place"
i18next.t('key', { count: 21, ordinal: true }); // -> "21st place"
i18next.t('key', { count: 2, ordinal: true }); // -> "2nd place"
i18next.t('key', { count: 11, ordinal: true }); // -> "11th place"
i18next.t('key', { count: 32, ordinal: true }); // -> "32nd place"
```

but there's also a fallback to the keys without _ordinal prefix


TODO: update the docs: https://www.i18next.com/translation-function/plurals#ordinal-plurals