### PR TITLE
types: fix resolvedLanguage type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1316,7 +1316,7 @@ export interface i18n {
    * Is set to the current resolved language.
    * It can be used as primary used language, for example in a language switcher.
    */
-  resolvedLanguage: string;
+  resolvedLanguage?: string;
 
   /**
    * Loads additional namespaces not defined in init options.


### PR DESCRIPTION
`resolvedLanguage` can be unset if i18next is initialized in `cimode` and `dev` language

https://github.com/i18next/i18next/blob/e240c0eb29b5e118df174c6ba863a570e56fa859/src/i18next.js#L306

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)