### PR TITLE
refactor: static createInstance for wider browser support

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -578,7 +578,7 @@ class I18n extends EventEmitter {
       : 'ltr';
   }
 
-  static createInstance = (options = {}, callback) => new I18n(options, callback)
+  static createInstance(options = {}, callback) { return new I18n(options, callback) }
 
   cloneInstance(options = {}, callback = noop) {
     const mergedOptions = { ...this.options, ...options, ...{ isClone: true } };


### PR DESCRIPTION
Reason: i18next 23 dropped support for older node and browsers.... The new version runs fine with recent node, but I feel there's an issue regarding the transpilation of

```javascript
class I18n extends EventEmitter {
  static createInstance = (options = {}, callback) => new I18n(options, callback)
}
```

It's currently transpiled as 

```js
class em extends D {
            static createInstance = function ()  {
                let e = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
                    t = arguments.length > 1 ? arguments[1] : void 0;
                return new em(e, t)
            };
}
```

Runs fine from es2022 (not before) ... but browser support I'm less sure how static +  function will work (https://caniuse.com/mdn-javascript_classes_static -> 95% / but I suspect that `static = function` is a different case). 

With this PR the transpiled code would be

```js
            static createInstance()  {
                let e = arguments.length > 0 && void 0 !== arguments[0] ? arguments[0] : {},
                    t = arguments.length > 1 ? arguments[1] : void 0;
                return new em(e, t)
            };
```

Which:

- allow to pass from es2019 to es2022 checks (difficult to exactly refer to node versions, but let's says node 14 is es2020 100% compat)
- keep the browser baseline at  threshold of 95%

Need to dig more...  

PS: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

