### PR TITLE
#1928: add fallbackNS type handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,12 @@ export type TypeOptions = $MergeBy<
     defaultNS: 'translation';
 
     /**
+     * Fallback namespace used if translation not found in given namespace
+     * @default false
+     */
+    fallbackNS: false;
+
+    /**
      * Json Format Version - V4 allows plural suffixes
      */
     jsonFormat: 'v4';
@@ -741,6 +747,7 @@ type _KeySeparator = TypeOptions['keySeparator'];
 type _NsSeparator = TypeOptions['nsSeparator'];
 type _PluralSeparator = TypeOptions['pluralSeparator'];
 type _DefaultNamespace = TypeOptions['defaultNS'];
+type _FallbackNamespace = TypeOptions['fallbackNS'];
 type _Resources = TypeOptions['resources'];
 type _JSONFormat = TypeOptions['jsonFormat'];
 type _InterpolationPrefix = TypeOptions['interpolationPrefix'];
@@ -834,9 +841,15 @@ export type ParseKeys<
   Keys extends $Dictionary = KeysByTOptions<TOpt>,
   ActualNS extends Namespace = NsByTOptions<Ns, TOpt>,
 > = $IsResourcesDefined extends true
-  ?
-      | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
-      | ParseKeysByNamespaces<ActualNS, Keys>
+  ? _FallbackNamespace extends false
+    ?
+        | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
+        | ParseKeysByNamespaces<ActualNS, Keys>
+    :
+        | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
+        | ParseKeysByKeyPrefix<Keys[$FirstNamespace<_FallbackNamespace>], KPrefix>
+        | ParseKeysByNamespaces<ActualNS, Keys>
+        | ParseKeysByNamespaces<_FallbackNamespace, Keys>
   : string;
 
 /*********************************************************

--- a/index.d.ts
+++ b/index.d.ts
@@ -845,6 +845,12 @@ export type ParseKeys<
     ?
         | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
         | ParseKeysByNamespaces<ActualNS, Keys>
+    : _FallbackNamespace extends Array<infer FallbackNs extends Namespace>
+    ?
+        | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
+        | ParseKeysByKeyPrefix<Keys[$FirstNamespace<FallbackNs>], KPrefix>
+        | ParseKeysByNamespaces<ActualNS, Keys>
+        | ParseKeysByNamespaces<FallbackNs, Keys>
     :
         | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>
         | ParseKeysByKeyPrefix<Keys[$FirstNamespace<_FallbackNamespace>], KPrefix>

--- a/test/typescript/custom-types/getFixedT.test.ts
+++ b/test/typescript/custom-types/getFixedT.test.ts
@@ -30,3 +30,4 @@ t7('alternate:foobar.barfoo');
 // @ts-expect-error
 t7('foobar.barfoo');
 t7('foobar.barfoo', { ns: 'alternate' });
+t7('fallbackKey');

--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -3,6 +3,7 @@ import 'i18next';
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
+    fallbackNS: 'fallback';
     resources: {
       custom: {
         foo: 'foo';
@@ -13,6 +14,9 @@ declare module 'i18next' {
         qux: 'some {{val, number}}';
         inter: 'some {{val}}';
         nullKey: null;
+      };
+      fallback: {
+        fallbackKey: 'fallback';
       };
       alternate: {
         baz: 'baz';

--- a/test/typescript/fallback-types/getFixedT.test.ts
+++ b/test/typescript/fallback-types/getFixedT.test.ts
@@ -1,0 +1,11 @@
+import i18next from 'i18next';
+
+const t = i18next.getFixedT('en');
+t('bar');
+// @ts-expect-error
+t('alternate:foobar.barfoo');
+// @ts-expect-error
+t('foobar.barfoo');
+t('foobar.barfoo', { ns: 'alternate' });
+t('fallbackKey');
+t('anotherFallbackKey');

--- a/test/typescript/fallback-types/i18next.d.ts
+++ b/test/typescript/fallback-types/i18next.d.ts
@@ -1,0 +1,24 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'custom';
+    fallbackNS: ['fallback', 'fallback2'];
+    resources: {
+      custom: {
+        bar: 'bar';
+      };
+      fallback: {
+        fallbackKey: 'fallback';
+      };
+      fallback2: {
+        anotherFallbackKey: 'fallback2';
+      };
+      alternate: {
+        foobar: {
+          barfoo: 'barfoo';
+        };
+      };
+    };
+  }
+}

--- a/test/typescript/fallback-types/tsconfig.json
+++ b/test/typescript/fallback-types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,9 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["./index.d.ts", "./test/**/*.ts*"],
-  "exclude": ["test/typescript/nonEsModuleInterop/**/*.ts", "test/typescript/custom-types"]
+  "exclude": [
+    "test/typescript/nonEsModuleInterop/**/*.ts",
+    "test/typescript/custom-types",
+    "test/typescript/fallback-types"
+  ]
 }


### PR DESCRIPTION
PR adds the feature mentioned in #1928 to allow setting a custom type for fallback namespace. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)