### PR TITLE
Constrain return type when `returnObjects` is `true`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -878,14 +878,11 @@ type ParseTReturn<Key, Res> = Key extends `${infer K1}${_KeySeparator}${infer Re
 
 type TReturnOptionalNull = _ReturnNull extends true ? null : never;
 type TReturnOptionalObjects<TOpt extends TOptions> = _ReturnObjects extends true
-  ? $SpecialObject
+  ? $SpecialObject | string
   : TOpt['returnObjects'] extends true
   ? $SpecialObject
-  : never;
-type DefaultTReturn<TOpt extends TOptions> =
-  | string
-  | TReturnOptionalObjects<TOpt>
-  | TReturnOptionalNull;
+  : string;
+type DefaultTReturn<TOpt extends TOptions> = TReturnOptionalObjects<TOpt> | TReturnOptionalNull;
 
 export type TFunctionReturn<
   Ns extends Namespace,

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -16,6 +16,8 @@ function overloadedUsage(t: TFunction) {
 function returnCasts(t: TFunction) {
   const s: string = t('friend'); // same as <string>
   const s2: string = t`friend`;
+  // @ts-expect-error
+  const s3: string = t('friend', { returnObjects: true });
   const o: object = t('friend', { returnObjects: true });
   const sa: string[] = t('friend', { returnObjects: true });
   const oa: object[] = t('friend', { returnObjects: true });


### PR DESCRIPTION
Closes https://github.com/i18next/i18next/issues/1982

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)