### PR TITLE
Clean language code before passing to formatters; fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - changed `returnNull` default to `false` [1885](https://github.com/i18next/i18next/pull/1885)
 - drop support for old browsers and Node.js < v12 [1948](https://github.com/i18next/i18next/issues/1948)
 
-- ordinal plural keys are now prefixed with `_ordinal` to help translators (non-breaking, bacause of fallback) [1945](https://github.com/i18next/i18next/pull/1945)
+- ordinal plural keys are now prefixed with `_ordinal` to help translators (non-breaking, because of fallback) [1945](https://github.com/i18next/i18next/pull/1945)
 
 ➡️ check out the [migration guide](https://www.i18next.com/misc/migration-guide#v22.x.x-to-v23.0.0)
 
@@ -130,7 +130,7 @@
 
 ## 22.1.4
 
-- dir function executible also without initialization
+- dir function executable also without initialization
 
 ## 22.1.3
 
@@ -631,7 +631,7 @@ For JavaScript users v22.0.0 is equivalent to 21.10.0
 ## 19.5.4
 
 - typescript fix: getDataByLanguage typings & test [1472](https://github.com/i18next/i18next/pull/1472)
-- typescript fix: type declarion of exposed EventEmitter#off methods [1460](https://github.com/i18next/i18next/pull/1460)
+- typescript fix: type declaration of exposed EventEmitter#off methods [1460](https://github.com/i18next/i18next/pull/1460)
 
 ## 19.5.3
 
@@ -653,9 +653,9 @@ For JavaScript users v22.0.0 is equivalent to 21.10.0
 - rename option nonExpicitWhitelist to nonExplicitSupportedLngs
 - rename function languageUtils.isWhitelisted to languageUtils.isSupportedCode
 
-This changes are made with temporal backwards compatiblity and will warn your for deprecated usage of old terms to give users and plugin providers some time to adapt their code base.
+These changes are made with temporal backwards compatibility and will warn your for deprecated usage of old terms to give users and plugin providers some time to adapt their code base.
 
-The temporal backwards compatiblity will be removed in a follow up major release.
+The temporal backwards compatibility will be removed in a follow-up major release.
 
 Learn more about why this change was made [here](https://github.com/i18next/i18next/issues/1466).
 
@@ -1647,7 +1647,7 @@ BREAKING:
 - PR #101 automatic gettext like sprintf syntax detection + postprocess injection
 - customload will get called on dynamicLoad too
 - fixes namespace array settings if loaded resourcebundle or additional namespaces
-- lookup of not existend resouces can be fallbacked to other namespaces - see option fallbackNS (array or string if one ns to fallback to)
+- lookup of not existend resources can be fallbacked to other namespaces - see option fallbackNS (array or string if one ns to fallback to)
 - defaultValues get postProcessed
 - BREAKING: per default null values in resources get translated to fallback. This can be changed by setting option fallbackOnNull to false
 - PR #81 added support for passing options to nested resources

--- a/i18next.js
+++ b/i18next.js
@@ -1395,7 +1395,7 @@
       const key = lng + JSON.stringify(options);
       let formatter = cache[key];
       if (!formatter) {
-        formatter = fn(lng, options);
+        formatter = fn(getCleanedCode(lng), options);
         cache[key] = formatter;
       }
       return formatter(val);

--- a/index.d.ts
+++ b/index.d.ts
@@ -665,7 +665,7 @@ export interface InitOptions<T = object> extends PluginOptions<T> {
   maxRetries?: number;
 
   /**
-   * Set how long to wait, in milliseconds, betweeen retries of failed requests.
+   * Set how long to wait, in milliseconds, between retries of failed requests.
    * This number is compounded by a factor of 2 for subsequent retry.
    * The default value is used if value is set below 1ms.
    * @default 350

--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -1,4 +1,5 @@
 import baseLogger from './logger.js';
+import {getCleanedCode} from "./utils";
 
 function parseFormatStr(formatStr) {
   let formatName = formatStr.toLowerCase().trim();
@@ -46,7 +47,7 @@ function createCachedFormatter(fn) {
     const key = lng + JSON.stringify(options);
     let formatter = cache[key];
     if (!formatter) {
-      formatter = fn(lng, options);
+      formatter = fn(getCleanedCode(lng), options);
       cache[key] = formatter;
     }
     return formatter(val);

--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -48,7 +48,7 @@ class LanguageUtil {
       } else if (p.length === 3) {
         p[0] = p[0].toLowerCase();
 
-        // if lenght 2 guess it's a country
+        // if length 2 guess it's a country
         if (p[1].length === 2) p[1] = p[1].toUpperCase();
         if (p[0] !== 'sgn' && p[2].length === 2) p[2] = p[2].toUpperCase();
 
@@ -117,7 +117,7 @@ class LanguageUtil {
 
     if (!code) return fallbacks.default || [];
 
-    // asume we have an object defining fallbacks
+    // assume we have an object defining fallbacks
     let found = fallbacks[code];
     if (!found) found = fallbacks[this.getScriptPartFromCode(code)];
     if (!found) found = fallbacks[this.formatLanguageCode(code)];

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -183,7 +183,7 @@ class Translator extends EventEmitter {
               ...options,
               ...{ joinArrays: false, ns: namespaces },
             });
-            if (copy[m] === deepKey) copy[m] = res[m]; // if nothing found use orginal value as fallback
+            if (copy[m] === deepKey) copy[m] = res[m]; // if nothing found use original value as fallback
           }
         }
         res = copy;

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -319,7 +319,7 @@ class I18n extends EventEmitter {
     const setLngProps = (l) => {
       this.language = l;
       this.languages = this.services.languageUtils.toResolveHierarchy(l);
-      // find the first language resolved languaged
+      // find the first language resolved language
       this.resolvedLanguage = undefined;
       this.setResolvedLanguage(l);
     };

--- a/test/backend/backendConnector.load.retry.spec.skip.js
+++ b/test/backend/backendConnector.load.retry.spec.skip.js
@@ -305,7 +305,7 @@ describe('BackendConnector retry with maxRetries=6', () => {
   });
 });
 
-// All tests have 250ms of code-exection buffer time built in.
+// All tests have 250ms of code-execution buffer time built in.
 // To ensure test correctness, the tests should never time out.
 describe('BackendConnector retry with shorter intervals', () => {
   let connector;

--- a/test/backward/v1.11.1.compat.js
+++ b/test/backward/v1.11.1.compat.js
@@ -925,7 +925,7 @@ describe('i18next', function () {
       //       beforeEach(function(done) {
       //         spy.reset();
       //
-      //         // exipred
+      //         // expired
       //         var local = window.localStorage.getItem('res_en-US');
       //         local = JSON.parse(local);
       //         local.i18nStamp = 0;
@@ -968,7 +968,7 @@ describe('i18next', function () {
       });
 
       describe('with lowercase flag', function () {
-        describe('default behaviour will uppercase specifc country part.', function () {
+        describe('default behaviour will uppercase specific country part.', function () {
           beforeEach(function (done) {
             i18n.init(
               i18n.functions.extend(opts, {

--- a/test/resourceStore.spec.js
+++ b/test/resourceStore.spec.js
@@ -29,7 +29,7 @@ describe('ResourceStore', () => {
         rs = new ResourceStore(data);
       });
 
-      it('it adds resouces by addResource', () => {
+      it('it adds resources by addResource', () => {
         // basic key
         rs.addResource('de', 'translation', 'test', 'test');
         expect(rs.getResource('de', 'translation', 'test')).to.equal('test');
@@ -129,7 +129,7 @@ describe('ResourceStore', () => {
         rs = new ResourceStore(data);
       });
 
-      it('it adds resouces by addResourceBundle', () => {
+      it('it adds resources by addResourceBundle', () => {
         rs.addResourceBundle('en', 'translation', { something: 'deeper' });
         expect(rs.getResource('en', 'translation')).to.eql({ something: 'deeper', test: 'test' });
 
@@ -161,7 +161,7 @@ describe('ResourceStore', () => {
         rs = new ResourceStore(data);
       });
 
-      it('it checks resouces by hasResourceBundle', () => {
+      it('it checks resources by hasResourceBundle', () => {
         expect(rs.hasResourceBundle('en', 'translation')).to.be.ok;
         expect(rs.hasResourceBundle('en', 'notExisting')).to.not.be.ok;
       });
@@ -173,7 +173,7 @@ describe('ResourceStore', () => {
         rs = new ResourceStore(data);
       });
 
-      it('it get resouces by getResourceBundle', () => {
+      it('it get resources by getResourceBundle', () => {
         expect(rs.getResourceBundle('en', 'translation')).to.be.eql({ test: 'test' });
       });
     });
@@ -184,7 +184,7 @@ describe('ResourceStore', () => {
         rs = new ResourceStore(data);
       });
 
-      it('it removes resouces by removeResourceBundle', () => {
+      it('it removes resources by removeResourceBundle', () => {
         rs.removeResourceBundle('en', 'translation');
         expect(rs.getResourceBundle('en', 'translation')).to.be.not.ok;
       });

--- a/test/translator/translator.translate.systemProperties.spec.js
+++ b/test/translator/translator.translate.systemProperties.spec.js
@@ -4,7 +4,7 @@ import LanguageUtils from '../../src/LanguageUtils';
 import PluralResolver from '../../src/PluralResolver';
 import Interpolator from '../../src/Interpolator';
 
-// These tests orignated from issues:
+// These tests originated from issues:
 //
 // https://github.com/i18next/i18next/issues/906
 // https://github.com/i18next/i18next-xhr-backend/issues/258


### PR DESCRIPTION
* Clean language code before passing to formatters, to avoid errors like this when using locale like `'en_US'`:
```
RangeError: Incorrect locale information provided
    at new ListFormat (<anonymous>)
    at i18next.js:1430:27
```

* Fix misc typos

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)