### PR TITLE
Add brand to TFunction type so different namespaces' TFunctions are not treated as compatible

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -907,6 +907,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  * T function declaration *
  **************************/
 export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = undefined> {
+  $TFunctionBrand: Ns;
   <
     Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     TOpt extends TOptions,

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -152,3 +152,10 @@ function nullTranslations() {
 //   // context + plural
 //   t('dessert', { context: 'muffin', count: 3 }).trim();
 // }
+
+function expectErrorForDifferentTFunctions(t: TFunction<'ord'>) {
+  const fn: (t: TFunction<'plurals'>) => void = () => {};
+
+  // @ts-expect-error
+  fn(t);
+}


### PR DESCRIPTION
Previously, two `TFunction` types would be treated as compatible even if they referred to different namespaces. For example:

```ts
function bar(t: TFunction<"bar">) { }

const { t } = useTranslation("foo");
bar(t); // wrong, but no TS error :(
```

This PR adds a property to the `TFunction` interface, making it a ["branded" type](https://medium.com/@KevinBGreene/surviving-the-typescript-ecosystem-branding-and-type-tagging-6cf6e516523d). Two `TFunction`s with different values of `Ns` will no longer be treated as compatible. The example above will now fail to compile.

Fixes #1941