### PR TITLE
Fix $TFunctionBrand for non-string namespaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -907,7 +907,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  * T function declaration *
  **************************/
 export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = undefined> {
-  $TFunctionBrand: `${$FirstNamespace<Ns>}`;
+  $TFunctionBrand: $IsResourcesDefined extends true ? `${$FirstNamespace<Ns>}` : never;
   <
     Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     TOpt extends TOptions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -907,7 +907,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  * T function declaration *
  **************************/
 export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = undefined> {
-  $TFunctionBrand: Ns;
+  $TFunctionBrand: [Ns] extends [string] ? `${Ns}` : never;
   <
     Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     TOpt extends TOptions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -907,7 +907,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  * T function declaration *
  **************************/
 export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = undefined> {
-  $TFunctionBrand: [Ns] extends [string] ? `${Ns}` : never;
+  $TFunctionBrand: Ns extends string ? `${Ns}` : never;
   <
     Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     TOpt extends TOptions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -907,7 +907,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  * T function declaration *
  **************************/
 export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = undefined> {
-  $TFunctionBrand: Ns extends string ? `${Ns}` : never;
+  $TFunctionBrand: `${$FirstNamespace<Ns>}`;
   <
     Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     TOpt extends TOptions,

--- a/package.json
+++ b/package.json
@@ -103,12 +103,13 @@
     "watchify": "4.0.0"
   },
   "scripts": {
-    "pretest": "npm run test:typescript && npm run test:typescript:customtypes && npm run test:typescript:fallbacktypes && npm run test:typescript:noninterop",
+    "pretest": "npm run test:typescript && npm run test:typescript:customtypes && npm run test:typescript:defaulttypes && npm run test:typescript:fallbacktypes && npm run test:typescript:noninterop",
     "lint": "eslint src",
     "test": "npm run lint && npm run test:new && npm run test:compat",
     "test:new": "karma start karma.conf.js --singleRun",
     "test:compat": "karma start karma.backward.conf.js --singleRun",
     "test:typescript": "tslint --project tsconfig.json",
+    "test:typescript:defaulttypes": "tslint --project test/typescript/default-types/tsconfig.json",
     "test:typescript:customtypes": "tslint --project test/typescript/custom-types/tsconfig.json",
     "test:typescript:fallbacktypes": "tslint --project test/typescript/fallback-types/tsconfig.json",
     "test:typescript:noninterop": "tslint --project tsconfig.nonEsModuleInterop.json",

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -156,10 +156,13 @@ function nullTranslations() {
 function expectErrorsForDifferentTFunctions(
   t1: TFunction<'ord'>,
   t2: TFunction<['ord', 'plurals']>,
+  t3: TFunction<['plurals', 'ord']>,
 ) {
   const fn: (t: TFunction<'plurals'>) => void = () => {};
 
   // @ts-expect-error
   fn(t1);
-  fn(t2); // no error - not checked
+  // @ts-expect-error
+  fn(t2);
+  fn(t3); // no error
 }

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -153,9 +153,13 @@ function nullTranslations() {
 //   t('dessert', { context: 'muffin', count: 3 }).trim();
 // }
 
-function expectErrorForDifferentTFunctions(t: TFunction<'ord'>) {
+function expectErrorsForDifferentTFunctions(
+  t1: TFunction<'ord'>,
+  t2: TFunction<['ord', 'plurals']>,
+) {
   const fn: (t: TFunction<'plurals'>) => void = () => {};
 
   // @ts-expect-error
-  fn(t);
+  fn(t1);
+  fn(t2); // no error - not checked
 }

--- a/test/typescript/default-types/t.test.ts
+++ b/test/typescript/default-types/t.test.ts
@@ -1,0 +1,14 @@
+import { TFunction } from 'i18next';
+
+function expectErrorsForDifferentTFunctions(
+  t1: TFunction<'ord'>,
+  t2: TFunction<['ord', 'plurals']>,
+  t3: TFunction<[string, string]>,
+) {
+  const fn: (t: TFunction<'plurals'>) => void = () => {};
+
+  // @ts-expect-error
+  fn(t1);
+  fn(t2); // no error - not checked
+  fn(t3); // no error - not checked
+}

--- a/test/typescript/default-types/t.test.ts
+++ b/test/typescript/default-types/t.test.ts
@@ -3,12 +3,16 @@ import { TFunction } from 'i18next';
 function expectErrorsForDifferentTFunctions(
   t1: TFunction<'ord'>,
   t2: TFunction<['ord', 'plurals']>,
-  t3: TFunction<[string, string]>,
+  t3: TFunction<['plurals', 'ord']>,
+  t4: TFunction<[string, string]>,
 ) {
   const fn: (t: TFunction<'plurals'>) => void = () => {};
 
   // @ts-expect-error
   fn(t1);
-  fn(t2); // no error - not checked
-  fn(t3); // no error - not checked
+  // @ts-expect-error
+  fn(t2);
+  fn(t3); // no error
+  // @ts-expect-error
+  fn(t4);
 }

--- a/test/typescript/default-types/t.test.ts
+++ b/test/typescript/default-types/t.test.ts
@@ -7,12 +7,15 @@ function expectErrorsForDifferentTFunctions(
   t4: TFunction<[string, string]>,
 ) {
   const fn: (t: TFunction<'plurals'>) => void = () => {};
+  const fn2: (t: TFunction) => void = () => {};
 
-  // @ts-expect-error
+  // no error - not checked when CustomTypeOptions["resources"] is not provided
   fn(t1);
-  // @ts-expect-error
   fn(t2);
-  fn(t3); // no error
-  // @ts-expect-error
+  fn(t3);
   fn(t4);
+  fn2(t1);
+  fn2(t2);
+  fn2(t3);
+  fn2(t4);
 }

--- a/test/typescript/default-types/tsconfig.json
+++ b/test/typescript/default-types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   "exclude": [
     "test/typescript/nonEsModuleInterop/**/*.ts",
     "test/typescript/custom-types",
+    "test/typescript/default-types",
     "test/typescript/fallback-types"
   ]
 }


### PR DESCRIPTION
Follow-up to #1994 
Fix type brand validation for more complex TFunction use cases (like `TFunction<["a", "b"]>`).