### PR TITLE
Restrict interpolation types based on format; Include typing for formatParams

### DIFF
--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -12,6 +12,7 @@ declare module 'i18next' {
           bing: 'boop';
         };
         qux: 'some {{val, number}}';
+        currencyWithCode: 'money {{val, currency(USD)}}';
         inter: 'some {{val}}';
         nullKey: null;
       };

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -102,7 +102,10 @@ function i18nextTUsage() {
   i18next.t('custom:inter', { val: 'asdf' }).trim();
   i18next.t('inter', { val: 'asdf', ns: 'custom' }).trim();
   i18next.t('inter', { val: 'asdf' }).trim();
-  i18next.t('qux', { val: 'asdf' }).trim();
+  // @ts-expect-error
+  i18next.t('qux', { val: 'this should be a number, hence the error' }).trim();
+  // @ts-expect-error
+  i18next.t('currencyWithCode', { val: 'this should also be a number' });
   // @ts-expect-error
   i18next.t('custom:inter', { foo: 'asdf' });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "es2021.intl"],
     "jsx": "react",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Currently, it's possible to pass any variable as an interpolation, which isn't great since it can be error prone. Take the following as an example:
```js
// Poorly named variable
const username = { name: 'some_user', ... };

// ...

// Assuming key fallback
t("Hello {{username}}", { username });
// -> "Hello [object Object]"
```

The above is not completely addressed in this PR. Instead, I'm first fixing a subset of this problem, which is formatted interpolations. Since the built-in interpolations must conform to the `Intl` formatters that they are passed to, this PR makes it so that any interpolation that is being formatted is restriced to the type that the corresponding `Intl` formatter expects. This PR also adds typing for `formatParams`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)