### PR TITLE
Use improved type inference with key fallback

### DIFF
--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -4,6 +4,7 @@ declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
     fallbackNS: 'fallback';
+    returnEmptyString: false;
     resources: {
       custom: {
         foo: 'foo';
@@ -14,6 +15,7 @@ declare module 'i18next' {
         qux: 'some {{val, number}}';
         inter: 'some {{val}}';
         nullKey: null;
+        'key fallback with {{val}}': '';
       };
       fallback: {
         fallbackKey: 'fallback';

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -111,6 +111,10 @@ function i18nextTUsage() {
   i18next.t('bar', { ns: 'custom', defaultValue: 'some default value' });
   i18next.t('bar', { defaultValue: 'some default value' });
   i18next.t('bar', 'some default value');
+
+  // key fallback
+  // @ts-expect-error
+  i18next.t('key fallback with {{val}}', {});
 }
 
 function expectErrorWhenInvalidKeyWithI18nextT() {
@@ -141,8 +145,7 @@ function returnNeverWithInvalidNamespace(t: TFunction<string>) {
 }
 
 function nullTranslations() {
-  // seems to work only when not using typesafe translations
-  // i18next.t('nullKey').trim();
+  i18next.t('nullKey').trim();
 }
 
 // function i18nextContextUsage(t: TFunction<'ctx'>) {


### PR DESCRIPTION
For TypeScript users who are using key fallback, the improved type inference introduced in v23 isn't working at the moment. This PR fixes that.

#### Checklist
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)