### PR TITLE
Fix performance issue that affects flat object with multiple (thousands) keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 // Internal Helpers
 type $MergeBy<T, K> = Omit<T, keyof K> & K;
 type $Dictionary<T = any> = { [key: string]: T };
-type $Value<Obj, Key> = Key extends keyof Obj ? Obj[Key] : never;
 type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof any[]> : Arr;
 type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
 type $FirstNamespace<Ns extends Namespace> = Ns extends readonly any[] ? Ns[0] : Ns;
@@ -866,14 +865,10 @@ type ParseTReturnPlural<
   KeyWithPlural = `${Key & string}${_PluralSeparator}${PluralSuffix}`,
   KeyWithOrdinalPlural = `${Key &
     string}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`,
-> = KeyWithOrdinalPlural extends keyof Res
-  ? Res[KeyWithOrdinalPlural]
-  : KeyWithPlural extends keyof Res
-  ? Res[KeyWithPlural]
-  : $Value<Res, Key>;
+> = Res[(KeyWithOrdinalPlural | KeyWithPlural | Key) & keyof Res];
 
 type ParseTReturn<Key, Res> = Key extends `${infer K1}${_KeySeparator}${infer RestKey}`
-  ? ParseTReturn<RestKey, $Value<Res, K1>>
+  ? ParseTReturn<RestKey, Res[K1 & keyof Res]>
   : ParseTReturnPlural<Res, Key>;
 
 type TReturnOptionalNull = _ReturnNull extends true ? null : never;
@@ -891,7 +886,7 @@ export type TFunctionReturn<
   ActualNS extends Namespace = NsByTOptions<Ns, TOpt>,
 > = $IsResourcesDefined extends true
   ? Key extends `${infer Nsp}${_NsSeparator}${infer RestKey}`
-    ? ParseTReturn<RestKey, $Value<Resources, Nsp>>
+    ? ParseTReturn<RestKey, Resources[Nsp & keyof Resources]>
     : ParseTReturn<Key, Resources[$FirstNamespace<ActualNS>]>
   : DefaultTReturn<TOpt>;
 
@@ -915,7 +910,6 @@ export interface TFunction<Ns extends Namespace = _DefaultNamespace, KPrefix = u
   >(
     ...args:
       | [key: Key | Key[], options?: TOpt & InterpolationMap<Ret>]
-      | [key: Key | Key[], defaultValue: string, options?: TOpt & InterpolationMap<Ret>]
       | [key: string | string[], options: TOpt & InterpolationMap<Ret> & { defaultValue: string }]
       | [key: string | string[], defaultValue: string, options?: TOpt & InterpolationMap<Ret>]
   ): TFunctionReturnOptionalDetails<Ret, TOpt>;


### PR DESCRIPTION
Closes https://github.com/i18next/i18next/issues/1991

In this PR, I've simplified the approach for inferring the return type by directly returning the value of a specified key, rather than using conditional type to verify the presence of all `KeyWithOrdinalPlural`, `KeyWithPlural`, and `Key` within `Res` before returning the value.

Here are the complexity results for the old and new approaches:

### Old approach

- N = Number of sub-keys in the same key or namespace
- KeyWithPlural = 6
- KeyWithOrdinalPlural = 6

**Complexity:** O((KeyWithPlural * N) + (KeyWithOrdinalPlural * N) + N) = O(13 * N)

### New approach
**Complexity:** O(1) - constant time


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)