### PR TITLE
Typescript - Support context

### DIFF
--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -37,6 +37,7 @@ declare module 'i18next' {
         foo_other: 'foo';
       };
       ctx: {
+        foo: 'foo';
         dessert_cake: 'a nice cake';
         dessert_muffin_one: 'a nice muffin';
         dessert_muffin_other: '{{count}} nice muffins';

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -111,6 +111,8 @@ function i18nextTUsage() {
   i18next.t('bar', { ns: 'custom', defaultValue: 'some default value' });
   i18next.t('bar', { defaultValue: 'some default value' });
   i18next.t('bar', 'some default value');
+
+  const str: string = i18next.t('unknown-ns:unknown-key', 'default value');
 }
 
 function expectErrorWhenInvalidKeyWithI18nextT() {
@@ -145,13 +147,16 @@ function nullTranslations() {
   // i18next.t('nullKey').trim();
 }
 
-// function i18nextContextUsage(t: TFunction<'ctx'>) {
-//   t('dessert', { context: 'cake' }).trim();
-//   t('dessert', { context: 'muffin' }).trim();
+function i18nextContextUsage(t: TFunction<'ctx'>) {
+  t('dessert', { context: 'cake' as const }).trim();
 
-//   // context + plural
-//   t('dessert', { context: 'muffin', count: 3 }).trim();
-// }
+  // context + plural
+  t('dessert', { context: 'muffin' as const, count: 3 }).trim();
+
+  // @ts-expect-error
+  // valid key with invalid context
+  t('foo', { context: 'cake' as const }).trim();
+}
 
 function expectErrorsForDifferentTFunctions(
   t1: TFunction<'ord'>,


### PR DESCRIPTION
Closes https://github.com/i18next/react-i18next/issues/1617, https://github.com/i18next/react-i18next/issues/1333, https://github.com/i18next/react-i18next/issues/1541

**Limitations:**

1. **Context and Plurals**: Currently, due to a TypeScript limitation, it's required to pass a `count` while using context with plurals. I still need to figure out an workaround for it.
3. **Filtering Keys Based on Context**: At present, to filter appropriate keys according to the context, it is necessary to assert the context using `as const` to infer the proper string literal value rather than `string`. This'll be addressed [here](https://github.com/i18next/i18next/issues/1929).

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)