### PR TITLE
types: add customisation of `contextSeparator`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "watchify": "4.0.0"
   },
   "scripts": {
-    "pretest": "npm run test:typescript && npm run test:typescript:customtypes && npm run test:typescript:defaulttypes && npm run test:typescript:fallbacktypes && npm run test:typescript:noninterop",
+    "pretest": "npm run test:typescript && npm run test:typescript:customtypes && npm run test:typescript:defaulttypes && npm run test:typescript:fallbacktypes && npm run test:typescript:noninterop && npm run test:typescript:customcontextseparator",
     "lint": "eslint src",
     "test": "npm run lint && npm run test:new && npm run test:compat",
     "test:new": "karma start karma.conf.js --singleRun",
@@ -119,6 +119,7 @@
     "test:typescript:defaulttypes": "tslint --project test/typescript/default-types/tsconfig.json",
     "test:typescript:customtypes": "tslint --project test/typescript/custom-types/tsconfig.json",
     "test:typescript:fallbacktypes": "tslint --project test/typescript/fallback-types/tsconfig.json",
+    "test:typescript:customcontextseparator": "tslint --project test/typescript/custom-context-separator/tsconfig.json",
     "test:typescript:noninterop": "tslint --project tsconfig.nonEsModuleInterop.json",
     "tdd": "karma start karma.conf.js",
     "tdd:compat": "karma start karma.backward.conf.js",

--- a/test/typescript/custom-context-separator/i18next.d.ts
+++ b/test/typescript/custom-context-separator/i18next.d.ts
@@ -1,0 +1,18 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'ctx';
+    contextSeparator: '|';
+    resources: {
+      ctx: {
+        beverage: 'beverage';
+        'beverage|beer': 'beer';
+
+        'dessert|cake': 'a nice cake';
+        'dessert|muffin_one': 'a nice muffin';
+        'dessert|muffin_other': '{{count}} nice muffins';
+      };
+    };
+  }
+}

--- a/test/typescript/custom-context-separator/t.test.ts
+++ b/test/typescript/custom-context-separator/t.test.ts
@@ -1,0 +1,12 @@
+import { TFunction } from 'i18next';
+
+function i18nextContextUsage(t: TFunction) {
+  t('dessert', { context: 'cake' }).trim();
+
+  // context + plural
+  t('dessert', { context: 'muffin', count: 3 }).trim();
+
+  // Without & with context
+  t('beverage').trim();
+  t('beverage', { context: 'beer' }).trim();
+}

--- a/test/typescript/custom-context-separator/tsconfig.json
+++ b/test/typescript/custom-context-separator/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "test/typescript/nonEsModuleInterop/**/*.ts",
     "test/typescript/custom-types",
     "test/typescript/default-types",
-    "test/typescript/fallback-types"
+    "test/typescript/fallback-types",
+    "test/typescript/custom-context-separator"
   ]
 }

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -55,9 +55,14 @@ export type TypeOptions = $MergeBy<
     nsSeparator: ':';
 
     /**
-     * Char to split namespace from key
+     * Char to split plural from key
      */
     pluralSeparator: '_';
+
+    /**
+     * Char to split context from key
+     */
+    contextSeparator: '_';
 
     /**
      * Default namespace used if not passed to translation function

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -19,6 +19,7 @@ type _ReturnNull = TypeOptions['returnNull'];
 type _KeySeparator = TypeOptions['keySeparator'];
 type _NsSeparator = TypeOptions['nsSeparator'];
 type _PluralSeparator = TypeOptions['pluralSeparator'];
+type _ContextSeparator = TypeOptions['contextSeparator'];
 type _FallbackNamespace = TypeOptions['fallbackNS'];
 type _Resources = TypeOptions['resources'];
 type _JSONFormat = TypeOptions['jsonFormat'];
@@ -104,7 +105,7 @@ type ParseKeysByFallbackNs<Keys extends $Dictionary> = _FallbackNamespace extend
   : Keys[_FallbackNamespace & string];
 
 type FilterKeysByContext<Keys, TOpt extends TOptions> = TOpt['context'] extends string
-  ? Keys extends `${infer Prefix}_${TOpt['context']}${infer Suffix}`
+  ? Keys extends `${infer Prefix}${_ContextSeparator}${TOpt['context']}${infer Suffix}`
     ? `${Prefix}${Suffix}`
     : never
   : Keys;
@@ -156,7 +157,7 @@ type TReturnOptionalObjects<TOpt extends TOptions> = _ReturnObjects extends true
 type DefaultTReturn<TOpt extends TOptions> = TReturnOptionalObjects<TOpt> | TReturnOptionalNull;
 
 type KeyWithContext<Key, TOpt extends TOptions> = TOpt['context'] extends string
-  ? `${Key & string}_${TOpt['context']}`
+  ? `${Key & string}${_ContextSeparator}${TOpt['context']}`
   : Key;
 
 export type TFunctionReturn<


### PR DESCRIPTION
Allow usage of custom `contextSeparator` in `CustomTypeOptions` for correctly resolving keys in typescript.

Added a new folder `custom-context-separator` in `test/typescript` to test this specific scenario.

Fixes #2016 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
