### PR TITLE
types: use unknown to better infer types on nested t functions

### DIFF
--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -171,3 +171,11 @@ function expectErrorsForDifferentTFunctions(
   fn(t2);
   fn(t3); // no error
 }
+
+function usingTFunctionInsideAnotherTFunction(t: TFunction) {
+  t('foo', { defaultValue: t('bar') });
+
+  t('foo', { something: t('bar') });
+
+  t('foo', { defaultValue: t('bar'), something: t('bar') });
+}

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -169,3 +169,11 @@ function interpolation(t: TFunction) {
 function nullTranslations() {
   i18next.t('nullKey').trim();
 }
+
+function usingTFunctionInsideAnotherTFunction(t: TFunction) {
+  t('foobar', { defaultValue: t('inter') });
+
+  t('foobar', { defaultValue: t('inter'), someValue: t('inter') });
+
+  t('foobar', { something: t('inter') });
+}

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -1,5 +1,5 @@
 export type $MergeBy<T, K> = Omit<T, keyof K> & K;
-export type $Dictionary<T = any> = { [key: string]: T };
+export type $Dictionary<T = unknown> = { [key: string]: T };
 export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof any[]> : Arr;
 export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
 export type $SpecialObject = object | Array<string | object>;

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -685,7 +685,7 @@ export interface TOptionsBase {
   /**
    * Default value to return if a translation was not found
    */
-  defaultValue?: any;
+  defaultValue?: unknown;
   /**
    * Count value used for plurals
    */

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -134,7 +134,10 @@ type ParseInterpolationValues<Ret> =
         | (Value extends `${infer ActualValue},${string}` ? ActualValue : Value)
         | ParseInterpolationValues<Rest>
     : never;
-type InterpolationMap<Ret> = Record<$PreservedValue<ParseInterpolationValues<Ret>, string>, any>;
+type InterpolationMap<Ret> = Record<
+  $PreservedValue<ParseInterpolationValues<Ret>, string>,
+  unknown
+>;
 
 type ParseTReturnPlural<
   Res,
@@ -208,6 +211,7 @@ type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string
  **************************/
 export interface TFunction<Ns extends Namespace = DefaultNamespace, KPrefix = undefined> {
   $TFunctionBrand: $IsResourcesDefined extends true ? `${$FirstNamespace<Ns>}` : never;
+
   <
     const Key extends ParseKeys<Ns, TOpt, KPrefix> | TemplateStringsArray,
     const TOpt extends TOptions,


### PR DESCRIPTION
While upgrading to v23 we encounter the same issue described in #2011.

The problem seems caused by `any` usage in defaultValue, interpolation map and dictionary.
Changing them to `unknown` should make type infer from nested `t` work properly.

We have tested this patch on our repository and it seems to be working.

## Before

<img width="516" alt="Screenshot 2023-08-09 at 09 38 54" src="https://github.com/i18next/i18next/assets/24919330/48672cea-995c-47c3-a039-2fd9ac6ebebf">

## After

### Without `CustomTypeOptions`

<img width="504" alt="Screenshot 2023-08-09 at 09 39 18" src="https://github.com/i18next/i18next/assets/24919330/b76098d4-f58b-4f12-90ff-54a4a674b939">

### With `CustomTypeOptions`

<img width="567" alt="Screenshot 2023-08-09 at 09 39 11" src="https://github.com/i18next/i18next/assets/24919330/4d7b929e-58da-450e-8e50-fc0dfed7fcbb">

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
