### PR TITLE
add interpolation data to response if returnDetails is true

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -555,6 +555,7 @@ class Translator extends EventEmitter {
   }
 
   getUsedParamsDetails(options = {}) {
+    // we need to remember to extend this array whenever new option properties are added
     const optionsKeys = [
       'defaultValue',
       'ordinal',

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -585,6 +585,7 @@ class Translator extends EventEmitter {
 
     // avoid reporting options (execpt count) as usedParams
     if (!useOptionsReplaceForData) {
+      data = { ...data };
       for (const key of optionsKeys) {
         delete data[key];
       }

--- a/test/translator/translator.translate.spec.js
+++ b/test/translator/translator.translate.spec.js
@@ -73,6 +73,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -83,6 +84,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -93,6 +95,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -103,6 +106,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'de',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -113,6 +117,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'de',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -123,6 +128,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -133,6 +139,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -143,6 +150,7 @@ describe('Translator', () => {
             exactUsedKey: 'test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -153,6 +161,7 @@ describe('Translator', () => {
             exactUsedKey: 'deep.test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
           },
         },
         {
@@ -163,12 +172,81 @@ describe('Translator', () => {
             exactUsedKey: 'deep.test',
             usedLng: 'en',
             usedNS: 'translation',
+            usedParams: {},
+          },
+        },
+        {
+          args: ['translation:test', { returnDetails: true, testParam: 'test-param' }],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+            usedParams: {
+              testParam: 'test-param',
+            },
+          },
+        },
+        {
+          args: [
+            'translation:test',
+            {
+              returnDetails: true,
+              replace: { testParam: 'test-param' },
+            },
+          ],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+            usedParams: {
+              testParam: 'test-param',
+            },
+          },
+        },
+        {
+          args: [
+            'translation:test',
+            {
+              defaultValue: 'default',
+              ordinal: true,
+              context: undefined,
+              replace: { testParam: 'test-param' },
+              lng: 'en',
+              lngs: ['en', 'de'],
+              fallbackLng: 'en',
+              ns: ['translation', 'other'],
+              keySeparator: '.',
+              nsSeparator: ':',
+              returnObjects: false,
+              returnDetails: true,
+              joinArrays: true,
+              postProcess: false,
+              interpolation: { escapeValue: false },
+              count: 1,
+            },
+          ],
+          expected: {
+            usedKey: 'test',
+            res: 'test_en',
+            exactUsedKey: 'test',
+            usedLng: 'en',
+            usedNS: 'translation',
+            usedParams: {
+              testParam: 'test-param',
+              count: 1,
+            },
           },
         },
       ];
 
       tests.forEach((test) => {
         it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+          console.log(t.translate.apply(t, test.args));
+          console.log(test.expected);
           expect(t.translate.apply(t, test.args)).to.eql(test.expected);
         });
       });

--- a/test/translator/translator.translate.spec.js
+++ b/test/translator/translator.translate.spec.js
@@ -245,8 +245,6 @@ describe('Translator', () => {
 
       tests.forEach((test) => {
         it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
-          console.log(t.translate.apply(t, test.args));
-          console.log(test.expected);
           expect(t.translate.apply(t, test.args)).to.eql(test.expected);
         });
       });

--- a/test/typescript/t.test.ts
+++ b/test/typescript/t.test.ts
@@ -143,6 +143,7 @@ function interpolation(t: TFunction) {
   resolved.exactUsedKey;
   resolved.usedNS;
   resolved.usedLng;
+  resolved.usedParams;
 
   const r2 = t('keyTwo', { returnDetails: false });
   r2?.substring(0, 2); // make sure it is a string

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -175,7 +175,7 @@ export type TFunctionReturn<
     : ParseTReturn<ActualKey, Resources[$FirstNamespace<ActualNS>]>
   : DefaultTReturn<TOpt>;
 
-export type TFunctionDetailedResult<T = string> = {
+export type TFunctionDetailedResult<T = string, TOpt extends TOptions = {}> = {
   /**
    * The plain used key
    */
@@ -196,10 +196,14 @@ export type TFunctionDetailedResult<T = string> = {
    * The used namespace for this translation.
    */
   usedNS: string;
+  /**
+   * The parameters used for interpolation.
+   */
+  usedParams: InterpolationMap<T> & { count?: TOpt['count'] };
 };
 
 type TFunctionReturnOptionalDetails<Ret, TOpt extends TOptions> = TOpt['returnDetails'] extends true
-  ? TFunctionDetailedResult<Ret>
+  ? TFunctionDetailedResult<Ret, TOpt>
   : Ret;
 
 type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -203,7 +203,7 @@ export type TFunctionDetailedResult<T = string, TOpt extends TOptions = {}> = {
 };
 
 type TFunctionReturnOptionalDetails<Ret, TOpt extends TOptions> = TOpt['returnDetails'] extends true
-  ? TFunctionDetailedResult<Ret>
+  ? TFunctionDetailedResult<Ret, TOpt>
   : Ret;
 
 type AppendKeyPrefix<Key, KPrefix> = KPrefix extends string

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -175,7 +175,7 @@ export type TFunctionReturn<
     : ParseTReturn<ActualKey, Resources[$FirstNamespace<ActualNS>]>
   : DefaultTReturn<TOpt>;
 
-export type TFunctionDetailedResult<T = string> = {
+export type TFunctionDetailedResult<T = string, TOpt extends TOptions = {}> = {
   /**
    * The plain used key
    */
@@ -196,6 +196,10 @@ export type TFunctionDetailedResult<T = string> = {
    * The used namespace for this translation.
    */
   usedNS: string;
+  /**
+   * The parameters used for interpolation.
+   */
+  usedParams: InterpolationMap<T> & { count?: TOpt['count'] };
 };
 
 type TFunctionReturnOptionalDetails<Ret, TOpt extends TOptions> = TOpt['returnDetails'] extends true


### PR DESCRIPTION
Fixes https://github.com/i18next/i18next/issues/2046

What was changed?
1. Added a new field (`usedParams`) to the object returned from `t()` when `returnDetails = true`. It should contain all the fields passed to interpolation.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)