### PR TITLE
fix(types): FormatFunction should allow any value inside options parameter

### DIFF
--- a/test/typescript/format.test.ts
+++ b/test/typescript/format.test.ts
@@ -1,0 +1,9 @@
+import { FormatFunction } from 'i18next';
+
+export const customFormatFunction: FormatFunction = (value, _, lng, options) => {
+  const passedOptions = options?.formatParams?.[options.interpolationkey] || {};
+
+  // All keys should can be read from options without any error
+  const randomParameter = options?.random;
+  return '';
+};

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -138,7 +138,7 @@ export type FormatFunction = (
   value: any,
   format?: string,
   lng?: string,
-  options?: InterpolationOptions & $Dictionary,
+  options?: InterpolationOptions & $Dictionary<any>,
 ) => string;
 
 export interface InterpolationOptions {


### PR DESCRIPTION
Fixes #2074

#### Followup

I might been able to develop a more sophisticated solution using interface augmentation to allow user extends interpolation options so you can get type checking and autocomplete also on `t`  alongside `FormatFunction` type.

However I never used them so I need to check how they work.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
