### PR TITLE
exposed initializedStoreOnce and initializedLanguageOnce props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -491,6 +491,16 @@ export interface i18n extends CustomInstanceExtenstions {
   isInitialized: boolean;
 
   /**
+   * Store was initialized
+   */
+  initializedStoreOnce: boolean;
+
+  /**
+   * Language was initialized
+   */
+  initializedLanguageOnce: boolean;
+
+  /**
    * Emit event
    */
   emit(eventName: string, ...args: any[]): void;


### PR DESCRIPTION
Addressing this issue:
https://github.com/i18next/i18next/issues/2087

initializedStoreOnce and initializedLanguageOnce are now public