### PR TITLE
chore: move linting to codeclimate to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
-      - image:  circleci/node:latest-browsers
+      - image: circleci/node:latest-browsers
         environment:
           CHROME_BIN: '/usr/bin/google-chrome'
     steps:
@@ -17,11 +17,11 @@ jobs:
           paths:
             - ./node_modules
       - run:
-          name: test
+          name: Test
           command: npm test
   lint:
     docker:
-      - image:  circleci/node
+      - image: circleci/node
     steps:
       - checkout
       - restore_cache:
@@ -34,5 +34,5 @@ jobs:
           paths:
             - ./node_modules
       - run:
-          name: test
+          name: Lint
           command: npm run lint

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,10 @@ engines:
         - python
         - php
   eslint:
+    # Disabled since this engine used a different set of version of
+    # `@typescript/eslint` and `typescript`
+    #
+    # @see https://github.com/i18next/i18next/pull/2098
     enabled: false
     channel: "eslint-8"
   fixme:


### PR DESCRIPTION
Follow up to #2098.

Added a `lint` to job to `circleci` and disabled eslint on `codeclimate`

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
