### PR TITLE
fix types for array access

### DIFF
--- a/test/typescript/array-access/i18next.d.ts
+++ b/test/typescript/array-access/i18next.d.ts
@@ -1,0 +1,37 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'main';
+    resources: {
+      main: {
+        arrayOfStrings: ['zero', 'one'];
+        arrayOfObjects: [
+          { foo: 'bar' },
+          { fizz: 'buzz' },
+          [{ test: 'success'; sub: { deep: 'still success' } }],
+        ];
+      };
+      ctx: {
+        dessert: [
+          {
+            dessert_cake: 'a nice cake';
+            dessert_muffin_one: 'a nice muffin';
+            dessert_muffin_other: '{{count}} nice muffins';
+          },
+        ];
+      };
+
+      ord: {
+        ord: [
+          {
+            place_ordinal_one: '1st place';
+            place_ordinal_two: '2nd place';
+            place_ordinal_few: '3rd place';
+            place_ordinal_other: '{{count}}th place';
+          },
+        ];
+      };
+    };
+  }
+}

--- a/test/typescript/array-access/t.test.ts
+++ b/test/typescript/array-access/t.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expectTypeOf, assertType } from 'vitest';
+import { TFunction } from 'i18next';
+
+describe('t', () => {
+  describe('main', () => {
+    const t = (() => '') as TFunction<['main']>;
+
+    it('works with simple usage', () => {
+      expectTypeOf(t('arrayOfStrings.0')).toEqualTypeOf<'zero'>();
+      expectTypeOf(t('arrayOfStrings.1')).toEqualTypeOf<'one'>();
+
+      expectTypeOf(t('arrayOfObjects.0.foo')).toEqualTypeOf<'bar'>();
+      expectTypeOf(t('arrayOfObjects.1.fizz')).toEqualTypeOf<'buzz'>();
+
+      expectTypeOf(t('arrayOfObjects.2.0.test')).toEqualTypeOf<'success'>();
+      expectTypeOf(t('arrayOfObjects.2.0.sub.deep')).toEqualTypeOf<'still success'>();
+    });
+
+    it('should throw an error when key is not present', () => {
+      // @ts-expect-error expected error
+      assertType(t('arrayOfStrings.2'));
+
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.0.food'));
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.0.fizz'));
+
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.2'));
+
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.2.bar'));
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.2.sub.deep'));
+      // @ts-expect-error expected error
+      assertType(t('arrayOfObjects.2.test'));
+    });
+
+    it('should work with `returnObjects`', () => {
+      expectTypeOf(t('arrayOfStrings', { returnObjects: true })).toBeArray();
+      expectTypeOf(t('arrayOfObjects', { returnObjects: true })).toEqualTypeOf<
+        [{ foo: 'bar' }, { fizz: 'buzz' }, [{ test: 'success'; sub: { deep: 'still success' } }]]
+      >();
+      expectTypeOf(t('arrayOfObjects.0', { returnObjects: true })).toEqualTypeOf<{ foo: 'bar' }>();
+    });
+
+    it('should work with const keys', () => {
+      const alternateTranslationKeys = ['arrayOfStrings.0', 'arrayOfObjects.0.foo'] as const;
+
+      const result = alternateTranslationKeys.map((value) => t(value));
+
+      assertType<string[]>(result);
+    });
+  });
+
+  it('should work with context', () => {
+    const t = (() => '') as TFunction<'ctx'>;
+
+    expectTypeOf(t('dessert.0.dessert', { context: 'cake' })).toEqualTypeOf<'a nice cake'>();
+
+    // context + plural
+    expectTypeOf(t('dessert.0.dessert', { context: 'muffin', count: 3 })).toMatchTypeOf<string>();
+  });
+
+  it('should process ordinal plurals', () => {
+    const t = (() => '') as TFunction<'ord'>;
+
+    expectTypeOf(t('ord.0.place', { ordinal: true, count: 1 })).toBeString();
+    expectTypeOf(t('ord.0.place', { ordinal: true, count: 2 })).toBeString();
+    expectTypeOf(t('ord.0.place', { ordinal: true, count: 3 })).toBeString();
+    expectTypeOf(t('ord.0.place', { ordinal: true, count: 4 })).toBeString();
+  });
+});

--- a/test/typescript/array-access/tsconfig.json
+++ b/test/typescript/array-access/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -54,7 +54,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-    : Res[Key] extends any[]
+    : Res[Key] extends unknown[]
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
@@ -64,7 +64,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-    : Res[Key] extends any[]
+    : Res[Key] extends unknown[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -175,7 +175,7 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-  Res extends any[]
+  Res extends unknown[]
   ? Key extends `${infer NKey extends number}`
     ? Res[NKey]
     : never

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -54,11 +54,17 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
+    : Res[Key] extends any[]
+    ?
+        | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
+        | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
     : never
   : never;
 
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
+    ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
+    : Res[Key] extends any[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -169,7 +175,11 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-    Res[Key & keyof Res];
+  Res extends any[]
+  ? Key extends `${infer NKey extends number}`
+    ? Res[NKey]
+    : never
+  : Res[Key & keyof Res];
 
 type TReturnOptionalNull = _ReturnNull extends true ? null : never;
 type TReturnOptionalObjects<TOpt extends TOptions> = _ReturnObjects extends true

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -54,7 +54,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-    : Res[Key] extends any[]
+    : Res[Key] extends unknown[]
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
@@ -64,7 +64,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-    : Res[Key] extends any[]
+    : Res[Key] extends unknown[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -175,7 +175,7 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-  Res extends any[]
+  Res extends unknown[]
   ? Key extends `${infer NKey extends number}`
     ? Res[NKey]
     : never

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -54,11 +54,17 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
+    : Res[Key] extends any[]
+    ?
+        | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
+        | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
     : never
   : never;
 
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
+    ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
+    : Res[Key] extends any[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -169,7 +175,11 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-    Res[Key & keyof Res];
+  Res extends any[]
+  ? Key extends `${infer NKey extends number}`
+    ? Res[NKey]
+    : never
+  : Res[Key & keyof Res];
 
 type TReturnOptionalNull = _ReturnNull extends true ? null : never;
 type TReturnOptionalObjects<TOpt extends TOptions> = _ReturnObjects extends true


### PR DESCRIPTION
The typing for accessing arrays was broken (yielding type errors on any access) and should be fixed with this PR. This should fix #2040 - I hope I spotted all the edge cases.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)