### PR TITLE
fix types for readonly array access

### DIFF
--- a/test/typescript/array-access/i18next.d.ts
+++ b/test/typescript/array-access/i18next.d.ts
@@ -6,6 +6,7 @@ declare module 'i18next' {
     resources: {
       main: {
         arrayOfStrings: ['zero', 'one'];
+        readonlyArrayOfStrings: readonly ['readonly zero', 'readonly one'];
         arrayOfObjects: [
           { foo: 'bar' },
           { fizz: 'buzz' },

--- a/test/typescript/array-access/t.test.ts
+++ b/test/typescript/array-access/t.test.ts
@@ -9,6 +9,9 @@ describe('t', () => {
       expectTypeOf(t('arrayOfStrings.0')).toEqualTypeOf<'zero'>();
       expectTypeOf(t('arrayOfStrings.1')).toEqualTypeOf<'one'>();
 
+      expectTypeOf(t('readonlyArrayOfStrings.0')).toEqualTypeOf<'readonly zero'>();
+      expectTypeOf(t('readonlyArrayOfStrings.1')).toEqualTypeOf<'readonly one'>();
+
       expectTypeOf(t('arrayOfObjects.0.foo')).toEqualTypeOf<'bar'>();
       expectTypeOf(t('arrayOfObjects.1.fizz')).toEqualTypeOf<'buzz'>();
 

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -54,7 +54,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-    : Res[Key] extends unknown[]
+    : Res[Key] extends readonly unknown[]
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
@@ -64,7 +64,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-    : Res[Key] extends unknown[]
+    : Res[Key] extends readonly unknown[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -175,7 +175,7 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-  Res extends unknown[]
+  Res extends readonly unknown[]
   ? Key extends `${infer NKey extends number}`
     ? Res[NKey]
     : never

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -54,7 +54,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-    : Res[Key] extends unknown[]
+    : Res[Key] extends readonly unknown[]
     ?
         | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
         | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
@@ -64,7 +64,7 @@ type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
 type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
   ? Res[Key] extends $Dictionary
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-    : Res[Key] extends unknown[]
+    : Res[Key] extends readonly unknown[]
     ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
     : Key
   : never;
@@ -175,7 +175,7 @@ type ParseTReturn<
     ? ParseTReturnPluralOrdinal<Res, Key>
     : ParseTReturnPlural<Res, Key>
   : // otherwise access plain key without adding plural and ordinal suffixes
-  Res extends unknown[]
+  Res extends readonly unknown[]
   ? Key extends `${infer NKey extends number}`
     ? Res[NKey]
     : never


### PR DESCRIPTION
I noticed one edge case was missing in yesterdays #2101 - it was an easy fix tho. Now the sandbox example provided in #2040 should actually be fixed as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)