### PR TITLE
fix: Use Typescript 5 types with Typescript 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "i18next internationalization framework",
   "main": "./dist/cjs/i18next.js",
   "module": "./dist/esm/i18next.js",
-  "types": "./index.v4.d.ts",
+  "types": "./index.d.ts",
   "typesVersions": {
     "<5.0": {
       "typescript/t.d.ts": [


### PR DESCRIPTION
#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [ ] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

Tests are still passing because the v5 types are also valid. I'm not sure how should I write a test to check if the type file used matches the typescript version. 