### PR TITLE
test: add `local` workspace

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,5 +22,4 @@ CONTRIBUTING.md
 .github
 .husky
 examples/
-vitest.config.mts
-vitest.workspace.mts
+vitest.*.mts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,16 @@ By making a contribution to this project, I certify that:
 
 ## Testing
 
-### `test/runtime/**/*.test.local.*`
+### Local tests
 
-The test files with the following pattern are meant to be executed and not on ci/cd envs.
+The test files within `test/local` are not meant to be executed on ci/cd envs
+so they have a separate vitest workspace definition: `vitest.workspace.local.mts`
+
+To run them simply use:
+
+```bash
+npm run test:local
+```
 
 ### Typescript
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "test:runtime": "vitest --workspace vitest.workspace.mts --project runtime",
     "test:compatibility": "vitest --workspace vitest.workspace.mts --project compatibility",
     "test:coverage": "npm run test:runtime -- --coverage --run",
+    "test:local": "vitest --workspace vitest.workspace.local.mts",
     "build": "rimraf dist && rollup -c && echo '{\"type\":\"module\"}' > dist/esm/package.json && cpy \"./dist/umd/*.js\" ./",
     "generate_ts_v4_index": "cp index.d.ts index.v4.d.ts && node -e \"fs.writeFileSync('index.v4.d.ts', fs.readFileSync('index.v4.d.ts').toString().replace(/t.js/g, 't.v4.js').replace(/export type \\* /g, '// export type * '))\"",
     "fix_dist_package": "node -e 'console.log(`{\"type\":\"module\",\"version\":\"${process.env.npm_package_version}\"}`)' > dist/esm/package.json",

--- a/test/local/backend/backendConnector.load.retry.test.js
+++ b/test/local/backend/backendConnector.load.retry.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, vitest } from 'vitest';
 import BackendConnector from '../../../src/BackendConnector.js';
 import Interpolator from '../../../src/Interpolator.js';
 import ResourceStore from '../../../src/ResourceStore.js';
-import BackendMock from './backendMock.js';
+import BackendMock from '../../runtime/backend/backendMock.js';
 
 /** Those are just skipped for ci/cd, but occasionally we run them locally */
 describe('BackendConnector load retry', () => {

--- a/test/local/backend/backendConnector.perfErrorRetries.test.js
+++ b/test/local/backend/backendConnector.perfErrorRetries.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vitest, beforeAll } from 'vitest';
 import BackendConnector from '../../../src/BackendConnector.js';
 import Interpolator from '../../../src/Interpolator.js';
 import ResourceStore from '../../../src/ResourceStore.js';
-import BackendMock from './backendMock.js';
+import BackendMock from '../../runtime/backend/backendMock.js';
 
 /** Those are just skipped for ci/cd, but occasionally we run them locally */
 describe('BackendConnector performance (retry) test', () => {

--- a/vitest.workspace.local.mts
+++ b/vitest.workspace.local.mts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineWorkspace } from 'vitest/config';
+
+/**
+ * See CONTRIBUTING.md for more information
+ */
+export default defineWorkspace([
+  {
+    test: {
+      name: 'local',
+      dir: './test/local',
+    },
+  },
+]);


### PR DESCRIPTION
Followup to #2017 [comment](https://github.com/i18next/i18next/pull/2107#issuecomment-1876921271):

What is the best way to run `test/runtime/**/*.test.local.*` tests? 

Now you can use:
```bash
npm run test:local
```

---

<img width="850" alt="Screenshot 2024-01-04 at 14 41 03" src="https://github.com/i18next/i18next/assets/24919330/a21cadba-b9e5-470a-b011-320cfcf24ed3">

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
