### PR TITLE
refactor: enable eslint in test directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
   env: {
@@ -41,45 +42,58 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
 
-    // Turned off due to codeclimate lacking support for this rules
-    '@typescript-eslint/naming-convention': 'off',
-    // '@typescript-eslint/naming-convention': [
-    //   'error',
-    //   {
-    //     selector: 'default',
-    //     format: ['camelCase'],
-    //     leadingUnderscore: 'allow',
-    //     trailingUnderscore: 'allow',
-    //   },
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'default',
+        format: ['camelCase'],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow',
+      },
 
-    //   {
-    //     selector: ['import', 'parameter'],
-    //     format: ['camelCase', 'PascalCase'],
-    //   },
+      {
+        selector: ['import', 'parameter'],
+        format: ['camelCase', 'PascalCase'],
+      },
 
-    //   {
-    //     selector: 'variable',
-    //     format: ['camelCase', 'UPPER_CASE'],
-    //     leadingUnderscore: 'allow',
-    //     trailingUnderscore: 'allow',
-    //   },
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow',
+      },
 
-    //   {
-    //     selector: 'typeLike',
-    //     format: ['PascalCase'],
-    //   },
+      {
+        selector: 'typeLike',
+        format: ['PascalCase'],
+      },
 
-    //   {
-    //     selector: 'interface',
-    //     format: ['PascalCase'],
-    //     filter: 'i18n',
-    //   },
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        filter: 'i18n',
+      },
 
-    //   {
-    //     selector: 'typeAlias',
-    //     format: ['PascalCase'],
-    //     leadingUnderscore: 'allow',
-    //   },
-    // ],
+      {
+        selector: 'typeAlias',
+        format: ['PascalCase'],
+        leadingUnderscore: 'allow',
+      },
+    ],
   },
+  overrides: [
+    {
+      files: ['./test/**/*'],
+      rules: {
+        '@typescript-eslint/naming-convention': 'off',
+        '@typescript-eslint/ban-ts-comment': [
+          'error',
+          {
+            // this is used for typechecking tests
+            'ts-expect-error': false,
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "vitest": "1.1.0"
   },
   "scripts": {
-    "lint": "eslint src typescript \"./*.{ts,mts}\"",
+    "lint": "eslint src typescript test \"./*.{ts,mts}\"",
     "pretest": "npm run generate_ts_v4_index && npm run lint",
     "test": "vitest --typecheck --workspace vitest.workspace.mts --run",
     "test:runtime": "vitest --workspace vitest.workspace.mts --project runtime",

--- a/test/compatibility/v1.js
+++ b/test/compatibility/v1.js
@@ -118,9 +118,7 @@ export function appendBackwardsAPI(i18n) {
     // logger.deprecate('i18next.lng() can be replaced by i18next.language for detected language or i18next.languages for languages ordered by translation lookup.');
     i18n.services.languageUtils.toResolveHierarchy(i18n.language)[0];
 
-  i18n.hasLoadedNamespace = function () {
-    return true;
-  };
+  i18n.hasLoadedNamespace = () => true;
 
   i18n.preload = (lngs, cb) => {
     // logger.deprecate('i18next.preload() can be replaced with i18next.loadLanguages()');

--- a/test/runtime/backend/backendMockPromise.js
+++ b/test/runtime/backend/backendMockPromise.js
@@ -9,6 +9,7 @@ class BackendMockPromise {
     this.created = {};
   }
 
+  // eslint-disable-next-line class-methods-use-this
   read(language, namespace) {
     return new Promise((resolve) => {
       setTimeout(() => {
@@ -34,7 +35,9 @@ class BackendMockPromise {
         options,
       };
     });
-    return new Promise((resolve) => setTimeout(() => resolve(), 15));
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(), 15);
+    });
   }
 }
 

--- a/test/runtime/backend/backendMockSync.js
+++ b/test/runtime/backend/backendMockSync.js
@@ -9,6 +9,7 @@ class BackendMockSync {
     this.created = {};
   }
 
+  // eslint-disable-next-line class-methods-use-this
   read(language, namespace) {
     return { status: 'ok', language, namespace };
   }

--- a/test/runtime/i18next.extendTranslation.test.js
+++ b/test/runtime/i18next.extendTranslation.test.js
@@ -38,8 +38,8 @@ describe('extendTranslation', () => {
       },
     ];
 
-    tests.forEach((test, i) => {
-      it('it ' + test.name, () => {
+    tests.forEach((test) => {
+      it(`it ${test.name}`, () => {
         instance
           .use({
             type: 'i18nFormat',

--- a/test/runtime/interpolation.test.js
+++ b/test/runtime/interpolation.test.js
@@ -338,57 +338,27 @@ describe('Interpolator', () => {
 
     const tests = [
       {
-        args: [
-          'test $t(test)',
-          function () {
-            return 'success';
-          },
-        ],
+        args: ['test $t(test)', () => 'success'],
         expected: 'test success',
       },
       {
-        args: [
-          '$t(test, {"key": "success"})',
-          function (key, opts) {
-            return `test ${opts.key}`;
-          },
-        ],
+        args: ['$t(test, {"key": "success"})', (key, opts) => `test ${opts.key}`],
         expected: 'test success',
       },
       {
-        args: [
-          "$t(test, {'key': 'success'})",
-          function (key, opts) {
-            return `test ${opts.key}`;
-          },
-        ],
+        args: ["$t(test, {'key': 'success'})", (key, opts) => `test ${opts.key}`],
         expected: 'test success',
       },
       {
-        args: [
-          '$t(test, is, {"key": "success"})',
-          function (key, opts) {
-            return `test, is ${opts.key}`;
-          },
-        ],
+        args: ['$t(test, is, {"key": "success"})', (key, opts) => `test, is ${opts.key}`],
         expected: 'test, is success',
       },
       {
-        args: [
-          '$t(test, is, ok)',
-          function () {
-            return 'test, is, ok';
-          },
-        ],
+        args: ['$t(test, is, ok)', () => 'test, is, ok'],
         expected: 'test, is, ok',
       },
       {
-        args: [
-          '$t(ns:test)',
-          function () {
-            return 'test from ns';
-          },
-        ],
+        args: ['$t(ns:test)', () => 'test from ns'],
         expected: 'test from ns',
       },
     ];

--- a/test/runtime/translator/translator.cimode.test.js
+++ b/test/runtime/translator/translator.cimode.test.js
@@ -42,7 +42,7 @@ describe('Translator', () => {
       t.changeLanguage('cimode');
     });
 
-    var tests = [
+    const tests = [
       {
         args: [
           'translation:test',
@@ -68,7 +68,7 @@ describe('Translator', () => {
     ];
 
     tests.forEach((test) => {
-      it('correctly return key for ' + JSON.stringify(test.args) + ' args in cimode', () => {
+      it(`correctly return key for ${JSON.stringify(test.args)} args in cimode`, () => {
         expect(t.translate.apply(t, test.args)).toEqual(test.expected);
       });
     });

--- a/test/runtime/translator/translator.exists.test.js
+++ b/test/runtime/translator/translator.exists.test.js
@@ -47,7 +47,7 @@ describe('Translator', () => {
       t.changeLanguage('en');
     });
 
-    var tests = [
+    const tests = [
       { args: ['translation:test'], expected: true },
       { args: ['translation:test', { lngs: ['en-US', 'en'] }], expected: true },
       { args: ['translation:test', { lngs: ['de'] }], expected: true },
@@ -60,7 +60,7 @@ describe('Translator', () => {
     ];
 
     tests.forEach((test) => {
-      it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+      it(`correctly translates for ${JSON.stringify(test.args)} args`, () => {
         expect(t.exists.apply(t, test.args)).toEqual(test.expected);
       });
     });
@@ -69,7 +69,7 @@ describe('Translator', () => {
 
     nullishArgs.forEach((nullishArg) => {
       it(`should return false if a "${nullishArg}" key is passed as an argument`, () => {
-        expect(t.exists(nullishArg)).to.false;
+        expect(t.exists(nullishArg)).toBeFalsy();
       });
     });
   });

--- a/test/runtime/translator/translator.translate.separator.test.js
+++ b/test/runtime/translator/translator.translate.separator.test.js
@@ -53,7 +53,7 @@ describe('Translator', () => {
       t.changeLanguage('en');
     });
 
-    var tests = [
+    const tests = [
       { args: ['translation:::test'], expected: 'test_en' },
       { args: ['translation2:::test'], expected: 'test2_en' },
       { args: ['translation:::deep::test'], expected: 'testDeep_en' },
@@ -71,7 +71,7 @@ describe('Translator', () => {
     ];
 
     tests.forEach((test) => {
-      it('correctly translates for ' + JSON.stringify(test.args) + ' args', () => {
+      it(`correctly translates for ${JSON.stringify(test.args)} args`, () => {
         expect(t.translate.apply(t, test.args)).toEqual(test.expected);
       });
     });

--- a/test/typescript/array-access/t.test.ts
+++ b/test/typescript/array-access/t.test.ts
@@ -19,22 +19,22 @@ describe('main', () => {
   });
 
   it('should throw an error when key is not present', () => {
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfStrings.2'));
 
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.0.food'));
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.0.fizz'));
 
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.2'));
 
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.2.bar'));
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.2.sub.deep'));
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('arrayOfObjects.2.test'));
   });
 
@@ -78,7 +78,7 @@ describe("don't break prefixes", () => {
     const t = (() => '') as TFunction<'prefix', 'deep'>;
     expectTypeOf(t('deep.deep')).toEqualTypeOf<string>();
 
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(t('morning'));
   });
 
@@ -99,7 +99,7 @@ describe("don't break prefixes", () => {
 
     expectTypeOf(use).toEqualTypeOf<{ t: TFunction<'prefix', 'deep'> }>();
 
-    // @ts-expect-error expected error
+    // @ts-expect-error
     assertType(use.t('morning'));
   });
 });

--- a/test/typescript/custom-types/mock.test.ts
+++ b/test/typescript/custom-types/mock.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { assertType, describe } from 'vitest';
 import { TFunction, WithT, CustomTypeOptions } from 'i18next';
 
 describe('WithT', () => {
   const resources = {} as CustomTypeOptions['resources'];
 
-  const mockWithTAndResources: WithT<'custom'> = {
+  assertType<WithT<'custom'>>({
     t: ((key) => {
       const keyValue = resources.custom.bar;
-      return keyValue;
+      return keyValue + key;
     }) as TFunction<'custom'>,
-  };
+  });
 });

--- a/test/typescript/many-keys/parseKeys.perf.ts
+++ b/test/typescript/many-keys/parseKeys.perf.ts
@@ -2,3 +2,6 @@ import { t, ParseKeys } from 'i18next';
 
 const getKey: () => ParseKeys<['generic']> = () => 'ahTLUS';
 const result = t(getKey());
+
+// eslint-disable-next-line no-console
+console.info(result);

--- a/test/typescript/misc/exposed.test.ts
+++ b/test/typescript/misc/exposed.test.ts
@@ -25,11 +25,11 @@ describe('exposed', () => {
     type Callback = (lng: string, ns: string) => void;
 
     expectTypeOf(resourceStore.on).parameters.toMatchTypeOf<['added' | 'removed', Callback]>();
-    expectTypeOf(resourceStore.on).returns.toBeVoid;
+    expectTypeOf(resourceStore.on).returns.toBeVoid();
 
     expectTypeOf(resourceStore.off).parameter(0).toMatchTypeOf<'added' | 'removed'>();
     expectTypeOf(resourceStore.off).parameter(1).toMatchTypeOf<Callback | undefined>();
-    expectTypeOf(resourceStore.off).returns.toBeVoid;
+    expectTypeOf(resourceStore.off).returns.toBeVoid();
   });
 
   describe('formatter', () => {
@@ -37,22 +37,22 @@ describe('exposed', () => {
 
     assertType<Formatter | undefined>(formatter);
 
-    expectTypeOf(formatter!.add).parameters.toMatchTypeOf<
+    expectTypeOf(formatter?.add).parameters.toMatchTypeOf<
       [string, (value: any, lng: string | undefined, options: any) => string]
     >();
-    expectTypeOf(formatter!.add).returns.toBeVoid();
+    expectTypeOf(formatter?.add).returns.toBeVoid();
 
-    expectTypeOf(formatter!.addCached).parameters.toMatchTypeOf<
+    expectTypeOf(formatter?.addCached).parameters.toMatchTypeOf<
       [string, (lng: string | undefined, options: any) => (value: any) => string]
     >();
-    expectTypeOf(formatter!.addCached).returns.toBeVoid();
+    expectTypeOf(formatter?.addCached).returns.toBeVoid();
   });
 
   describe('eventEmitter', () => {
     expectTypeOf(i18next.on).parameters.toMatchTypeOf<[string, (...args: unknown[]) => void]>();
-    expectTypeOf(i18next.on).returns.toBeVoid;
+    expectTypeOf(i18next.on).returns.toBeVoid();
 
     expectTypeOf(i18next.emit).parameters.toMatchTypeOf<[string, ...unknown[]]>();
-    expectTypeOf(i18next.emit).returns.toBeVoid;
+    expectTypeOf(i18next.emit).returns.toBeVoid();
   });
 });

--- a/test/typescript/misc/init.test.ts
+++ b/test/typescript/misc/init.test.ts
@@ -1,489 +1,398 @@
-import i18next, { TFunction, createInstance } from 'i18next';
+import { describe, it, assertType, expectTypeOf } from 'vitest';
+import i18next, { InitOptions, TFunction, createInstance } from 'i18next';
 
-// i18next.js export default as esm module because the build is apart from commonjs.
-i18next.init(
-  {
-    lng: 'en',
-    debug: true,
-    resources: {
-      en: {
-        translation: {
-          key: 'hello world',
+describe('init', () => {
+  describe('initOptions', () => {
+    it('should accept `initImmediate`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        initImmediate: false,
+      });
+    });
+
+    it('should accept `fallbackLng`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        fallbackLng: 'en',
+      });
+
+      expectTypeOf(i18next.init).toBeCallableWith({
+        fallbackLng: ['fr', 'en'],
+      });
+
+      // depending on user language
+      // fallback depending on user language
+      expectTypeOf(i18next.init).toBeCallableWith({
+        fallbackLng: {
+          'de-CH': ['fr', 'it'],
+          'zh-HANT': ['zh-HANS', 'en'],
+          es: ['fr'],
+          default: ['en'],
         },
-        key: 'hello world',
-      },
-    },
-    ignoreJSONStructure: false,
-  },
-  (err, t) => {
-    // initialized and ready to go!
-    const value: string = t('key');
-  },
-);
+      });
+    });
 
-i18next.init({ initImmediate: false });
-
-i18next.init(
-  {
-    lng: 'en',
-    debug: true,
-    resources: {
-      en: {
-        translation: {
-          key: 'hello world',
+    it('should accept `resources`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        resources: {
+          en: {
+            namespace1: {
+              key: 'hello from namespace 1',
+            },
+            namespace2: {
+              key: 'hello from namespace 2',
+            },
+          },
+          de: {
+            namespace1: {
+              key: 'hallo von namespace 1',
+            },
+            namespace2: {
+              key: 'hallo von namespace 2',
+            },
+          },
         },
-      },
-      de: {
-        translation: {
-          key: 'hello welt',
+      });
+    });
+
+    it('should accept `lng`, `nsSeparator`, `keySeparator` and `fallbackLng`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        lng: 'de',
+
+        // allow keys to be phrases having `:`, `.`
+        nsSeparator: false,
+        keySeparator: false,
+
+        // do not load a fallback
+        fallbackLng: false,
+      });
+    });
+
+    it('should accept `backend` options', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        fallbackLng: 'en',
+        debug: true,
+        ns: ['special', 'common'],
+        defaultNS: 'special',
+        backend: {
+          // load from i18next-gitbook repo
+          loadPath:
+            'https://raw.githubusercontent.com/i18next/i18next-gitbook/master/locales/{{lng}}/{{ns}}.json',
+          crossDomain: true,
         },
-      },
-    },
-    ignoreJSONStructure: true,
-  },
-  // not necessary but check a non-inferred arg for paranoia's sake
-  (err, t: TFunction) => {
-    // init set content
-    updateContent();
-  },
-);
+      });
+    });
 
-i18next.init(
-  {
-    ns: ['common', 'moduleA', 'moduleB'] as const,
-    defaultNS: 'moduleA',
-  },
-  (err, t) => {
-    t('myKey'); // key in moduleA namespace (defined default)
-    t('common:myKey'); // key in common namespace
-  },
-);
+    it('should accept locize options', () => {
+      // Init with Locize options.
+      // From https://github.com/i18next/react-i18next/blob/master/example/locize/src/i18n.js
+      const locizeOptions = {
+        projectId: '',
+        apiKey: '',
+        referenceLng: 'en',
+      };
+      expectTypeOf(i18next.init).toBeCallableWith({
+        fallbackLng: 'en',
+        debug: true,
+        saveMissing: true,
 
-i18next.loadNamespaces('anotherNamespace', (err, t) => {
-  /* ... */
-});
+        interpolation: {
+          escapeValue: false, // not needed for react as it escapes by default
+        },
+        backend: locizeOptions,
+        locizeLastUsed: locizeOptions,
+        react: {
+          bindI18n: 'languageChanged editorSaved',
+        },
+      });
+    });
 
-// fallback to one language
-i18next.init(
-  {
-    lng: 'en-GB',
-  },
-  () => {
-    i18next.t('i18n'); // -> "Internationalisation"
-    i18next.t('i18n_short'); // -> "i18n" (from en.json)
+    it('should accept `react`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        react: {
+          hashTransKey: (defaultValue) => {
+            if (typeof defaultValue === 'string') {
+              return defaultValue.replace(/\s+/g, '_');
+            }
 
-    // force loading en
-    i18next.t('i18n', { lng: 'en' }); // -> "Internationalization"
-  },
-);
+            throw new Error("Don't know how to make key for non-string defaultValue");
+          },
+        },
+      });
+    });
 
-// fallback to one language
-i18next.init({
-  fallbackLng: 'en',
-});
+    it('should accept `resources` and `interpolation`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        lng: 'en',
+        fallbackLng: 'en',
 
-// fallback ordered
-i18next.init({
-  fallbackLng: ['fr', 'en'],
-});
+        resources: {
+          en: {
+            translation: {
+              key1: 'test',
+              interpolateKey: 'add {{insert}} {{up, uppercase}}',
+              interpolateKey2: '<strong>add</strong> {{insert}} {{up, uppercase}}',
+            },
+          },
+        },
 
-// fallback depending on user language
-i18next.init({
-  fallbackLng: {
-    'de-CH': ['fr', 'it'],
-    'zh-HANT': ['zh-HANS', 'en'],
-    es: ['fr'],
-    default: ['en'],
-  },
-});
+        interpolation: {
+          escapeValue: false, // not needed for react!!
+          formatSeparator: ',',
+          format: (value) => value,
+        },
+      });
+    });
 
-const updateContent = () => {
-  const value: string = i18next.t('key');
-};
-
-const changeLng = (lng: string) => {
-  i18next.changeLanguage(lng);
-};
-
-i18next.init(
-  {
-    // files to load
-    ns: ['app', 'common'],
-
-    // default namespace (needs no prefix on calling t)
-    defaultNS: 'app',
-
-    // fallback, can be a string or an array of namespaces
-    fallbackNS: 'common',
-  },
-  () => {
-    i18next.t('title'); // -> "i18next"
-
-    i18next.t('button.save'); // -> "save" (fallback from common)
-
-    // without fallbackNS you would have to prefix namespace
-    // to access keys in that namespace
-    i18next.t('common:button.save'); // -> "save"
-  },
-);
-
-i18next.init({
-  lng: 'de',
-
-  // allow keys to be phrases having `:`, `.`
-  nsSeparator: false,
-  keySeparator: false,
-
-  // do not load a fallback
-  fallbackLng: false,
-});
-
-const languageChangedCallback = () => {
-  updateContent();
-};
-
-i18next.on('languageChanged', languageChangedCallback);
-i18next.off('languageChanged', languageChangedCallback);
-
-i18next.init(
-  {
-    fallbackLng: 'en',
-    debug: true,
-    ns: ['special', 'common'],
-    defaultNS: 'special',
-    backend: {
-      // load from i18next-gitbook repo
-      loadPath:
-        'https://raw.githubusercontent.com/i18next/i18next-gitbook/master/locales/{{lng}}/{{ns}}.json',
-      crossDomain: true,
-    },
-  },
-  (err, t) => {
-    // init set content
-    updateContent2();
-  },
-);
-
-// just set some content and react to language changes
-// could be optimized using vue-i18next, jquery-i18next, react-i18next, ...
-const updateContent2 = () => {
-  const value: string = i18next.t('title', { what: 'i18next' });
-  const value2: string = i18next.t('common:button.save', {
-    count: Math.floor(Math.random() * 2 + 1),
+    it('should infer namespace from initOptions', () => {
+      i18next.init(
+        {
+          ns: ['common', 'moduleA', 'moduleB'] as const,
+          defaultNS: 'moduleA',
+        },
+        (err, t) => {
+          // key in moduleA namespace (defined default)
+          assertType<string>(t('myKey'));
+          // key in common namespace
+          assertType<string>(t('common:myKey'));
+        },
+      );
+    });
   });
-  const value3 = `detected user language: "${
-    i18next.language
-  }"  --> loaded languages: "${i18next.languages.join(', ')}"`;
-};
 
-i18next.init(
-  {
-    fallbackLng: 'en',
-    ns: ['file1', 'file2'],
-    defaultNS: 'file1',
-    debug: true,
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+  it('should provide t function on ready callback', () => {
+    // i18next.js export default as esm module because the build is apart from commonjs.
+    i18next.init(
+      {
+        lng: 'en',
+        debug: true,
+        resources: {
+          en: {
+            translation: {
+              key: 'hello world',
+            },
+            key: 'hello world',
+          },
+        },
+        ignoreJSONStructure: false,
+      },
+      (err, t) => {
+        // not necessary but check a non-inferred arg for paranoia's sake
+        assertType<TFunction>(t);
+        // initialized and ready to go!
+        assertType<string>(t('key'));
+      },
+    );
+  });
 
-// with only callback
-i18next.init((err, t) => {
-  if (err) {
-    console.log('something went wrong loading', err);
-    return;
-  }
-  t('key'); // -> same as i18next.t
-});
+  describe('`loadNamespaces`', () => {
+    i18next.loadNamespaces('anotherNamespace', (err, t) => {
+      assertType<any>(err);
+      assertType<TFunction>(t);
+    });
 
-const v: string = i18next.t('my.key');
+    const cb = () => {};
+    expectTypeOf(i18next.loadNamespaces).toBeCallableWith('myNamespace', cb);
+    expectTypeOf(i18next.loadNamespaces).toBeCallableWith(['myNamespace1', 'myNamespace2'], cb);
 
-// fix language to german
-const de = i18next.getFixedT('de');
-const z: string = de('myKey');
+    expectTypeOf(i18next.loadLanguages).toBeCallableWith('de', cb);
+    expectTypeOf(i18next.loadLanguages).toBeCallableWith(['de', 'fr'], cb);
+  });
 
-// verify we can get the German data
-const data = i18next.getDataByLanguage('de');
+  it('`reloadResources`', () => {
+    // due to function overload can't use .toBeCallableWith
 
-// verify the data.translation field exists
-console.log(data ? data.translation.myKey : 'data does not exist');
+    // reload all
+    i18next.reloadResources();
 
-// verify the field for a specific namespace exists
-console.log(data ? data.common.myKey : 'data does not exist');
+    // reload languages
+    i18next.reloadResources(['de', 'fr'] as const);
 
-// or fix the namespace to anotherNamespace
-const anotherNamespace = i18next.getFixedT(null, 'anotherNamespace');
-const x: string = anotherNamespace('anotherNamespaceKey'); // no need to prefix ns i18n.t('anotherNamespace:anotherNamespaceKey');
+    // reload namespaces for all languages
+    i18next.reloadResources(null, ['ns1', 'ns2']);
 
-i18next.changeLanguage('en', (err, t) => {
-  if (err) {
-    console.log('something went wrong loading', err);
-    return;
-  }
-  t('key'); // -> same as i18next.t
-});
+    // reload namespaces in languages
+    i18next.reloadResources(['de', 'fr'], ['ns1', 'ns2']);
+  });
 
-i18next.loadNamespaces('myNamespace', (err, t) => {
-  /* resources have been loaded */
-});
-i18next.loadNamespaces(['myNamespace1', 'myNamespace2'], (err, t) => {
-  /* resources have been loaded */
-});
+  it('`dir`', () => {
+    type Dir = 'ltr' | 'rtl';
+    // for current language
+    assertType<Dir>(i18next.dir());
 
-i18next.loadLanguages('de', (err, t) => {
-  /* resources have been loaded */
-});
-i18next.loadLanguages(['de', 'fr'], (err, t) => {
-  /* resources have been loaded */
-});
+    // for another language
+    assertType<Dir>(i18next.dir('en-US'));
+    assertType<Dir>(i18next.dir('ar'));
+  });
 
-// reload all
-i18next.reloadResources();
+  it('`getDataByLanguage`', () => {
+    const data = i18next.getDataByLanguage('de');
+    assertType<Record<string, Record<string, string>> | undefined>(data);
 
-// reload languages
-i18next.reloadResources(['de', 'fr'] as const);
+    assertType<string | undefined>(data?.translation.myKey);
+    assertType<string | undefined>(data?.common.myKey);
+  });
 
-// reload namespaces for all languages
-i18next.reloadResources(null, ['ns1', 'ns2']);
+  it('`getFixedT`', () => {
+    const anotherNamespace = i18next.getFixedT(null, 'anotherNamespace');
+    // no need to prefix ns i18n.t('anotherNamespace:anotherNamespaceKey')
+    assertType<string>(anotherNamespace('anotherNamespaceKey'));
+  });
 
-// reload namespaces in languages
-i18next.reloadResources(['de', 'fr'], ['ns1', 'ns2']);
+  it('`changeLanguage`', () => {
+    i18next.changeLanguage('en', (err, t) => {
+      assertType<any>(err);
+      assertType<TFunction>(t);
+    });
+  });
 
-// for current language
-i18next.dir();
+  describe('`EventEmitter`', () => {
+    it('should work with EventEmitter methods', () => {
+      expectTypeOf(i18next.on).toBeCallableWith('languageChanged', () => {});
+      expectTypeOf(i18next.off).toBeCallableWith('languageChanged', () => {});
+    });
 
-// for another language
-i18next.dir('en-US'); // -> "ltr";
-i18next.dir('ar'); // -> "rtl";
+    it('should have correct `initialized` event callback signature ', () => {
+      i18next.on('initialized', (options) => {
+        assertType<InitOptions>(options);
+      });
+    });
+    it('should have correct `loaded` event callback signature ', () => {
+      i18next.on('loaded', (loaded) => {
+        assertType<{ [language: string]: { [namespace: string]: boolean } }>(loaded);
+      });
+    });
+    it('should have correct `failedLoading` event callback signature ', () => {
+      i18next.on('failedLoading', (lng, ns, msg) => {
+        assertType<string>(lng);
+        assertType<string>(ns);
+        assertType<string>(msg);
+      });
+    });
+    it('should have correct `missingKey` event callback signature ', () => {
+      i18next.on('missingKey', (lngs, ns, key, res) => {
+        assertType<readonly string[]>(lngs);
+        assertType<string>(ns);
+        assertType<string>(key);
+        assertType<string>(res);
+      });
+    });
+    it('should have correct `added` event callback signature ', () => {
+      i18next.on('added', (lng, ns) => {
+        assertType<string>(lng);
+        assertType<string>(ns);
+      });
+    });
+    it('should have correct `removed` event callback signature ', () => {
+      i18next.on('removed', (lng, ns) => {
+        assertType<string>(lng);
+        assertType<string>(ns);
+      });
+    });
+    it('should have correct `languageChanged` event callback signature ', () => {
+      i18next.on('languageChanged', (lng) => {
+        assertType<string>(lng);
+      });
+    });
+    it('should have correct `customEvent` event callback signature ', () => {
+      i18next.on('customEvent', () => {});
+    });
+  });
 
-const newInstance = i18next.createInstance(
-  {
-    fallbackLng: 'en',
-    ns: ['file1', 'file2'] as const,
-    defaultNS: 'file1',
-    debug: true,
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+  it('store event emitter', () => {
+    i18next.store.on('added', (lng, ns) => {
+      assertType<string>(lng);
+      assertType<string>(ns);
+    });
+    i18next.store.on('removed', (lng, ns) => {
+      assertType<string>(lng);
+      assertType<string>(ns);
+    });
+  });
 
-// is the same as
-newInstance.init(
-  {
-    fallbackLng: 'en',
-    ns: ['file1', 'file2'],
-    defaultNS: 'file1',
-    debug: true,
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+  describe('resource store', () => {
+    it('`getResource`', () => {
+      expectTypeOf(i18next.getResource).toBeCallableWith('en', 'test', 'key');
+      expectTypeOf(i18next.getResource).toBeCallableWith('en', 'test', 'key', {
+        keySeparator: '-',
+        ignoreJSONStructure: false,
+      });
+    });
 
-const newInstance2 = i18next.cloneInstance(
-  {
-    fallbackLng: 'en',
-    ns: ['file1', 'file2'],
-    defaultNS: 'file1',
-    debug: true,
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+    it('`addResource`', () => {
+      expectTypeOf(i18next.addResource).toBeCallableWith('en', 'test', 'key', 'value');
+      expectTypeOf(i18next.addResource).toBeCallableWith('en', 'test', 'key', 'value', {
+        keySeparator: '-',
+        silent: false,
+      });
 
-// is the same as
-const newInstance3 = i18next.cloneInstance();
-newInstance.init(
-  {
-    fallbackLng: 'en',
-    ns: ['file1', 'file2'],
-    defaultNS: 'file1',
-    debug: true,
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+      expectTypeOf(i18next.addResources).toBeCallableWith('en', 'test', { key: 'value' });
+    });
 
-const cloneWithFork = i18next.cloneInstance(
-  {
-    forkResourceStore: true,
-    keySeparator: '__',
-  },
-  (err, t) => {
-    if (err) {
-      console.log('something went wrong loading', err);
-      return;
-    }
-    t('key'); // -> same as i18next.t
-  },
-);
+    it('`addResourceBundle`', () => {
+      expectTypeOf(i18next.addResourceBundle).toBeCallableWith(
+        'en',
+        'translations',
+        {
+          key: 'value',
+        },
+        true,
+        true,
+      );
+    });
 
-i18next.on('initialized', (options) => {});
-i18next.on('loaded', (loaded) => {});
-i18next.on('failedLoading', (lng: string, ns: string, msg: string) => {});
-i18next.on('missingKey', (lngs: string[], namespace: string, key: string, res: string) => {});
-i18next.on('added', (lng: string, ns: string) => {});
-i18next.on('removed', (lng: string, ns: string) => {});
-i18next.on('languageChanged', (lng: string) => {});
-i18next.on('customEvent', () => {});
+    it('`hasResourceBundle`', () => {
+      expectTypeOf(i18next.hasResourceBundle).toBeCallableWith('en', 'test');
+      expectTypeOf(i18next.hasResourceBundle).returns.toBeBoolean();
+    });
 
-i18next.store.on('added', (lng: string, ns: string) => {});
-i18next.store.on('removed', (lng: string, ns: string) => {});
+    it('`getResourceBundle`', () => {
+      expectTypeOf(i18next.getResourceBundle).toBeCallableWith('en', 'test');
+    });
 
-i18next.getResource('en', 'test', 'key');
-i18next.getResource('en', 'test', 'key', { keySeparator: '-', ignoreJSONStructure: false });
+    it('`removeResourceBundle`', () => {
+      expectTypeOf(i18next.removeResourceBundle).toBeCallableWith('en', 'test');
+    });
 
-i18next.addResource('en', 'test', 'key', 'value');
-i18next.addResource('en', 'test', 'key', 'value', {
-  keySeparator: '-',
-  silent: false,
-});
-
-i18next.addResources('en', 'test', { key: 'value' });
-
-i18next.addResourceBundle(
-  'en',
-  'translations',
-  {
-    key: 'value',
-  },
-  true,
-  true,
-);
-
-const has: boolean = i18next.hasResourceBundle('en', 'test');
-
-i18next.getResourceBundle('en', 'test');
-
-i18next.removeResourceBundle('en', 'test');
-
-i18next.init({
-  resources: {
-    en: {
-      namespace1: {
+    it('`addResourceBundle`', () => {
+      expectTypeOf(i18next.addResourceBundle).toBeCallableWith('en', 'namespace1', {
         key: 'hello from namespace 1',
+      });
+    });
+  });
+
+  it('`createInstance`', () => {
+    expectTypeOf(createInstance).toBeCallableWith({
+      lng: 'en',
+      fallbackLng: 'en',
+    });
+
+    const instance = createInstance();
+
+    expectTypeOf(instance.init).toBeCallableWith(
+      {
+        fallbackLng: 'en',
+        ns: ['file1', 'file2'] as const,
+        defaultNS: 'file1',
+        debug: true,
       },
-      namespace2: {
-        key: 'hello from namespace 2',
+      (err, t) => {
+        assertType<any>(err);
+        assertType<TFunction>(t);
       },
-    },
-    de: {
-      namespace1: {
-        key: 'hallo von namespace 1',
+    );
+  });
+
+  it('`cloneInstance`', () => {
+    expectTypeOf(i18next.cloneInstance().init).toBeCallableWith(
+      {
+        fallbackLng: 'en',
+        ns: ['file1', 'file2'],
+        defaultNS: 'file1',
+        debug: true,
       },
-      namespace2: {
-        key: 'hallo von namespace 2',
+      (err, t) => {
+        assertType<any>(err);
+        assertType<TFunction>(t);
       },
-    },
-  },
-});
-
-i18next.init();
-
-i18next.addResourceBundle('en', 'namespace1', {
-  key: 'hello from namespace 1',
-});
-
-i18next.init({
-  backend: {
-    // for all available options read the backend's repository readme file
-    loadPath: '/locales/{{lng}}/{{ns}}.json',
-  },
-});
-
-i18next.init({
-  ns: ['common', 'moduleA'],
-  defaultNS: 'moduleA',
-});
-
-i18next.init({
-  lng: 'en',
-  fallbackLng: 'en',
-
-  resources: {
-    en: {
-      translation: {
-        key1: 'test',
-        interpolateKey: 'add {{insert}} {{up, uppercase}}',
-        interpolateKey2: '<strong>add</strong> {{insert}} {{up, uppercase}}',
-      },
-    },
-  },
-
-  interpolation: {
-    escapeValue: false, // not needed for react!!
-    formatSeparator: ',',
-    format: (value, format, lng) => {
-      if (format === 'uppercase') {
-        return value.toUpperCase();
-      }
-      if (value instanceof Date) {
-        return value.toLocaleString();
-      }
-      return value;
-    },
-  },
-});
-
-i18next.init({
-  react: {
-    hashTransKey: (defaultValue) => {
-      if (typeof defaultValue === 'string') {
-        return defaultValue.replace(/\s+/g, '_');
-      }
-
-      throw new Error("Don't know how to make key for non-string defaultValue");
-    },
-  },
-});
-
-// Init with Locize options.
-// From https://github.com/i18next/react-i18next/blob/master/example/locize/src/i18n.js
-const locizeOptions = {
-  projectId: '',
-  apiKey: '',
-  referenceLng: 'en',
-};
-i18next.init({
-  fallbackLng: 'en',
-  debug: true,
-  saveMissing: true,
-
-  interpolation: {
-    escapeValue: false, // not needed for react as it escapes by default
-  },
-  backend: locizeOptions,
-  locizeLastUsed: locizeOptions,
-  react: {
-    bindI18n: 'languageChanged editorSaved',
-  },
-});
-
-createInstance({
-  lng: 'en',
-  fallbackLng: 'en',
+    );
+  });
 });

--- a/test/typescript/misc/modules.test.ts
+++ b/test/typescript/misc/modules.test.ts
@@ -88,11 +88,17 @@ describe('modules', () => {
         // exercise class usage
         // Need both static and member definitions of type to satisfy use() signature, see #1442
         class MyLoggerModule implements LoggerModule {
-          static type: 'logger' = 'logger';
-          type: 'logger' = 'logger';
+          static type = 'logger' as const;
+
+          type = 'logger' as const;
+
+          /* eslint-disable class-methods-use-this */
           log = () => null;
+
           warn = () => null;
+
           error = () => null;
+          /* eslint-enable class-methods-use-this */
         }
 
         expectTypeOf(i18next.use<MyLoggerModule>)

--- a/test/typescript/misc/t.test.ts
+++ b/test/typescript/misc/t.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, assertType, expectTypeOf } from 'vitest';
-import i18next, { InterpolationMap, TFunction } from 'i18next';
+import { describe, it, expectTypeOf } from 'vitest';
+import i18next, { TFunction } from 'i18next';
 
 describe('t', () => {
   it('basic usage', () => {
@@ -31,8 +31,7 @@ describe('t', () => {
       object | string[] | object[]
     >();
 
-    // @ts-expect-error
-    // this is not a string
+    // @ts-expect-error this is not a string
     expectTypeOf(t('friend', { returnObjects: true })).toEqualTypeOf<string>();
   });
 

--- a/test/typescript/misc/tGeneric.test.ts
+++ b/test/typescript/misc/tGeneric.test.ts
@@ -5,7 +5,7 @@ describe('tGeneric', () => {
   type Keys = 'friend' | 'tree';
 
   it('should accept keys via generic', () => {
-    const t = i18next.t<Keys, {}, string>;
+    const t = i18next.t<Keys, Record<string, unknown>, string>;
 
     expectTypeOf(t).parameter(0).toMatchTypeOf<string | string[]>();
     expectTypeOf(t).parameter(1).extract<object>().toMatchTypeOf<TOptions>();
@@ -15,7 +15,7 @@ describe('tGeneric', () => {
   });
 
   it('should work with interpolation values', () => {
-    const t = i18next.t<Keys, {}, '{{myVar}}'>;
+    const t = i18next.t<Keys, Record<string, unknown>, '{{myVar}}'>;
 
     expectTypeOf(t).parameter(0).toMatchTypeOf<string | string[]>();
     expectTypeOf(t).parameter(1).extract<object>().toMatchTypeOf<Record<string, unknown>>();


### PR DESCRIPTION
ESLint now includes also `test` directory

The most notable change is `test/typescript/misc/init.test.ts` rewrite.
During #2097 I have miss out the file so it wasn't using any type assertion.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
