### PR TITLE
fix(types): typescript joinArrays support

### DIFF
--- a/test/typescript/array-access/i18next.d.ts
+++ b/test/typescript/array-access/i18next.d.ts
@@ -12,6 +12,11 @@ declare module 'i18next' {
           { fizz: 'buzz' },
           [{ test: 'success'; sub: { deep: 'still success' } }],
         ];
+        arrayJoinWithInterpolation_one: ['{{myName}}, You have', '{{count}}', 'email'];
+        arrayJoinWithInterpolation_other: ['{{myName}}, You have', '{{count}}', 'emails'];
+        key_one: 'item';
+        key_other: 'items';
+        nestedArrayJoin: [['line1', 'line2', 'line3']];
       };
       ctx: {
         dessert: [

--- a/test/typescript/array-access/t.test.ts
+++ b/test/typescript/array-access/t.test.ts
@@ -46,6 +46,24 @@ describe('main', () => {
     expectTypeOf(t('arrayOfObjects.0', { returnObjects: true })).toEqualTypeOf<{ foo: 'bar' }>();
   });
 
+  it('should work with `count`', () => {
+    expectTypeOf(t('key', { count: 1 })).toEqualTypeOf<'item' | 'items'>();
+  });
+
+  it('should work with `joinArrays`', () => {
+    expectTypeOf(t('arrayOfStrings', { joinArrays: '+' })).toEqualTypeOf<'zero+one'>();
+    expectTypeOf(t('arrayOfObjects', { joinArrays: '+' })).toEqualTypeOf<never>();
+    expectTypeOf(t('nestedArrayJoin.0', { joinArrays: '/' })).toEqualTypeOf<'line1/line2/line3'>();
+    expectTypeOf(
+      t('arrayJoinWithInterpolation', { count: 2, myName: 'Claude', joinArrays: ' ' }),
+    ).toEqualTypeOf<
+      '{{myName}}, You have {{count}} email' | '{{myName}}, You have {{count}} emails'
+    >();
+    expectTypeOf(
+      t('readonlyArrayOfStrings', { joinArrays: ',' }),
+    ).toEqualTypeOf<'readonly zero,readonly one'>();
+  });
+
   it('should work with const keys', () => {
     const alternateTranslationKeys = ['arrayOfStrings.0', 'arrayOfObjects.0.foo'] as const;
 

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -3,3 +3,10 @@ export type $Dictionary<T = unknown> = { [key: string]: T };
 export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof any[]> : Arr;
 export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
 export type $SpecialObject = object | Array<string | object>;
+export type $PrependIfDefined<T extends string, S extends string> = T extends '' ? T : `${S}${T}`;
+export type $ConcatArray<T, S extends string, U = never> = T extends readonly [
+  infer F extends string,
+  ...infer R extends string[],
+]
+  ? `${F}${$PrependIfDefined<$ConcatArray<R, S, ''>, S>}`
+  : U;

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -101,6 +101,11 @@ export type TypeOptions = $MergeBy<
      * Suffix for interpolation
      */
     interpolationSuffix: '}}';
+
+    /**
+     * A string to separate each pair of adjacent elements of the array
+     */
+    joinArrays: false;
   },
   CustomTypeOptions
 >;


### PR DESCRIPTION
This fixes typing errors when using joinArrays on array types.

I'm not completely confident on the approach but I did my best to define a clear test suite that would demonstrate the issues I encountered. I'd be glad to discuss this through.

Here is a minimum reproducible example of the initial problem: https://codesandbox.io/p/sandbox/18n-basic-example-2-forked-7lgxrf?file=/src/App.tsx:10,11

![image](https://github.com/i18next/i18next/assets/4232218/4a91f532-55a1-4d1d-8238-adaf16a31531)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)