### PR TITLE
types: fix support for defaultNS as array (fixes #2118)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,16 +36,11 @@ npm run test:local
 
 ### Typescript
 
-To run all typescript test run
+If you want to run only a specific project use `--project` flag.
+As value provide `ts-` followed by the folder name
 
 ```bash
-npm run test:typescript
-```
-
-If you want to run only a specific project
-
-```bash
-npm run test:typescript -- --project many-keys
+npx vitest --project ts-custom-types
 ```
 
 #### New Test scenario

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // Internal Helpers
-import type { $Dictionary } from './typescript/helpers.js';
+import type { $Dictionary, $NormalizeIntoArray } from './typescript/helpers.js';
 import type {
   DefaultNamespace,
   FlatNamespace,
@@ -219,10 +219,20 @@ export interface CloneOptions extends InitOptions {
 
 export interface CustomInstanceExtenstions {}
 
+// Used just here to exclude `DefaultNamespace` which can be both string or array from `FlatNamespace`
+// in TFunction declaration below.
+// Due to this only very special usage I'm not moving this inside helpers.
+type InferArrayValuesElseReturnType<T> = T extends (infer A)[] ? A : T;
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface i18n extends CustomInstanceExtenstions {
   // Expose parameterized t in the i18next interface hierarchy
-  t: TFunction<[DefaultNamespace, ...Exclude<FlatNamespace, DefaultNamespace>[]]>;
+  t: TFunction<
+    [
+      ...$NormalizeIntoArray<DefaultNamespace>,
+      ...Exclude<FlatNamespace, InferArrayValuesElseReturnType<DefaultNamespace>>[],
+    ]
+  >;
 
   /**
    * The default of the i18next module is an i18next instance ready to be initialized by calling init.

--- a/test/typescript/array-access/i18next.d.ts
+++ b/test/typescript/array-access/i18next.d.ts
@@ -13,6 +13,7 @@ declare module 'i18next' {
           [{ test: 'success'; sub: { deep: 'still success' } }],
         ];
       };
+
       ctx: {
         dessert: [
           {
@@ -24,24 +25,15 @@ declare module 'i18next' {
       };
 
       prefix: {
-        greeting: string;
-        timeOfDay: {
-          morning: string;
-          afternoon: string;
-        };
-        parent: {
-          parent: string;
-          other: string;
-        };
         deep: {
-          deep: {
-            deep: string;
+          deeper: {
+            extra_deep: string;
           };
         };
       };
 
       ord: {
-        ord: [
+        list: [
           {
             place_ordinal_one: '1st place';
             place_ordinal_two: '2nd place';

--- a/test/typescript/array-access/t.test.ts
+++ b/test/typescript/array-access/t.test.ts
@@ -67,17 +67,20 @@ it('should work with context', () => {
 it('should process ordinal plurals', () => {
   const t = (() => '') as TFunction<'ord'>;
 
-  expectTypeOf(t('ord.0.place', { ordinal: true, count: 1 })).toBeString();
-  expectTypeOf(t('ord.0.place', { ordinal: true, count: 2 })).toBeString();
-  expectTypeOf(t('ord.0.place', { ordinal: true, count: 3 })).toBeString();
-  expectTypeOf(t('ord.0.place', { ordinal: true, count: 4 })).toBeString();
+  expectTypeOf(t('list.0.place', { ordinal: true, count: 1 })).toBeString();
+  expectTypeOf(t('list.0.place', { ordinal: true, count: 2 })).toBeString();
+  expectTypeOf(t('list.0.place', { ordinal: true, count: 3 })).toBeString();
+  expectTypeOf(t('list.0.place', { ordinal: true, count: 4 })).toBeString();
 });
 
 describe("don't break prefixes", () => {
-  it('does not allow access to morning', () => {
-    const t = (() => '') as TFunction<'prefix', 'deep'>;
-    expectTypeOf(t('deep.deep')).toEqualTypeOf<string>();
+  const t = (() => '') as TFunction<'prefix', 'deep'>;
 
+  it('should work with key prefix', () => {
+    expectTypeOf(t('deeper.extra_deep')).toEqualTypeOf<string>();
+  });
+
+  it('does not allow access to key not existing in prefix', () => {
     // @ts-expect-error
     assertType(t('morning'));
   });

--- a/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
+++ b/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
@@ -1,64 +1,37 @@
 import 'i18next';
 
+import {
+  TestNamespaceContext,
+  TestNamespacePlurals,
+  TestNamespaceOrdinal,
+  TestNamespaceCustom,
+  TestNamespaceCustomAlternate,
+  TestNamespaceFallback,
+  TestNamespaceNonPlurals,
+} from '../test.namespace.samples';
+
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: ['custom', 'custom_b'];
     fallbackNS: 'fallback';
     resources: {
-      custom: {
-        foo: 'foo';
-        bar: 'bar';
-        baz: {
-          bing: 'boop';
-        };
-        qux: 'some {{val, number}}';
-        inter: 'some {{val}}';
-        nullKey: null;
-      };
+      custom: TestNamespaceCustom;
+
       custom_b: {
         another_entry: 'Argh';
       };
-      alternate: {
-        baz: 'baz';
-        foobar: {
-          barfoo: 'barfoo';
-          deep: {
-            deeper: {
-              deeeeeper: 'foobar';
-            };
-          };
-        };
-      };
-      fallback: {
-        fallbackKey: 'fallback';
-      };
-      plurals: {
-        foo_zero: 'foo';
-        foo_one: 'foo';
-        foo_two: 'foo';
-        foo_many: 'foo';
-        foo_other: 'foo';
-      };
-      nonPlurals: {
-        test: 'Test';
-        test_2: 'Test 2';
-        // 'test_form.title': 'title';
-        test_form: {
-          title: 'title';
-        };
-      };
-      ctx: {
-        foo: 'foo';
-        dessert_cake: 'a nice cake';
-        dessert_muffin_one: 'a nice muffin';
-        dessert_muffin_other: '{{count}} nice muffins';
-      };
-      ord: {
-        place_ordinal_one: '1st place';
-        place_ordinal_two: '2nd place';
-        place_ordinal_few: '3rd place';
-        place_ordinal_other: '{{count}}th place';
-      };
+
+      alternate: TestNamespaceCustomAlternate;
+
+      fallback: TestNamespaceFallback;
+
+      plurals: TestNamespacePlurals;
+
+      nonPlurals: TestNamespaceNonPlurals;
+
+      ctx: TestNamespaceContext;
+
+      ord: TestNamespaceOrdinal;
     };
   }
 }

--- a/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
+++ b/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
@@ -1,0 +1,64 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: ['custom', 'custom_b'];
+    fallbackNS: 'fallback';
+    resources: {
+      custom: {
+        foo: 'foo';
+        bar: 'bar';
+        baz: {
+          bing: 'boop';
+        };
+        qux: 'some {{val, number}}';
+        inter: 'some {{val}}';
+        nullKey: null;
+      };
+      custom_b: {
+        another_entry: 'Argh';
+      };
+      alternate: {
+        baz: 'baz';
+        foobar: {
+          barfoo: 'barfoo';
+          deep: {
+            deeper: {
+              deeeeeper: 'foobar';
+            };
+          };
+        };
+      };
+      fallback: {
+        fallbackKey: 'fallback';
+      };
+      plurals: {
+        foo_zero: 'foo';
+        foo_one: 'foo';
+        foo_two: 'foo';
+        foo_many: 'foo';
+        foo_other: 'foo';
+      };
+      nonPlurals: {
+        test: 'Test';
+        test_2: 'Test 2';
+        // 'test_form.title': 'title';
+        test_form: {
+          title: 'title';
+        };
+      };
+      ctx: {
+        foo: 'foo';
+        dessert_cake: 'a nice cake';
+        dessert_muffin_one: 'a nice muffin';
+        dessert_muffin_other: '{{count}} nice muffins';
+      };
+      ord: {
+        place_ordinal_one: '1st place';
+        place_ordinal_two: '2nd place';
+        place_ordinal_few: '3rd place';
+        place_ordinal_other: '{{count}}th place';
+      };
+    };
+  }
+}

--- a/test/typescript/custom-types-default-ns-as-array/i18nextT.test.ts
+++ b/test/typescript/custom-types-default-ns-as-array/i18nextT.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, assertType, expectTypeOf } from 'vitest';
+import i18next from 'i18next';
+
+describe('i18next.t', () => {
+  it('should work with standard keys', () => {
+    expectTypeOf(i18next.t('bar', {})).toEqualTypeOf<'bar'>();
+    expectTypeOf(i18next.t('bar')).toEqualTypeOf<'bar'>();
+
+    expectTypeOf(i18next.t('foobar.barfoo', { ns: 'alternate' })).toEqualTypeOf<'barfoo'>();
+    expectTypeOf(i18next.t('alternate:foobar.barfoo')).toEqualTypeOf<'barfoo'>();
+
+    expectTypeOf(i18next.t('custom:bar')).toEqualTypeOf<'bar'>();
+    expectTypeOf(i18next.t('bar', { ns: 'custom' })).toEqualTypeOf<'bar'>();
+
+    expectTypeOf(i18next.t('baz.bing')).toEqualTypeOf<'boop'>();
+
+    expectTypeOf(i18next.t('alternate:foobar.barfoo')).toEqualTypeOf<'barfoo'>();
+  });
+
+  it('should throw error when key is not defined in namespace', () => {
+    // @ts-expect-error
+    assertType(i18next.t('bar', { ns: 'alternate' }));
+  });
+
+  it('should work with `returnObjects`', () => {
+    type AlternateFoobarDeepResult = {
+      deeper: {
+        deeeeeper: 'foobar';
+      };
+    };
+
+    // i18next.t('alternate:foobar.deep').deeper.deeeeeper; // i18next would say: "key 'foobar.deep (en)' returned an object instead of string."
+    expectTypeOf(
+      i18next.t('alternate:foobar.deep', { returnObjects: true }),
+    ).toEqualTypeOf<AlternateFoobarDeepResult>();
+    expectTypeOf(
+      i18next.t('foobar.deep', { ns: 'alternate', returnObjects: true }),
+    ).toEqualTypeOf<AlternateFoobarDeepResult>();
+    expectTypeOf(
+      i18next.t('foobar.deep', { ns: 'alternate', returnObjects: true, returnDetails: true }).res,
+    ).toEqualTypeOf<AlternateFoobarDeepResult>();
+  });
+
+  describe('interpolation', () => {
+    it('should work with passing along values', () => {
+      expectTypeOf(i18next.t('custom:inter', { val: 'asdf' })).toEqualTypeOf<'some {{val}}'>();
+      expectTypeOf(
+        i18next.t('inter', { val: 'asdf', ns: 'custom' }),
+      ).toEqualTypeOf<'some {{val}}'>();
+      expectTypeOf(i18next.t('inter', { val: 'asdf' })).toEqualTypeOf<'some {{val}}'>();
+      expectTypeOf(i18next.t('qux', { val: 'asdf' })).toEqualTypeOf<'some {{val, number}}'>();
+    });
+
+    it('should throw an error when value is not present inside key', () => {
+      // @ts-expect-error
+      assertType(i18next.t('custom:inter', { foo: 'asdf' }));
+    });
+  });
+
+  it('should work with default value', () => {
+    expectTypeOf(
+      i18next.t('custom:bar', { defaultValue: 'some default value' }),
+    ).toMatchTypeOf<unknown>();
+    expectTypeOf(i18next.t('custom:bar', 'some default value')).toMatchTypeOf<unknown>();
+    expectTypeOf(
+      i18next.t('bar', { ns: 'custom', defaultValue: 'some default value' }),
+    ).toMatchTypeOf<unknown>();
+    expectTypeOf(i18next.t('bar', { defaultValue: 'some default value' })).toMatchTypeOf<unknown>();
+    expectTypeOf(i18next.t('bar', 'some default value')).toMatchTypeOf<unknown>();
+  });
+
+  it('should accept any key if default vale is provided', () => {
+    const str: string = i18next.t('unknown-ns:unknown-key', 'default value');
+    assertType<string>(str);
+  });
+
+  it('should work with null translations', () => {
+    expectTypeOf(i18next.t('nullKey')).toBeNull();
+  });
+
+  it('should work with plurals', () => {
+    expectTypeOf(i18next.t('plurals:foo', { count: 1 })).toBeString();
+    expectTypeOf(i18next.t('plurals:foo_many', { count: 10 })).toBeString();
+  });
+
+  it('should throw error with invalid key', () => {
+    // @ts-expect-error
+    assertType(i18next.t('custom:test'));
+  });
+
+  it('should throw error with invalid namespace', () => {
+    // @ts-expect-error
+    assertType(i18next.t('test:bar'));
+  });
+});

--- a/test/typescript/custom-types-default-ns-as-array/t.test.ts
+++ b/test/typescript/custom-types-default-ns-as-array/t.test.ts
@@ -13,6 +13,14 @@ describe('t', () => {
       expectTypeOf(t('baz.bing')).toEqualTypeOf<'boop'>();
     });
 
+    it('should work with keys from both default namespaces', () => {
+      expectTypeOf(t('custom:bar')).toEqualTypeOf<'bar'>();
+      expectTypeOf(t('bar')).toEqualTypeOf<'bar'>();
+
+      expectTypeOf(t('custom_b:another_entry')).toEqualTypeOf<'Argh'>();
+      expectTypeOf(t('another_entry', { ns: 'custom_b' })).toEqualTypeOf<'Argh'>();
+    });
+
     it('should work with `returnObjects`', () => {
       expectTypeOf(t('baz', { returnObjects: true })).toEqualTypeOf<{
         bing: 'boop';
@@ -25,7 +33,8 @@ describe('t', () => {
 
       // @ts-expect-error
       assertType(t('baz'));
-
+      // @ts-expect-error
+      assertType(t('custom:foobar'));
       // @ts-expect-error
       assertType(t('foobar'));
     });
@@ -177,8 +186,6 @@ describe('t', () => {
 
     expectTypeOf(tOrdinal).not.toMatchTypeOf(tPlurals);
     expectTypeOf(tOrdPlurals).not.toMatchTypeOf(tPlurals);
-
     expectTypeOf(tPluralsOrd).toMatchTypeOf(tPlurals);
-    expectTypeOf(tPluralsOrd).not.toEqualTypeOf(tPlurals);
   });
 });

--- a/test/typescript/custom-types-default-ns-as-array/tsconfig.json
+++ b/test/typescript/custom-types-default-ns-as-array/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/test/typescript/custom-types-json-v3/i18next.d.ts
+++ b/test/typescript/custom-types-json-v3/i18next.d.ts
@@ -1,49 +1,33 @@
 import 'i18next';
 
+import {
+  TestNamespaceCustom,
+  TestNamespaceCustomAlternate,
+  TestNamespaceFallback,
+  TestNamespaceNonPlurals,
+} from '../test.namespace.samples';
+
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
     fallbackNS: 'fallback';
     jsonFormat: 'v3';
     resources: {
-      custom: {
-        foo: 'foo';
-        bar: 'bar';
-        baz: {
-          bing: 'boop';
-        };
-        qux: 'some {{val, number}}';
-        inter: 'some {{val}}';
-        nullKey: null;
-      };
-      fallback: {
-        fallbackKey: 'fallback';
-      };
-      alternate: {
-        baz: 'baz';
-        foobar: {
-          barfoo: 'barfoo';
-          deep: {
-            deeper: {
-              deeeeeper: 'foobar';
-            };
-          };
-        };
-      };
+      custom: TestNamespaceCustom;
+
+      fallback: TestNamespaceFallback;
+
+      alternate: TestNamespaceCustomAlternate;
+
       plurals: {
         foo: 'foo';
         foo_1: 'foo';
         foo_2: 'foo';
         foo_plural: 'foo';
       };
-      nonPlurals: {
-        test: 'Test';
-        test_2: 'Test 2';
-        // 'test_form.title': 'title';
-        test_form: {
-          title: 'title';
-        };
-      };
+
+      nonPlurals: TestNamespaceNonPlurals;
+
       ctx: {
         foo: 'foo';
         foo_plural: 'foos';
@@ -51,6 +35,7 @@ declare module 'i18next' {
         dessert_muffin: 'a nice muffin';
         dessert_muffin_plural: '{{count}} nice muffins';
       };
+
       ord: {
         place_ordinal_1: '1st place';
         place_ordinal_2: '2nd place';

--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -1,61 +1,33 @@
 import 'i18next';
 
+import {
+  TestNamespaceContext,
+  TestNamespacePlurals,
+  TestNamespaceOrdinal,
+  TestNamespaceCustom,
+  TestNamespaceCustomAlternate,
+  TestNamespaceFallback,
+  TestNamespaceNonPlurals,
+} from '../test.namespace.samples';
+
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'custom';
     fallbackNS: 'fallback';
     resources: {
-      custom: {
-        foo: 'foo';
-        bar: 'bar';
-        baz: {
-          bing: 'boop';
-        };
-        qux: 'some {{val, number}}';
-        inter: 'some {{val}}';
-        nullKey: null;
-      };
-      alternate: {
-        baz: 'baz';
-        foobar: {
-          barfoo: 'barfoo';
-          deep: {
-            deeper: {
-              deeeeeper: 'foobar';
-            };
-          };
-        };
-      };
-      fallback: {
-        fallbackKey: 'fallback';
-      };
-      plurals: {
-        foo_zero: 'foo';
-        foo_one: 'foo';
-        foo_two: 'foo';
-        foo_many: 'foo';
-        foo_other: 'foo';
-      };
-      nonPlurals: {
-        test: 'Test';
-        test_2: 'Test 2';
-        // 'test_form.title': 'title';
-        test_form: {
-          title: 'title';
-        };
-      };
-      ctx: {
-        foo: 'foo';
-        dessert_cake: 'a nice cake';
-        dessert_muffin_one: 'a nice muffin';
-        dessert_muffin_other: '{{count}} nice muffins';
-      };
-      ord: {
-        place_ordinal_one: '1st place';
-        place_ordinal_two: '2nd place';
-        place_ordinal_few: '3rd place';
-        place_ordinal_other: '{{count}}th place';
-      };
+      custom: TestNamespaceCustom;
+
+      alternate: TestNamespaceCustomAlternate;
+
+      fallback: TestNamespaceFallback;
+
+      ctx: TestNamespaceContext;
+
+      plurals: TestNamespacePlurals;
+
+      nonPlurals: TestNamespaceNonPlurals;
+
+      ord: TestNamespaceOrdinal;
     };
   }
 }

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -25,8 +25,7 @@ describe('t', () => {
 
       // @ts-expect-error
       assertType(t('baz'));
-      // @ts-expect-error
-      assertType(t('custom:bar'));
+
       // @ts-expect-error
       assertType(t('foobar'));
     });

--- a/test/typescript/many-keys/PERF_README.md
+++ b/test/typescript/many-keys/PERF_README.md
@@ -13,7 +13,7 @@ cd test/typescript/many-keys
 Then run tsc
 
 ```bash
-tsc time tsc --noEmit
+time tsc --noEmit
 ```
 
 Alternatively you can also debug using [ts trace](https://github.com/microsoft/typescript-analyze-trace)

--- a/test/typescript/test.namespace.samples.ts
+++ b/test/typescript/test.namespace.samples.ts
@@ -1,0 +1,56 @@
+export type TestNamespaceCustom = {
+  foo: 'foo';
+  bar: 'bar';
+  baz: {
+    bing: 'boop';
+  };
+  qux: 'some {{val, number}}';
+  inter: 'some {{val}}';
+  nullKey: null;
+};
+
+export type TestNamespaceCustomAlternate = {
+  baz: 'baz';
+  foobar: {
+    barfoo: 'barfoo';
+    deep: {
+      deeper: {
+        deeeeeper: 'foobar';
+      };
+    };
+  };
+};
+
+export type TestNamespaceFallback = {
+  fallbackKey: 'fallback';
+};
+
+export type TestNamespaceOrdinal = {
+  place_ordinal_one: '1st place';
+  place_ordinal_two: '2nd place';
+  place_ordinal_few: '3rd place';
+  place_ordinal_other: '{{count}}th place';
+};
+
+export type TestNamespaceContext = {
+  dessert_cake: 'a nice cake';
+  dessert_muffin_one: 'a nice muffin';
+  dessert_muffin_other: '{{count}} nice muffins';
+};
+
+export type TestNamespacePlurals = {
+  foo_zero: 'foo';
+  foo_one: 'foo';
+  foo_two: 'foo';
+  foo_many: 'foo';
+  foo_other: 'foo';
+};
+
+export type TestNamespaceNonPlurals = {
+  test: 'Test';
+  test_2: 'Test 2';
+  // 'test_form.title': 'title';
+  test_form: {
+    title: 'title';
+  };
+};

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -1,5 +1,15 @@
-export type $MergeBy<T, K> = Omit<T, keyof K> & K;
+// Types
+
 export type $Dictionary<T = unknown> = { [key: string]: T };
-export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof any[]> : Arr;
-export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
+
 export type $SpecialObject = object | Array<string | object>;
+
+// Types Operators
+
+export type $MergeBy<T, K> = Omit<T, keyof K> & K;
+
+export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof any[]> : Arr;
+
+export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
+
+export type $NormalizeIntoArray<T extends unknown | unknown[]> = T extends unknown[] ? T : [T];

--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -41,7 +41,7 @@ export default defineWorkspace([
         workspaces.push({
           test: {
             dir: `./${dirPath}`,
-            name: `typescript-${workspaceName}`,
+            name: `ts-${workspaceName}`,
             typecheck: {
               enabled: true,
               include: [`**/${dirPath}/*.test.ts`],


### PR DESCRIPTION
Fixes #2118.

The main difference from #2119 is that I tried to take into account all namespaces included in `defaultNS` when providing it as an array.

----

Before marking this PR ready for review I would like to see what I can do to deduce test code. 
I hope to have something ready tomorrow.

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)