### PR TITLE
types: fix typo in `CustomInstanceExtensions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -217,10 +217,10 @@ export interface CloneOptions extends InitOptions {
   forkResourceStore?: boolean;
 }
 
-export interface CustomInstanceExtenstions {}
+export interface CustomInstanceExtensions {}
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export interface i18n extends CustomInstanceExtenstions {
+export interface i18n extends CustomInstanceExtensions {
   // Expose parameterized t in the i18next interface hierarchy
   t: TFunction<[DefaultNamespace, ...Exclude<FlatNamespace, DefaultNamespace>[]]>;
 


### PR DESCRIPTION
During #2121 I noticed a typo in `CustomInstanceExtensions` so I corrected it.
I don't know if this should be considered a breaking change or a bug but there is no mention in the doc of this interface (https://www.i18next.com/?q=CustomInstanceExtensions), hence I think it can be considered a fix.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- (N/A) tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
