### PR TITLE
types: support readonly defaultNS

### DIFF
--- a/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
+++ b/test/typescript/custom-types-default-ns-as-array/i18next.d.ts
@@ -12,7 +12,7 @@ import {
 
 declare module 'i18next' {
   interface CustomTypeOptions {
-    defaultNS: ['custom', 'custom_b'];
+    defaultNS: Readonly<['custom', 'custom_b']>;
     fallbackNS: 'fallback';
     resources: {
       custom: TestNamespaceCustom;

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -12,4 +12,4 @@ export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof a
 
 export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
 
-export type $NormalizeIntoArray<T extends unknown | unknown[]> = T extends unknown[] ? T : [T];
+export type $NormalizeIntoArray<T extends unknown | readonly unknown[]> = T extends readonly unknown[] ? T : [T];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Follow-up of #2121 to also allow defaultNS to be readonly (This is the case when using `as const` on the defaultNS definitions and using typeof defaultNS in the types)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)