### PR TITLE
Improve performance by reducing array slices and RegExp recreation

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -32,19 +32,21 @@ class EventEmitter {
 
   emit(event, ...args) {
     if (this.observers[event]) {
-      for (const [observer, numTimesAdded] of this.observers[event].entries()) {
+      const cloned = Array.from(this.observers[event].entries());
+      cloned.forEach(([observer, numTimesAdded]) => {
         for (let i = 0; i < numTimesAdded; i++) {
           observer(...args);
         }
-      }
+      });
     }
 
     if (this.observers['*']) {
-      for (const [observer, numTimesAdded] of this.observers['*'].entries()) {
+      const cloned = Array.from(this.observers['*'].entries());
+      cloned.forEach(([observer, numTimesAdded]) => {
         for (let i = 0; i < numTimesAdded; i++) {
           observer.apply(observer, [event, ...args]);
         }
-      }
+      });
     }
   }
 }

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -70,15 +70,23 @@ class Interpolator {
   }
 
   resetRegExp() {
-    // the regexp
-    const regexpStr = `${this.prefix}(.+?)${this.suffix}`;
-    this.regexp = new RegExp(regexpStr, 'g');
+    const getOrResetRegExp = (existingRegExp, pattern) => {
+      if (existingRegExp && existingRegExp.source === pattern) {
+        existingRegExp.lastIndex = 0;
+        return existingRegExp;
+      }
+      return new RegExp(pattern, 'g');
+    };
 
-    const regexpUnescapeStr = `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${this.suffix}`;
-    this.regexpUnescape = new RegExp(regexpUnescapeStr, 'g');
-
-    const nestingRegexpStr = `${this.nestingPrefix}(.+?)${this.nestingSuffix}`;
-    this.nestingRegexp = new RegExp(nestingRegexpStr, 'g');
+    this.regexp = getOrResetRegExp(this.regexp, `${this.prefix}(.+?)${this.suffix}`);
+    this.regexpUnescape = getOrResetRegExp(
+      this.regexpUnescape,
+      `${this.prefix}${this.unescapePrefix}(.+?)${this.unescapeSuffix}${this.suffix}`,
+    );
+    this.nestingRegexp = getOrResetRegExp(
+      this.nestingRegexp,
+      `${this.nestingPrefix}(.+?)${this.nestingSuffix}`,
+    );
   }
 
   interpolate(str, data, lng, options) {

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -37,13 +37,20 @@ class ResourceStore extends EventEmitter {
         ? options.ignoreJSONStructure
         : this.options.ignoreJSONStructure;
 
-    let path = [lng, ns];
-    if (key && typeof key !== 'string') path = path.concat(key);
-    if (key && typeof key === 'string')
-      path = path.concat(keySeparator ? key.split(keySeparator) : key);
-
+    let path;
     if (lng.indexOf('.') > -1) {
       path = lng.split('.');
+    } else {
+      path = [lng, ns];
+      if (key) {
+        if (Array.isArray(key)) {
+          path.push(...key);
+        } else if (typeof key === 'string' && keySeparator) {
+          path.push(...key.split(keySeparator));
+        } else {
+          path.push(key);
+        }
+      }
     }
 
     const result = utils.getPath(this.data, path);

--- a/test/runtime/eventEmitter.test.js
+++ b/test/runtime/eventEmitter.test.js
@@ -27,6 +27,19 @@ describe('i18next', () => {
       expect(disabledHandler).not.toHaveBeenCalled();
     });
 
+    it('should emit twice if a handler was attached twice', () => {
+      const calls = [];
+      const listener = (payload) => {
+        calls.push(payload);
+      };
+
+      emitter.on('events', listener);
+      emitter.on('events', listener);
+      emitter.emit('events', 1);
+
+      expect(calls).toEqual([1, 1]);
+    });
+
     it('it should emit wildcard', () => {
       expect.assertions(2);
 

--- a/test/runtime/utils.test.js
+++ b/test/runtime/utils.test.js
@@ -31,4 +31,30 @@ describe('utils', () => {
       expect(res).toEqual({ some: 'thing' });
     });
   });
+
+  describe('#deepFind', () => {
+    it('finds value for a basic path', () => {
+      const obj = { a: { b: { c: 1 } } };
+      const value = utils.deepFind(obj, 'a.b.c');
+      expect(value).toEqual(1);
+    });
+
+    it('finds no value for a non-existent path', () => {
+      const obj = { a: { b: { c: 1 } } };
+      const value = utils.deepFind(obj, 'a.b.d');
+      expect(value).toEqual(undefined);
+    });
+
+    it('finds value for a key that has a dot', () => {
+      const obj = { a: { 'b.b': { c: 1 } } };
+      const value = utils.deepFind(obj, 'a.b.b.c');
+      expect(value).toEqual(1);
+    });
+
+    it('finds value for an array index', () => {
+      const obj = { a: [{ c: 1 }] };
+      const value = utils.deepFind(obj, 'a.0.c');
+      expect(value).toEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

## Motivation

Our app recently switched to using i18next. It works great, but the app felt slower. We have hundreds of strings on-screen at a time, so i18next code is run a lot.

After profiling, some i18next functions were the top contributors to time taken within our 20s stacktrace:

- `off`: used by react-i18next (and base library i18next) for detaching event handlers on unmount. It looks like it calls a array.filter according to [source code](https://github.com/i18next/i18next/blob/26844609a8bfa8db7b7c62b58329f3e9a7a3694a/src/EventEmitter.js#L14). This may be iterating through a very large array
- `getLastOfPath`: 158ms - [code](https://github.com/i18next/i18next/blob/26844609a8bfa8db7b7c62b58329f3e9a7a3694a/src/utils.js#L29) does a lot of recursive retrieval and also creates a RegExp, which may take longer
- `looksLikeObjectPath`: 293ms - [code](https://github.com/i18next/i18next/blob/26844609a8bfa8db7b7c62b58329f3e9a7a3694a/src/utils.js#L138) constructs RegExp
- `getResource`: 221ms - [code](https://github.com/i18next/i18next/blob/26844609a8bfa8db7b7c62b58329f3e9a7a3694a/src/ResourceStore.js#L31) runs concat and `deepFind`, which does a lot of O(n) array operations

Looking at the causes, the 2 main causes are:

1. Linear time array operations like `.slice`, `.concat`
2. RegExp construction, which may be slow in the React Native Android runtime in particular

## Fix

- Change EventEmitter to use a Map instead of an array, changing `off` from an `O(n)` to `O(1)`
- Cache regular expression construction for `looksLikeObjectPath`
    - Store expressions in a Map, there are only 32 possible `RegExp` that can be constructed so memory is trivial
- Improve performance of `resetRegExp`
    - Rather than creating a `new RegExp` every time, just set `lastIndex = 0` to reset a global `RegExp` state
- Improve `deepFind` performance
    - Change recursive call to iterative
    - Perform less array copies and `slice` , use indexing and string appending instead of `join`
    - Changed parts from `O(n^2)` to `O(n)`
- Improve `getLastOfPath` performance
    - Don't create a `new RegExp` every time, set `lastIndex = 0`
    - Use regular indexing `O(1)` rather than `array.shift` `O(n)`
- Improve `getResource` performance
    - Don't copy arrays multiple times, just create array once and `push` items into it

## Testing

1. Added new automated tests for `deepFind` and `eventEmitter.test.ts`
2. Used a branch of the code in our app and verified the performance improvements. The time spent in translation code decreased from about 700ms to 50-100ms in total