### PR TITLE
types: support nested keys in `InterpolationMap`

### DIFF
--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -8,6 +8,7 @@ import {
   TestNamespaceCustomAlternate,
   TestNamespaceFallback,
   TestNamespaceNonPlurals,
+  TestNamespaceInterpolators,
 } from '../test.namespace.samples';
 
 declare module 'i18next' {
@@ -28,6 +29,8 @@ declare module 'i18next' {
       nonPlurals: TestNamespaceNonPlurals;
 
       ord: TestNamespaceOrdinal;
+
+      interpolator: TestNamespaceInterpolators;
     };
   }
 }

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -21,7 +21,7 @@ describe('t', () => {
 
     it('should throw an error when keys are not defined', () => {
       // @ts-expect-error
-      assertType(t('inter', { wrongOrNoValPassed: 'xx' }));
+      assertType(t('do_not_exists', { wrongOrNoValPassed: 'xx' }));
 
       // @ts-expect-error
       assertType(t('baz'));
@@ -178,5 +178,49 @@ describe('t', () => {
     expectTypeOf(tOrdinal).not.toMatchTypeOf(tPlurals);
     expectTypeOf(tOrdPlurals).not.toMatchTypeOf(tPlurals);
     expectTypeOf(tPluralsOrd).toMatchTypeOf(tPlurals);
+  });
+
+  describe('should work with `InterpolatorMap`', () => {
+    const t = (() => '') as TFunction<['interpolator']>;
+
+    it('should allow anything when key is a string', () => {
+      expectTypeOf(t('just_a_string', { asd: '', beep: 'boop' }));
+    });
+
+    it('simple key', () => {
+      expectTypeOf(t('simple', { olim: 'yes' })).toEqualTypeOf<'This is {{olim}}'>();
+
+      // @ts-expect-error because nope isn't a valid key
+      expectTypeOf(t('simple', { nope: 'yes' })).toEqualTypeOf<'This is {{olim}}'>();
+    });
+
+    it('simple key (multiple)', () => {
+      type Expected = 'This has {{more}} than {{one}}';
+      expectTypeOf(t('simple_multiple_keys', { more: '', one: '' })).toEqualTypeOf<Expected>();
+
+      // @ts-expect-error one of the required keys is missing
+      expectTypeOf(t('simple_multiple_keys', { less: '', one: '' })).toEqualTypeOf<Expected>();
+    });
+
+    it('keypath', () => {
+      expectTypeOf(
+        t('keypath', { out: { there: 'yes' } }),
+      ).toEqualTypeOf<'Give me one day {{out.there}}'>();
+
+      expectTypeOf(
+        t('keypath_with_format', { out: { there: 'yes' } }),
+      ).toEqualTypeOf<'Give me one day {{out.there, format}}'>();
+    });
+
+    it('keypath deep', () => {
+      type Expected = '{{living.in.the}} in the sun';
+
+      expectTypeOf(t('keypath_deep', { living: { in: { the: 'yes' } } })).toEqualTypeOf<Expected>();
+
+      expectTypeOf(
+        // @ts-expect-error one of the required keys is missing
+        t('keypath_deep', { suffering: { in: { the: 'yes' } } }),
+      ).toEqualTypeOf<Expected>();
+    });
   });
 });

--- a/test/typescript/test.namespace.samples.ts
+++ b/test/typescript/test.namespace.samples.ts
@@ -55,3 +55,17 @@ export type TestNamespaceNonPlurals = {
     title: 'title';
   };
 };
+
+export type TestNamespaceInterpolators = {
+  just_a_string: string;
+
+  simple: 'This is {{olim}}';
+  simple_with_format: 'This is {{olim, format}}';
+  simple_multiple_keys: 'This has {{more}} than {{one}}';
+
+  keypath: 'Give me one day {{out.there}}';
+  keypath_with_format: 'Give me one day {{out.there, format}}';
+  keypath_multiple: '{{some.thing}} asd {{some.else}}';
+
+  keypath_deep: '{{living.in.the}} in the sun';
+};

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -12,4 +12,49 @@ export type $OmitArrayKeys<Arr> = Arr extends readonly any[] ? Omit<Arr, keyof a
 
 export type $PreservedValue<Value, Fallback> = [Value] extends [never] ? Fallback : Value;
 
-export type $NormalizeIntoArray<T extends unknown | readonly unknown[]> = T extends readonly unknown[] ? T : [T];
+export type $NormalizeIntoArray<T extends unknown | readonly unknown[]> =
+  T extends readonly unknown[] ? T : [T];
+
+/**
+ * @typeParam T
+ * @example
+ * ```
+ * $UnionToIntersection<{foo: {bar: string} | {asd: boolean}}> = {foo: {bar: string} & {asd: boolean}}
+ * ```
+ *
+ * @see https://stackoverflow.com/questions/50374908/transform-union-type-to-intersection-type
+ */
+type $UnionToIntersection<T> = (T extends unknown ? (k: T) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
+
+/**
+ * @typeParam TPath union of strings
+ * @typeParam TValue value of the record
+ * @example
+ * ```
+ * $StringKeyPathToRecord<'foo.bar' | 'asd'> = {foo: {bar: string} | {asd: boolean}}
+ * ```
+ */
+type $StringKeyPathToRecordUnion<
+  TPath extends string,
+  TValue,
+> = TPath extends `${infer TKey}.${infer Rest}`
+  ? { [Key in TKey]: $StringKeyPathToRecord<Rest, TValue> }
+  : { [Key in TPath]: TValue };
+
+/**
+ * Used to intersect output of {@link $StringKeyPathToRecordUnion}
+ *
+ * @typeParam TPath union of strings
+ * @typeParam TValue value of the record
+ * @example
+ * ```
+ * $StringKeyPathToRecord<'foo.bar' | 'asd'> = {foo: {bar: string} & {asd: boolean}}
+ * ```
+ */
+export type $StringKeyPathToRecord<TPath extends string, TValue> = $UnionToIntersection<
+  $StringKeyPathToRecordUnion<TPath, TValue>
+>;

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -1,4 +1,10 @@
-import type { $OmitArrayKeys, $PreservedValue, $Dictionary, $SpecialObject } from './helpers.js';
+import type {
+  $OmitArrayKeys,
+  $PreservedValue,
+  $Dictionary,
+  $SpecialObject,
+  $StringKeyPathToRecord,
+} from './helpers.js';
 import type {
   TypeOptions,
   Namespace,
@@ -140,9 +146,10 @@ type ParseInterpolationValues<Ret> =
         | (Value extends `${infer ActualValue},${string}` ? ActualValue : Value)
         | ParseInterpolationValues<Rest>
     : never;
-type InterpolationMap<Ret> = Record<
-  $PreservedValue<ParseInterpolationValues<Ret>, string>,
-  unknown
+
+type InterpolationMap<Ret> = $PreservedValue<
+  $StringKeyPathToRecord<ParseInterpolationValues<Ret>, unknown>,
+  Record<string, unknown>
 >;
 
 type ParseTReturnPlural<

--- a/typescript/t.v4.d.ts
+++ b/typescript/t.v4.d.ts
@@ -1,4 +1,10 @@
-import type { $OmitArrayKeys, $PreservedValue, $Dictionary, $SpecialObject } from './helpers.js';
+import type {
+  $OmitArrayKeys,
+  $PreservedValue,
+  $Dictionary,
+  $SpecialObject,
+  $StringKeyPathToRecord,
+} from './helpers.js';
 import type {
   TypeOptions,
   Namespace,
@@ -6,6 +12,9 @@ import type {
   DefaultNamespace,
   TOptions,
 } from './options.js';
+
+/** @todo consider to replace {} with Record<string, never> */
+/* eslint @typescript-eslint/ban-types: ['error', { types: { "{}": false } }] */
 
 // Type Options
 type _ReturnObjects = TypeOptions['returnObjects'];
@@ -20,9 +29,6 @@ type _Resources = TypeOptions['resources'];
 type _JSONFormat = TypeOptions['jsonFormat'];
 type _InterpolationPrefix = TypeOptions['interpolationPrefix'];
 type _InterpolationSuffix = TypeOptions['interpolationSuffix'];
-
-/** @todo consider to replace {} with Record<string, never> */
-/* eslint @typescript-eslint/ban-types: ['error', { types: { "{}": false } }] */
 
 type $IsResourcesDefined = [keyof _Resources] extends [never] ? false : true;
 type $ValueIfResourcesDefined<Value, Fallback> = $IsResourcesDefined extends true
@@ -140,9 +146,10 @@ type ParseInterpolationValues<Ret> =
         | (Value extends `${infer ActualValue},${string}` ? ActualValue : Value)
         | ParseInterpolationValues<Rest>
     : never;
-type InterpolationMap<Ret> = Record<
-  $PreservedValue<ParseInterpolationValues<Ret>, string>,
-  unknown
+
+type InterpolationMap<Ret> = $PreservedValue<
+  $StringKeyPathToRecord<ParseInterpolationValues<Ret>, unknown>,
+  Record<string, unknown>
 >;
 
 type ParseTReturnPlural<


### PR DESCRIPTION
Fixes #2014

Now `InterpolatorMap` parse the keys retrieved via `ParseInterpolationValues` creating a mapped type instead of a a `Record<string, unknown>`.

Here is a typescript playground where all types involved are available:

- Open [Playground](https://www.typescriptlang.org/play?ts=5.3.3#code/KYDwDg9gTgLgBDAnmYcAkAFKwDOwoBuwAJgGoCGANgK7AA8FNwANHAGJWUBG5AxgNYA+OAF44AbUa0AunFAxgAO2I4Ji4ESiyA-O048BcAFxwpwANwAoSwHoAVHctw7cAAJIUGclHIBbOAAqTi6uoH5glMDBcAAGcdFoAKqKAJYQigEQAJKKClB4vDBpinQA3gBmEBAmpTxQJjgwUCmKAOYAvnAAPnCl5DjEJlxVkeSK7e3CYhVVNXUNTS0dcABkvf2DcMMQo+Pt0XEx0dGueKgAFjAwYDhGNjaNfPwQmuWUEADuAHS8EL42AEdaI1ijgbABWAAMAGYAOwAFgAnJCABw2JpjHCVKC+AC01FS6VxHmAxIguJaeQKRSJJOCNksJPQyWKmRyVOAhWKdACUzgAAoAnIQAplKoCfxFJ9FHBdPz+CYAgBKUTCAgQFLEYxwdSaFXyJQqAVOOAKuAtcr4OBZZiWFUiNUa4gm3RZE0mXX4Ky2BwnEleHz+AJeGDnOAE4pwCDlOCNZptHB+5DAAN+QJmOAEKi0KMx0OobC-KDO5xuMK+CJRUuHBIAZUWbQA0sBECHzpkAEqc6DEOgAckqEC+dT73TgfY2fb5M2qvXmsYbyx6fQGQxGwDGEwO8WcDKZaHr8dazdb5FDne7xZZ6ToJuDZ7DBrFC6Ptrg6ezLEsfPvoeFoqNGI0FKC0rQCE92i+YDQKgOAu0adojnfXRSgkE9zRlcCW2kEwD0XE82wvIte3gmBWACMxhH2d8ajQlsMMCNscI-Jg4Hab17EcUtEjwLUYAgDCOUKKNqGuUTc16VxKBafh0EPJYCIfIie2vcZgiTTxvDTX8wwjdIJLjJZE1Ldxk1TIMMyzVjowQc4C0vEsQnLSttyQlw8KPRTzwgLtiP7Qdh28UcegnAYp1EXpBzmbwFiPTo1hXTZtl2Ldqx3OwGVASBYAQZM5PwltCJ8hyeTbf9DVUQy2nIyiIqSQkMmyXJ8GpbkTQ8hTCqU4riNU0qHxqz9BG-b0mQAfXZfBIEoM9iiwYByhSEAIr7UpSj7KxxsmqBptm9Ja2ocpFuWsQ+wmDbrHuOBAHBqQB4P7uh77qeu7bBsOAAFFiBSeB+Hoqyczs7AjFem7nrBx7GTyrt4DEAAiDZekSiZEYiUSIFYbFfDPCZYZBwAwalugmicJkmCesJkAzwbbdppRQzBwOhoamE1ofK58gNKKqOmAibmp2nY9sUebjvaaDFEtWCzFF0pebyGnigOo6lulmC4NwGBEJNZC4C198xwzJ9ALFiW4AAQUKagqCl5hgK5xDZXfc2YEtygMxMMxdffHpKeAamBdp+nGfV4a9e1T0oG9SGUGtPn5fSABZcgwCDmA+UwbA8EIEgzFvd8OqbLrvN8ns6B9v2ZoDz8GaZ1gJSlD5FEEN81b8rna8USVpWGwRRqh3BqEoGGY7l-3ikT5OmasK64AAPW0SwgA)
- Scroll down and edit string type on line 50 (`Ret` type)

From my basic test this shouldn't affect performance very much,
but I haven't conducted deep performance test so far.

Unfortunately this I haven't a real app scenario to test this since 
I am not using JSONs for translation so all my values are `string`.

If someone with the issue could test this it would be great. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

----

#### Off topic

@adrai sorry if I write here but I don't know a better place 😅
Thanks for the invite! I have a few ideas to share about some changes to the library and repo, 
if is ok for you I'll open an issue with more details in the upcoming days.
