### PR TITLE
fix: log error when Intl.PluralRules error

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -1200,6 +1200,7 @@
             type: options.ordinal ? 'ordinal' : 'cardinal'
           });
         } catch (err) {
+          this.logger.warn(err);
           return;
         }
       }


### PR DESCRIPTION
When using `i18next` in an environment where Intl and Intl.PluralRules are not available we need to polyfill them.

When using `intl` and `intl-pluralrules` package, we also need to include locale data for the language we want like `intl/locale-data/jsonp/fr.js` (see [here](https://github.com/andyearnshaw/Intl.js/tree/master?tab=readme-ov-file#intljs-and-browserifywebpack)). If we do not do it, pluralization will fail silently and we will only get a `no plural rule found for: fr` warn log. 

In this PR, I add a new log in the catch where we try to get the PluralRules. It helps debugging. It allowed to display a new and more explicit `No locale data has been provided` warn log in my case .

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)