### PR TITLE
types: remove const from ParseKeys Context type parameter and disable `skipLibCheck`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "rimraf": "5.0.5",
         "rollup": "^4.3.0",
         "sinon": "17.0.1",
-        "typescript": "5.1.3",
+        "typescript": "5.4.4",
         "vitest": "1.1.0"
       }
     },
@@ -11278,9 +11278,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20164,9 +20164,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "dev": true
     },
     "ufo": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "rimraf": "5.0.5",
     "rollup": "^4.3.0",
     "sinon": "17.0.1",
-    "typescript": "5.1.3",
+    "typescript": "5.4.4",
     "vitest": "1.1.0"
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,24 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
-    "lib": ["es6", "dom"],
+    "module": "ES6",
+    "target": "ES5",
+    "lib": ["ES6", "DOM"],
     "jsx": "react",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noEmit": true,
     "baseUrl": ".",
-    "paths": { "i18next": ["./index.d.mts"] },
+    "paths": {
+      "i18next": ["./index.d.mts"]
+    },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
+
+    /**
+     * setting this to `false` to throw an error when d.ts file trow an error
+     * @see https://github.com/i18next/i18next/issues/2168
+     */
+    "skipLibCheck": false
   }
 }

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -128,7 +128,7 @@ export type ParseKeys<
   KPrefix = undefined,
   Keys extends $Dictionary = KeysByTOptions<TOpt>,
   ActualNS extends Namespace = NsByTOptions<Ns, TOpt>,
-  const Context extends TOpt['context'] = TOpt['context'],
+  Context extends TOpt['context'] = TOpt['context'],
 > = $IsResourcesDefined extends true
   ? FilterKeysByContext<
       | ParseKeysByKeyPrefix<Keys[$FirstNamespace<ActualNS>], KPrefix>


### PR DESCRIPTION
Fixes #2168

- Remove `const` `Context` type parameter of `ParseKeys` type
- Update `typescript` to `5.4.4`
- to prevent silent error on `*.d.ts` that won't be catched by ts tests, 
  `tsconfig.json` `compilerOptions.skipLibCheck` has been changed to `false`.
- Update `tsconfig.json` `module` and `moduleResolution`  using "modern" values. 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
