### PR TITLE
types: add test for accessing a context default value

### DIFF
--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -154,6 +154,15 @@ describe('t', () => {
       assertType(t('foo', { context: 'cake' }));
     });
 
+    it('should accept a default context key as a valid `t` function key', () => {
+      expectTypeOf(t('beverage')).toMatchTypeOf('cold water');
+    });
+
+    it('should throw error when no `context` is provided using and the context key has no default value ', () => {
+      // @ts-expect-error dessert has no default value, it needs a context
+      expectTypeOf(t('dessert')).toMatchTypeOf('error');
+    });
+
     it('should work with enum as a context value', () => {
       enum Dessert {
         CAKE = 'cake',
@@ -163,7 +172,9 @@ describe('t', () => {
       const ctx = Dessert.CAKE;
 
       expectTypeOf(t('dessert', { context: ctx })).toMatchTypeOf<string>();
+    });
 
+    it('should trow error with string union with missing context value', () => {
       enum DessertMissingValue {
         COOKIE = 'cookie',
         CAKE = 'cake',

--- a/test/typescript/test.namespace.samples.ts
+++ b/test/typescript/test.namespace.samples.ts
@@ -37,6 +37,10 @@ export type TestNamespaceContext = {
   dessert_cake: 'a nice cake';
   dessert_muffin_one: 'a nice muffin';
   dessert_muffin_other: '{{count}} nice muffins';
+
+  beverage: 'a classic beverage';
+  beverage_beer: 'fresh beer';
+  beverage_water: 'cold water';
 };
 
 export type TestNamespacePlurals = {


### PR DESCRIPTION
Added few more tests for `context` with or without context value

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
