### PR TITLE
types: add tests for context values

### DIFF
--- a/test/typescript/custom-types/i18next.d.ts
+++ b/test/typescript/custom-types/i18next.d.ts
@@ -9,6 +9,7 @@ import {
   TestNamespaceFallback,
   TestNamespaceNonPlurals,
   TestNamespaceInterpolators,
+  TestNamespaceContextAlternate,
 } from '../test.namespace.samples';
 
 declare module 'i18next' {
@@ -23,6 +24,7 @@ declare module 'i18next' {
       fallback: TestNamespaceFallback;
 
       ctx: TestNamespaceContext;
+      ctxAlternate: TestNamespaceContextAlternate;
 
       plurals: TestNamespacePlurals;
 

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -203,6 +203,41 @@ describe('t', () => {
     // });
   });
 
+  describe('context + explicit namespace', () => {
+    const t = (() => '') as TFunction<['ctx']>;
+
+    it('should work with basic usage', () => {
+      expectTypeOf(t('ctx:dessert', { context: 'cake' })).toEqualTypeOf<'a nice cake'>();
+
+      // context + plural
+      expectTypeOf(t('ctx:dessert', { context: 'muffin', count: 3 })).toMatchTypeOf<string>();
+
+      // @ts-expect-error
+      // valid key with invalid context
+      assertType(t('ctx:foo', { context: 'cake' }));
+    });
+  });
+
+  describe('context with `t` function with multiple namespaces', () => {
+    const t = (() => '') as TFunction<['ctx', 'ctxAlternate']>;
+
+    it('should work with basic usage', () => {
+      expectTypeOf(t('ctx:dessert', { context: 'cake' })).toEqualTypeOf<'a nice cake'>();
+
+      // context + plural
+      expectTypeOf(t('ctx:dessert', { context: 'muffin', count: 3 })).toMatchTypeOf<string>();
+
+      // @ts-expect-error
+      // valid key with invalid context
+      assertType(t('ctx:foo', { context: 'cake' }));
+    });
+
+    it('should work with text value from another namespace', () => {
+      expectTypeOf(t('ctxAlternate:game')).toMatchTypeOf<string>();
+      expectTypeOf(t('ctxAlternate:game', { context: 'monopoly' })).toMatchTypeOf<string>();
+    });
+  });
+
   it('should work with false plural usage', () => {
     const t = (() => '') as TFunction<'nonPlurals'>;
 

--- a/test/typescript/test.namespace.samples.ts
+++ b/test/typescript/test.namespace.samples.ts
@@ -43,6 +43,12 @@ export type TestNamespaceContext = {
   beverage_water: 'cold water';
 };
 
+export type TestNamespaceContextAlternate = {
+  game: 'A fun game';
+  game_chess: 'Chess';
+  game_monopoly: 'Monopoly';
+};
+
 export type TestNamespacePlurals = {
   foo_zero: 'foo';
   foo_one: 'foo';


### PR DESCRIPTION
Added new tests for `context`:
- usage with namespace prefix in `t` key
- usage of context value with the same `t` function from two different namespaces

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)