### PR TITLE
types: add test for context with default value

### DIFF
--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -154,6 +154,12 @@ describe('t', () => {
       assertType(t('foo', { context: 'cake' }));
     });
 
+    it('should accept not mapped context if a fallback key is present', () => {
+      // wine is not mapped
+      const currentTheme = 'wine' as 'wine' | 'beer' | 'water';
+      expectTypeOf(t('beverage', { context: currentTheme })).toMatchTypeOf<string>();
+    });
+
     it('should accept a default context key as a valid `t` function key', () => {
       expectTypeOf(t('beverage')).toMatchTypeOf('cold water');
     });


### PR DESCRIPTION
This should be the last test that needs to be added to fill the gap discovered in #2182

https://github.com/i18next/i18next/pull/2182#pullrequestreview-2055968571 ("Default context value" section)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
