### PR TITLE
perf: use Array.isArray()

### DIFF
--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -118,7 +118,7 @@ class LanguageUtil {
     if (!fallbacks) return [];
     if (typeof fallbacks === 'function') fallbacks = fallbacks(code);
     if (typeof fallbacks === 'string') fallbacks = [fallbacks];
-    if (Object.prototype.toString.apply(fallbacks) === '[object Array]') return fallbacks;
+    if (Array.isArray(fallbacks)) return fallbacks;
 
     if (!code) return fallbacks.default || [];
 

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -87,10 +87,7 @@ class ResourceStore extends EventEmitter {
   addResources(lng, ns, resources, options = { silent: false }) {
     /* eslint no-restricted-syntax: 0 */
     for (const m in resources) {
-      if (
-        typeof resources[m] === 'string' ||
-        Object.prototype.toString.apply(resources[m]) === '[object Array]'
-      )
+      if (typeof resources[m] === 'string' || Array.isArray(resources[m]))
         this.addResource(lng, ns, m, resources[m], { silent: true });
     }
     if (!options.silent) this.emit('added', lng, ns, resources);

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -160,7 +160,7 @@ class Translator extends EventEmitter {
       res &&
       handleAsObject &&
       noObject.indexOf(resType) < 0 &&
-      !(typeof joinArrays === 'string' && resType === '[object Array]')
+      !(typeof joinArrays === 'string' && Array.isArray(res))
     ) {
       if (!options.returnObjects && !this.options.returnObjects) {
         if (!this.options.returnedObjectHandler) {
@@ -180,7 +180,7 @@ class Translator extends EventEmitter {
       // if we got a separator we loop over children - else we just return object as is
       // as having it set to false means no hierarchy so no lookup for nested values
       if (keySeparator) {
-        const resTypeIsArray = resType === '[object Array]';
+        const resTypeIsArray = Array.isArray(res);
         const copy = resTypeIsArray ? [] : {}; // apply child translation on a copy
 
         /* eslint no-restricted-syntax: 0 */
@@ -197,11 +197,7 @@ class Translator extends EventEmitter {
         }
         res = copy;
       }
-    } else if (
-      handleAsObjectInI18nFormat &&
-      typeof joinArrays === 'string' &&
-      resType === '[object Array]'
-    ) {
+    } else if (handleAsObjectInI18nFormat && typeof joinArrays === 'string' && Array.isArray(res)) {
       // array special treatment
       res = res.join(joinArrays);
       if (res) res = this.extendTranslation(res, keys, options, lastKey);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Uses `Array.isArray(obj)` instead of `Object.prototype.toString.apply(object) === '[object Array]'` for a small performance and bundle size gain.

By utilising the new native builtin supported by all target browsers we can reduce the previous 3 step operation to 1 step.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)