### PR TITLE
perf: trim keys once

### DIFF
--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -19,18 +19,21 @@ function parseFormatStr(formatStr) {
       const opts = optStr.split(';');
 
       opts.forEach((opt) => {
-        if (!opt) return;
-        const [key, ...rest] = opt.split(':');
-        const val = rest
-          .join(':')
-          .trim()
-          .replace(/^'+|'+$/g, ''); // trim and replace ''
+        if (opt) {
+          const [key, ...rest] = opt.split(':');
+          const val = rest
+            .join(':')
+            .trim()
+            .replace(/^'+|'+$/g, ''); // trim and replace ''
 
-        if (!formatOptions[key.trim()]) formatOptions[key.trim()] = val;
-        if (val === 'false') formatOptions[key.trim()] = false;
-        if (val === 'true') formatOptions[key.trim()] = true;
-        // eslint-disable-next-line no-restricted-globals
-        if (!isNaN(val)) formatOptions[key.trim()] = parseInt(val, 10);
+          const trimmedKey = key.trim();
+
+          if (!formatOptions[trimmedKey]) formatOptions[trimmedKey] = val;
+          if (val === 'false') formatOptions[trimmedKey] = false;
+          if (val === 'true') formatOptions[trimmedKey] = true;
+          // eslint-disable-next-line no-restricted-globals
+          if (!isNaN(val)) formatOptions[trimmedKey] = parseInt(val, 10);
+        }
       });
     }
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Trims the key once and reuse it rather than calling trim multiple times. Also moves the logic inside the if condition instead of using an early return since it's the only logic in there.

This should improve both the performance and bundle size a tiny bit.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)