### PR TITLE
feat(logger): initOptions.debugOptionsFilter

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -193,7 +193,12 @@ class I18n extends EventEmitter {
         this.isInitializing = false;
         if (this.isInitialized && !this.initializedStoreOnce) this.logger.warn('init: i18next is already initialized. You should call init just once!');
         this.isInitialized = true;
-        if (!this.options.isClone) this.logger.log('initialized', this.options);
+        if (!this.options.isClone) {
+          this.logger.log(
+            'initialized',
+            typeof this.options.debugOptionsFilter === 'function' ? this.options.debugOptionsFilter(this.options) : this.options
+          );
+        }
         this.emit('initialized', this.options);
 
         deferred.resolve(t); // not rejecting on err (as err is only a loading translation failed warning)

--- a/test/runtime/i18next.debug.test.js
+++ b/test/runtime/i18next.debug.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import i18next from '../../src/i18next.js';
+import logger from '../../src/logger.js';
+
+describe('i18next debug', () => {
+  let logSpy;
+  beforeAll(async () => {
+    logSpy = vi.spyOn(logger, 'log');
+    await i18next.init({
+      foo: 'bar',
+      debug: true,
+    });
+    i18next.changeLanguage('en');
+  });
+
+  describe('init log options filtering', () => {
+    it('logs a subset of the options object', () => {
+      expect(logSpy).toHaveBeenCalledWith('initialized', i18next.options);
+    });
+  });
+});

--- a/test/runtime/i18next.debugFilter.test.js
+++ b/test/runtime/i18next.debugFilter.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import i18next from '../../src/i18next.js';
+import logger from '../../src/logger.js';
+
+describe('i18next debug', () => {
+  let logSpy;
+  beforeAll(async () => {
+    logSpy = vi.spyOn(logger, 'log');
+    await i18next.init({
+      foo: 'bar',
+      debug: true,
+      debugOptionsFilter: (opt) => ({ namespaces: opt.ns.length }),
+    });
+    i18next.changeLanguage('en');
+  });
+
+  describe('init log options filtering', () => {
+    it('logs a subset of the options object', () => {
+      expect(logSpy).toHaveBeenCalledWith('initialized', { namespaces: 1 });
+    });
+  });
+});

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -351,6 +351,12 @@ export interface InitOptions<T = object> extends PluginOptions<T> {
   debug?: boolean;
 
   /**
+   * Filter function that allows changing the logged option value when `debug` is set to true.
+   * @default undefined
+   */
+  debugOptionsFilter?: (options: InitOptions<T>) => unknown;
+
+  /**
    * Resources to initialize with (if not using loading or not appending using addResourceBundle)
    * @default undefined
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Our Issue

We're using i18next for a react-native project and we'd like to have `debug` set to true in dev mode so that we can catch issues with missing strings/keys in the logs. The problem we found is that the `initialization` log event prints a massive object to the console that, in our case, takes 3-4 full screen heights of scrolling to get through. Since this is terminal output, the object isn't interactive or collapsed like in a browser console, so there's a lot of noise in the output (`[Object]`).

#### Proposed Solution

Allow for an option (`debugOptionsFilter`) that allows for passing a function to filter the options object down to the interesting components for users. If provided, the return value would be what's logged by the logger on initialization.

#### Other Notes

I've added two new test suites since this involves `init` and I can't re-init in the existing test suite. I've also added a separate debug suite without the filter to cover the existing behaviour when the filter function is not passed in.

Some tests were failing for me locally for dates, and I assume it's a timezone issue.

If this is accepted I can update the doc site repo.

#### Questions

* should i run the build command? (i notice there's a UMD file in the root of the repo)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
