### PR TITLE
rename initImmediate to initAsync

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,7 @@
 export function get() {
   return {
     debug: false,
-    initImmediate: true,
+    initAsync: true,
 
     ns: ['translation'],
     defaultNS: ['translation'],
@@ -80,6 +80,9 @@ export function transformOptions(options) {
   if (typeof options.ns === 'string') options.ns = [options.ns];
   if (typeof options.fallbackLng === 'string') options.fallbackLng = [options.fallbackLng];
   if (typeof options.fallbackNS === 'string') options.fallbackNS = [options.fallbackNS];
+
+  // for backward compatibility, assign initImmediate to initAsync (if set)
+  if (typeof options.initImmediate === 'boolean') options.initAsync = options.initImmediate;
 
   // extend supportedLngs with cimode
   if (options.supportedLngs && options.supportedLngs.indexOf('cimode') < 0) {

--- a/src/i18next.js
+++ b/src/i18next.js
@@ -37,7 +37,7 @@ class I18n extends EventEmitter {
 
     if (callback && !this.isInitialized && !options.isClone) {
       // https://github.com/i18next/i18next/issues/879
-      if (!this.options.initImmediate) {
+      if (!this.options.initAsync) {
         this.init(options, callback);
         return this;
       }
@@ -204,7 +204,7 @@ class I18n extends EventEmitter {
       this.changeLanguage(this.options.lng, finish);
     };
 
-    if (this.options.resources || !this.options.initImmediate) {
+    if (this.options.resources || !this.options.initAsync) {
       load();
     } else {
       setTimeout(load, 0);

--- a/test/runtime/languageDetector.test.js
+++ b/test/runtime/languageDetector.test.js
@@ -12,7 +12,7 @@ describe('LanguageDetector with different signatures', () => {
 
     describe('#init', () => {
       it('should work as usual', () => {
-        i18n.init({ initImmediate: false });
+        i18n.init({ initAsync: false });
         expect(i18n.language).to.eql('de-CH');
       });
     });
@@ -42,7 +42,7 @@ describe('LanguageDetector with different signatures', () => {
 
     describe('#init', () => {
       it('should work as usual', () => {
-        i18n.init({ initImmediate: false });
+        i18n.init({ initAsync: false });
         expect(i18n.language).to.eql('de-CH');
         expect(cachedLng).to.eql('de-CH');
       });

--- a/test/typescript/misc/init.test.ts
+++ b/test/typescript/misc/init.test.ts
@@ -3,6 +3,12 @@ import i18next, { InitOptions, TFunction, createInstance } from 'i18next';
 
 describe('init', () => {
   describe('initOptions', () => {
+    it('should accept `initAsync`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        initAsync: false,
+      });
+    });
+
     it('should accept `initImmediate`', () => {
       expectTypeOf(i18next.init).toBeCallableWith({
         initImmediate: false,

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -574,6 +574,11 @@ export interface InitOptions<T = object> extends PluginOptions<T> {
    * init is possible without relaying on the init callback.
    * @default true
    */
+  initAsync?: boolean;
+
+  /**
+   * @deprecated Use initAsync instead.
+   */
   initImmediate?: boolean;
 
   /**


### PR DESCRIPTION
`initImmediate` option name is misleading because it actually does the opposite of what you would expect.
This PR renames it to `initAsync` that clearly express what it does while keeping backward compatibility with the former name.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)