### PR TITLE
types: merge `hasLoadedNamespace` declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -327,13 +327,21 @@ export interface i18n extends CustomInstanceExtensions {
     ns: string | readonly string[],
     options?: {
       lng?: string | readonly string[];
-      precheck: (
+      fallbackLng?: InitOptions['fallbackLng'];
+      /**
+       * if `undefined` is returned default checks are performed.
+       */
+      precheck?: (
         i18n: i18n,
+        /**
+         * Check if the language namespace provided are not in loading status:
+         * returns `true` if load is completed successfully or with an error.
+         */
         loadNotPending: (
           lng: string | readonly string[],
           ns: string | readonly string[],
         ) => boolean,
-      ) => boolean;
+      ) => boolean | undefined;
     },
   ): boolean;
 
@@ -361,11 +369,6 @@ export interface i18n extends CustomInstanceExtensions {
    * Changes the default namespace.
    */
   setDefaultNamespace(ns: string): void;
-
-  /**
-   * Checks if a namespace has been loaded.
-   */
-  hasLoadedNamespace(ns: string, options?: Pick<InitOptions, 'fallbackLng'>): boolean;
 
   /**
    * Returns rtl or ltr depending on languages read direction.

--- a/test/typescript/misc/i18nInstance.test.ts
+++ b/test/typescript/misc/i18nInstance.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, assertType, expectTypeOf } from 'vitest';
-import i18next, { InitOptions, TFunction, createInstance } from 'i18next';
+import i18next, { InitOptions, TFunction, createInstance, i18n } from 'i18next';
 
-describe('init', () => {
+describe('i18nInstance', () => {
   describe('initOptions', () => {
     it('should accept `initImmediate`', () => {
       expectTypeOf(i18next.init).toBeCallableWith({
@@ -394,5 +394,36 @@ describe('init', () => {
         assertType<TFunction>(t);
       },
     );
+  });
+
+  it('`hasLoadedNamespace`', () => {
+    expectTypeOf(i18next.hasLoadedNamespace).toBeCallableWith('test-ns');
+
+    expectTypeOf(i18next.hasLoadedNamespace).toBeCallableWith('test-ns', {
+      lng: 'en',
+    });
+
+    expectTypeOf(i18next.hasLoadedNamespace).toBeCallableWith('test-ns', {
+      lng: 'it',
+      fallbackLng: 'en',
+    });
+
+    expectTypeOf(i18next.hasLoadedNamespace).toBeCallableWith('test-ns', {
+      lng: 'it',
+      fallbackLng: 'en',
+      precheck(i18nPreCheck, loadNotPending) {
+        assertType<i18n>(i18nPreCheck);
+
+        type ExpectedLoadNotPending = (
+          lng: string | readonly string[],
+          ns: string | readonly string[],
+        ) => boolean | undefined;
+        assertType<ExpectedLoadNotPending>(loadNotPending);
+
+        return false;
+      },
+    });
+
+    expectTypeOf(i18next.hasLoadedNamespace('test-ns')).toBeBoolean();
   });
 });


### PR DESCRIPTION
`i18n.hasLoadedNamespace` has two definitions.
Comparing the definition with the js implementation the two definition can be merged with a single one.

https://github.com/i18next/i18next/blob/c8d9f7bbc77ccb1bc1f24272827afd9295281756/src/i18next.js#L426-L463

I also added relevant definition tests.

---

> [!NOTE]  
> `test/typescript/misc/init.test.ts` has been renamed to `test/typescript/misc/i18nInstance.test.ts` to better reflect the file content

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)