### PR TITLE
Use explicit imports for utils

### DIFF
--- a/src/BackendConnector.js
+++ b/src/BackendConnector.js
@@ -1,4 +1,4 @@
-import * as utils from './utils.js';
+import { pushPath } from './utils.js';
 import baseLogger from './logger.js';
 import EventEmitter from './EventEmitter.js';
 
@@ -105,7 +105,7 @@ class Connector extends EventEmitter {
 
     // callback if ready
     this.queue.forEach((q) => {
-      utils.pushPath(q.loaded, [lng], ns);
+      pushPath(q.loaded, [lng], ns);
       removePending(q, name);
 
       if (err) q.errors.push(err);

--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -1,4 +1,10 @@
-import * as utils from './utils.js';
+import {
+  getPathWithDefaults,
+  deepFind,
+  escape as utilsEscape,
+  regexEscape,
+  makeString,
+} from './utils.js';
 import baseLogger from './logger.js';
 
 function deepFindWithDefaults(
@@ -8,10 +14,10 @@ function deepFindWithDefaults(
   keySeparator = '.',
   ignoreJSONStructure = true,
 ) {
-  let path = utils.getPathWithDefaults(data, defaultData, key);
+  let path = getPathWithDefaults(data, defaultData, key);
   if (!path && ignoreJSONStructure && typeof key === 'string') {
-    path = utils.deepFind(data, key, keySeparator);
-    if (path === undefined) path = utils.deepFind(defaultData, key, keySeparator);
+    path = deepFind(data, key, keySeparator);
+    if (path === undefined) path = deepFind(defaultData, key, keySeparator);
   }
   return path;
 }
@@ -49,12 +55,12 @@ class Interpolator {
       alwaysFormat,
     } = options.interpolation;
 
-    this.escape = escape !== undefined ? escape : utils.escape;
+    this.escape = escape !== undefined ? escape : utilsEscape;
     this.escapeValue = escapeValue !== undefined ? escapeValue : true;
     this.useRawValueToEscape = useRawValueToEscape !== undefined ? useRawValueToEscape : false;
 
-    this.prefix = prefix ? utils.regexEscape(prefix) : prefixEscaped || '{{';
-    this.suffix = suffix ? utils.regexEscape(suffix) : suffixEscaped || '}}';
+    this.prefix = prefix ? regexEscape(prefix) : prefixEscaped || '{{';
+    this.suffix = suffix ? regexEscape(suffix) : suffixEscaped || '}}';
 
     this.formatSeparator = formatSeparator || ',';
 
@@ -62,11 +68,11 @@ class Interpolator {
     this.unescapeSuffix = this.unescapePrefix ? '' : unescapeSuffix || '';
 
     this.nestingPrefix = nestingPrefix
-      ? utils.regexEscape(nestingPrefix)
-      : nestingPrefixEscaped || utils.regexEscape('$t(');
+      ? regexEscape(nestingPrefix)
+      : nestingPrefixEscaped || regexEscape('$t(');
     this.nestingSuffix = nestingSuffix
-      ? utils.regexEscape(nestingSuffix)
-      : nestingSuffixEscaped || utils.regexEscape(')');
+      ? regexEscape(nestingSuffix)
+      : nestingSuffixEscaped || regexEscape(')');
 
     this.nestingOptionsSeparator = nestingOptionsSeparator || ',';
 
@@ -193,7 +199,7 @@ class Interpolator {
             value = '';
           }
         } else if (typeof value !== 'string' && !this.useRawValueToEscape) {
-          value = utils.makeString(value);
+          value = makeString(value);
         }
         const safeValue = todo.safeValue(value);
         str = str.replace(match[0], safeValue);
@@ -287,7 +293,7 @@ class Interpolator {
       if (value && match[0] === str && typeof value !== 'string') return value;
 
       // no string to include or empty
-      if (typeof value !== 'string') value = utils.makeString(value);
+      if (typeof value !== 'string') value = makeString(value);
       if (!value) {
         this.logger.warn(`missed to resolve ${match[1]} for nesting ${str}`);
         value = '';

--- a/src/ResourceStore.js
+++ b/src/ResourceStore.js
@@ -1,5 +1,5 @@
 import EventEmitter from './EventEmitter.js';
-import * as utils from './utils.js';
+import { getPath, deepFind, setPath, deepExtend } from './utils.js';
 
 class ResourceStore extends EventEmitter {
   constructor(data, options = { ns: ['translation'], defaultNS: 'translation' }) {
@@ -53,7 +53,7 @@ class ResourceStore extends EventEmitter {
       }
     }
 
-    const result = utils.getPath(this.data, path);
+    const result = getPath(this.data, path);
     if (!result && !ns && !key && lng.indexOf('.') > -1) {
       lng = path[0];
       ns = path[1];
@@ -61,7 +61,7 @@ class ResourceStore extends EventEmitter {
     }
     if (result || !ignoreJSONStructure || typeof key !== 'string') return result;
 
-    return utils.deepFind(this.data && this.data[lng] && this.data[lng][ns], key, keySeparator);
+    return deepFind(this.data && this.data[lng] && this.data[lng][ns], key, keySeparator);
   }
 
   addResource(lng, ns, key, value, options = { silent: false }) {
@@ -79,7 +79,7 @@ class ResourceStore extends EventEmitter {
 
     this.addNamespaces(ns);
 
-    utils.setPath(this.data, path, value);
+    setPath(this.data, path, value);
 
     if (!options.silent) this.emit('added', lng, ns, key, value);
   }
@@ -111,17 +111,17 @@ class ResourceStore extends EventEmitter {
 
     this.addNamespaces(ns);
 
-    let pack = utils.getPath(this.data, path) || {};
+    let pack = getPath(this.data, path) || {};
 
     if (!options.skipCopy) resources = JSON.parse(JSON.stringify(resources)); // make a copy to fix #2081
 
     if (deep) {
-      utils.deepExtend(pack, resources, overwrite);
+      deepExtend(pack, resources, overwrite);
     } else {
       pack = { ...pack, ...resources };
     }
 
-    utils.setPath(this.data, path, pack);
+    setPath(this.data, path, pack);
 
     if (!options.silent) this.emit('added', lng, ns, resources);
   }

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -1,7 +1,7 @@
 import baseLogger from './logger.js';
 import EventEmitter from './EventEmitter.js';
 import postProcessor from './postProcessor.js';
-import * as utils from './utils.js';
+import { copy as utilsCopy, looksLikeObjectPath } from './utils.js';
 
 const checkedLoadedFor = {};
 
@@ -9,7 +9,7 @@ class Translator extends EventEmitter {
   constructor(services, options = {}) {
     super();
 
-    utils.copy(
+    utilsCopy(
       [
         'resourceStore',
         'languageUtils',
@@ -59,7 +59,7 @@ class Translator extends EventEmitter {
       !options.keySeparator &&
       !this.options.userDefinedNsSeparator &&
       !options.nsSeparator &&
-      !utils.looksLikeObjectPath(key, nsSeparator, keySeparator);
+      !looksLikeObjectPath(key, nsSeparator, keySeparator);
     if (wouldCheckForNsInKey && !seemsNaturalLanguage) {
       const m = key.match(this.interpolator.nestingRegexp);
       if (m && m.length > 0) {

--- a/test/runtime/utils.test.js
+++ b/test/runtime/utils.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as utils from '../../src/utils.js';
+import { deepExtend, deepFind } from '../../src/utils.js';
 
 describe('utils', () => {
   describe('#deepExtend', () => {
     it('it should overwrite if flag set', () => {
-      const res = utils.deepExtend(
+      const res = deepExtend(
         {
           some: 'thing',
         },
@@ -18,7 +18,7 @@ describe('utils', () => {
     });
 
     it('it should not overwrite', () => {
-      const res = utils.deepExtend(
+      const res = deepExtend(
         {
           some: 'thing',
         },
@@ -35,29 +35,29 @@ describe('utils', () => {
   describe('#deepFind', () => {
     it('finds value for a basic path', () => {
       const obj = { a: { b: { c: 1 } } };
-      const value = utils.deepFind(obj, 'a.b.c');
+      const value = deepFind(obj, 'a.b.c');
       expect(value).toEqual(1);
     });
 
     it('finds no value for a non-existent path', () => {
       const obj = { a: { b: { c: 1 } } };
-      const value = utils.deepFind(obj, 'a.b.d');
+      const value = deepFind(obj, 'a.b.d');
       expect(value).toEqual(undefined);
     });
 
     it('finds value for a key that has a dot', () => {
       const obj = { a: { b: 'zero', 'b.b': { c: 1 } } };
-      const value = utils.deepFind(obj, 'a.b.b.c');
+      const value = deepFind(obj, 'a.b.b.c');
       expect(value).toEqual(1);
-      const value2 = utils.deepFind(obj, 'a.b');
+      const value2 = deepFind(obj, 'a.b');
       expect(value2).toEqual('zero');
-      const value3 = utils.deepFind(obj, 'a.b.b');
+      const value3 = deepFind(obj, 'a.b.b');
       expect(value3).toEqual({ c: 1 });
     });
 
     it('finds value for an array index', () => {
       const obj = { a: [{ c: 1 }] };
-      const value = utils.deepFind(obj, 'a.0.c');
+      const value = deepFind(obj, 'a.0.c');
       expect(value).toEqual(1);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Changes the star imports (import `*`) to explicitly import the utils that are used in each file, this helps with dead code elimination and some code in the resulting build from:
```js
  function pushPath(object, path, newValue, concat) {
    const {
      obj,
      k
    } = getLastOfPath(object, path, Object);
    obj[k] = obj[k] || [];
    if (concat) obj[k] = obj[k].concat(newValue);
    if (!concat) obj[k].push(newValue);
  }
```
to:
```js
  function pushPath(object, path, newValue, concat) {
    const {
      obj,
      k
    } = getLastOfPath(object, path, Object);
    obj[k] = obj[k] || [];
    obj[k].push(newValue);
  }
```
This is because concat is not actually passed to the util function which means the build process can remove the branching as it will always have a deterministic output.

If that changes in the future the code will once again be included so this does not affect any functionality or source code in it self.

PS: I also changed the star imports in the test so it matches the rest of the code for consistency.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)