### PR TITLE
languageOnly with LanguageDetector bugfix

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -936,7 +936,7 @@
       let found;
       codes.forEach(code => {
         if (found) return;
-        const cleanedLng = this.formatLanguageCode(code);
+        const cleanedLng = this.options.load === 'languageOnly' ? this.getLanguagePartFromCode(code) : this.formatLanguageCode(code);
         if (!this.options.supportedLngs || this.isSupportedCode(cleanedLng)) found = cleanedLng;
       });
       if (!found && this.options.supportedLngs) {

--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -77,7 +77,10 @@ class LanguageUtil {
     // pick first supported code or if no restriction pick the first one (highest prio)
     codes.forEach((code) => {
       if (found) return;
-      const cleanedLng = this.formatLanguageCode(code);
+      const cleanedLng =
+        this.options.load === 'languageOnly'
+          ? this.getLanguagePartFromCode(code)
+          : this.formatLanguageCode(code);
       if (!this.options.supportedLngs || this.isSupportedCode(cleanedLng)) found = cleanedLng;
     });
 

--- a/test/runtime/languageUtils.test.js
+++ b/test/runtime/languageUtils.test.js
@@ -328,6 +328,35 @@ describe('LanguageUtils', () => {
     });
   });
 
+  describe('getBestMatchFromCodes() with languageOnly', () => {
+    /** @type {LanguageUtils} */
+    let cu;
+    beforeAll(() => {
+      cu = new LanguageUtils({
+        fallbackLng: ['en'],
+        supportedLngs: ['fr', 'en'],
+      });
+    });
+
+    const tests = [
+      { args: [['en']], expected: 'en' },
+      { args: [['ru', 'en']], expected: 'en' },
+      { args: [['en-GB']], expected: 'en' },
+      { args: [['ru', 'en-US']], expected: 'en' },
+      { args: [['de-CH']], expected: 'en' },
+      { args: [['fr']], expected: 'fr' },
+      { args: [['fr-FR']], expected: 'fr' },
+      { args: [['e']], expected: 'en' },
+      { args: [[]], expected: 'en' },
+    ];
+
+    tests.forEach((test) => {
+      it(`correctly get best match for ${JSON.stringify(test.args)} args`, () => {
+        expect(cu.getBestMatchFromCodes.apply(cu, test.args)).to.eql(test.expected);
+      });
+    });
+  });
+
   describe('getBestMatchFromCodes() with dev', () => {
     /** @type {LanguageUtils} */
     let cu;

--- a/test/runtime/languageUtils.test.js
+++ b/test/runtime/languageUtils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import LanguageUtils from '../../src/LanguageUtils';
 
 describe('LanguageUtils', () => {
@@ -335,6 +335,7 @@ describe('LanguageUtils', () => {
       cu = new LanguageUtils({
         fallbackLng: ['en'],
         supportedLngs: ['fr', 'en'],
+        load: 'languageOnly',
       });
     });
 


### PR DESCRIPTION
getBestMatchFromCodes(['en-US']) with languageOnly should return 'en' but currently return 'en-US'

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [Y] only relevant code is changed (make a diff before you submit the PR)
- [Y] run tests `npm run test`
- [Y] tests are included
- [Y] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [N/A] only relevant documentation part is changed (make a diff before you submit the PR)
- [Y] motivation/reason is provided
- [Y] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)