### PR TITLE
Cache output of getRule to optimize performance

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -1135,28 +1135,31 @@
         this.logger.error('Your environment seems not to be Intl API compatible, use an Intl.PluralRules polyfill. Will fallback to the compatibilityJSON v3 format handling.');
       }
       this.rules = createRules();
-      this.pluralRulesCache = new Map();
+      this.pluralRulesCache = {};
     }
     addRule(lng, obj) {
       this.rules[lng] = obj;
+    }
+    clearCache() {
+      this.pluralRulesCache = {};
     }
     getRule(code) {
       let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       if (this.shouldUseIntlApi()) {
         try {
-          const locales = getCleanedCode(code === 'dev' ? 'en' : code);
+          const cleanedCode = getCleanedCode(code === 'dev' ? 'en' : code);
           const type = options.ordinal ? 'ordinal' : 'cardinal';
           const cacheKey = JSON.stringify({
-            locales,
+            cleanedCode,
             type
           });
-          if (this.pluralRulesCache.has(cacheKey)) {
-            return this.pluralRulesCache.get(cacheKey);
+          if (cacheKey in this.pluralRulesCache) {
+            return this.pluralRulesCache[cacheKey];
           }
-          const rule = new Intl.PluralRules(locales, {
+          const rule = new Intl.PluralRules(cleanedCode, {
             type
           });
-          this.pluralRulesCache.set(cacheKey, rule);
+          this.pluralRulesCache[cacheKey] = rule;
           return rule;
         } catch (err) {
           return;

--- a/i18next.js
+++ b/i18next.js
@@ -1135,32 +1135,17 @@
         this.logger.error('Your environment seems not to be Intl API compatible, use an Intl.PluralRules polyfill. Will fallback to the compatibilityJSON v3 format handling.');
       }
       this.rules = createRules();
-      this.pluralRulesCache = {};
     }
     addRule(lng, obj) {
       this.rules[lng] = obj;
-    }
-    clearCache() {
-      this.pluralRulesCache = {};
     }
     getRule(code) {
       let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       if (this.shouldUseIntlApi()) {
         try {
-          const cleanedCode = getCleanedCode(code === 'dev' ? 'en' : code);
-          const type = options.ordinal ? 'ordinal' : 'cardinal';
-          const cacheKey = JSON.stringify({
-            cleanedCode,
-            type
+          return new Intl.PluralRules(getCleanedCode(code === 'dev' ? 'en' : code), {
+            type: options.ordinal ? 'ordinal' : 'cardinal'
           });
-          if (cacheKey in this.pluralRulesCache) {
-            return this.pluralRulesCache[cacheKey];
-          }
-          const rule = new Intl.PluralRules(cleanedCode, {
-            type
-          });
-          this.pluralRulesCache[cacheKey] = rule;
-          return rule;
         } catch (err) {
           return;
         }

--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -102,6 +102,7 @@ class PluralResolver {
     }
 
     this.rules = createRules();
+    this.pluralRulesCache = new Map();
   }
 
   addRule(lng, obj) {
@@ -111,7 +112,18 @@ class PluralResolver {
   getRule(code, options = {}) {
     if (this.shouldUseIntlApi()) {
       try {
-        return new Intl.PluralRules(getCleanedCode(code === 'dev' ? 'en' : code), { type: options.ordinal ? 'ordinal' : 'cardinal' });
+        const locales = getCleanedCode(code === 'dev' ? 'en' : code);
+        const type = options.ordinal ? 'ordinal' : 'cardinal';
+        const cacheKey = JSON.stringify({locales, type});
+        if (this.pluralRulesCache.has(cacheKey)) {
+          return this.pluralRulesCache.get(cacheKey);
+        }
+
+        const rule = new Intl.PluralRules(locales, {
+          type
+        });
+        this.pluralRulesCache.set(cacheKey, rule)
+        return rule;
       } catch (err) {
         return;
       }

--- a/test/runtime/pluralResolver.test.js
+++ b/test/runtime/pluralResolver.test.js
@@ -30,6 +30,7 @@ describe('PluralResolver', () => {
     });
 
     it('correctly returns getRule for an unsupported locale', () => {
+      pr.clearCache();
       const pluralRulesSpy = vitest.spyOn(Intl, 'PluralRules').mockImplementation(() => {
         throw Error('mock error');
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
# Motivation
While profiling scrolling our app, we saw that this function was taking a long time. This is because in React Native and possibly other runtimes, calling Intl functions can be slow.

# Change
Cached the output of getRule to improve performance.

# Testing
Using a consistent test process of scrolling 20 seconds in our app at the same starting point and then restarting the app after each trial, we measured the cumulative time that getRule was taking. The performance improvement is significant, whereas the memory usage difference was negligible since most apps ever use a 1 to a few codes per run, this cached object is tiny. The total universe is # codes * 2, which is still very small.


  | Time 1(ms) | Time 2(ms) | Time 3(ms)
-- | -- | -- | --
Before(no caching) | 630 | 581 | 619
After(with caching) | 2 | 2 | 3


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)