### PR TITLE
support unescaped variables in TypeScript

### DIFF
--- a/examples/typescript/i18n/en/ns1.ts
+++ b/examples/typescript/i18n/en/ns1.ts
@@ -5,11 +5,13 @@ const ns1 = {
     part2: '😉',
   },
   inter: 'interpolated {{val}}',
+  interUnescaped: 'interpolated and unescaped {{- val}}',
   some: 'ctx',
   some_me: 'ctx2',
   some_1234: 'ctx3',
   pl_one: 'sing',
   pl_other: '{{count}} plur',
+  lastChanged: 'Last changed {{- date}}',
 } as const;
 
 export default ns1;

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -20,6 +20,9 @@ const l = i18next.language;
 // interpolation
 i18next.t('inter', { val: 'xx' });
 
+// interpolation and unescaped
+i18next.t('interUnescaped', { val: 'xx' });
+
 // this ts error occurs only if resources are imported:
 //   1) as const (ts file)
 //   or

--- a/test/typescript/custom-types-json-v3/i18nextT.test.ts
+++ b/test/typescript/custom-types-json-v3/i18nextT.test.ts
@@ -49,6 +49,15 @@ describe('i18next.t', () => {
       ).toEqualTypeOf<'some {{val}}'>();
       expectTypeOf(i18next.t('inter', { val: 'asdf' })).toEqualTypeOf<'some {{val}}'>();
       expectTypeOf(i18next.t('qux', { val: 'asdf' })).toEqualTypeOf<'some {{val, number}}'>();
+      expectTypeOf(
+        i18next.t('interUnescaped', { val: 'asdf' }),
+      ).toEqualTypeOf<'some unescaped {{- val}}'>();
+      expectTypeOf(
+        i18next.t('interUnescapedNoSpace', { val: 'asdf' }),
+      ).toEqualTypeOf<'some unescaped {{-val}}'>();
+      expectTypeOf(
+        i18next.t('interUnescapedFormatted', { val: 'asdf' }),
+      ).toEqualTypeOf<'some unescaped {- val, number}}'>();
     });
 
     it('should throw an error when value is not present inside key', () => {

--- a/test/typescript/test.namespace.samples.ts
+++ b/test/typescript/test.namespace.samples.ts
@@ -6,6 +6,9 @@ export type TestNamespaceCustom = {
   };
   qux: 'some {{val, number}}';
   inter: 'some {{val}}';
+  interUnescaped: 'some unescaped {{- val}}';
+  interUnescapedNoSpace: 'some unescaped {{-val}}';
+  interUnescapedFormatted: 'some unescaped {- val, number}}';
   nullKey: null;
   'empty string with {{val}}': '';
 };

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -106,6 +106,16 @@ export type TypeOptions = $MergeBy<
      * Suffix for interpolation
      */
     interpolationSuffix: '}}';
+
+    /**
+     * Prefix for unescaped interpolation
+     */
+    unescapePrefix: '-';
+
+    /**
+     * Suffix for unescaped interpolation
+     */
+    unescapeSuffix: '';
   },
   CustomTypeOptions
 >;

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -29,6 +29,8 @@ type _Resources = TypeOptions['resources'];
 type _JSONFormat = TypeOptions['jsonFormat'];
 type _InterpolationPrefix = TypeOptions['interpolationPrefix'];
 type _InterpolationSuffix = TypeOptions['interpolationSuffix'];
+type _UnescapePrefix = TypeOptions['unescapePrefix'];
+type _UnescapeSuffix = TypeOptions['unescapeSuffix'];
 
 type $IsResourcesDefined = [keyof _Resources] extends [never] ? false : true;
 type $ValueIfResourcesDefined<Value, Fallback> = $IsResourcesDefined extends true
@@ -52,6 +54,14 @@ type WithOrWithoutPlural<Key> = _JSONFormat extends 'v4' | 'v3'
 
 type JoinKeys<K1, K2> = `${K1 & string}${_KeySeparator}${K2 & string}`;
 type AppendNamespace<Ns, Keys> = `${Ns & string}${_NsSeparator}${Keys & string}`;
+
+type TrimSpaces<T extends string, Acc extends string = ''> = T extends `${infer Char}${infer Rest}`
+  ? Char extends ' '
+    ? TrimSpaces<Rest, Acc>
+    : TrimSpaces<Rest, `${Acc}${Char}`>
+  : T extends ''
+  ? Acc
+  : never;
 
 /** ****************************************************
  * Build all keys and key prefixes based on Resources *
@@ -141,10 +151,16 @@ export type ParseKeys<
 /** *******************************************************
  * Parse t function return type and interpolation values *
  ******************************************************** */
+type ParseActualValue<Ret> = Ret extends `${_UnescapePrefix}${infer ActualValue}${_UnescapeSuffix}`
+  ? TrimSpaces<ActualValue>
+  : Ret;
+
 type ParseInterpolationValues<Ret> =
   Ret extends `${string}${_InterpolationPrefix}${infer Value}${_InterpolationSuffix}${infer Rest}`
     ?
-        | (Value extends `${infer ActualValue},${string}` ? ActualValue : Value)
+        | (Value extends `${infer ActualValue},${string}`
+            ? ParseActualValue<ActualValue>
+            : ParseActualValue<Value>)
         | ParseInterpolationValues<Rest>
     : never;
 


### PR DESCRIPTION
Support unescaped variables in TypeScript when parsing actual values.

Without this fix, the variable names parsed in TypeScript will include the unescaped prefix/suffix, for example:

```
"locale": "Something {{- var}}"
```

```
t("locale", { "- var": value })
```

instead of:

```
t("locale", { var: value })
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)