### PR TITLE
types(TFunction): make return not inferrable and use defaultValue as return when provided

### DIFF
--- a/test/typescript/custom-types-default-ns-as-array/i18nextT.test.ts
+++ b/test/typescript/custom-types-default-ns-as-array/i18nextT.test.ts
@@ -70,8 +70,7 @@ describe('i18next.t', () => {
   });
 
   it('should accept any key if default value is provided', () => {
-    const str: string = i18next.t('unknown-ns:unknown-key', 'default value');
-    assertType<string>(str);
+    assertType<'default value'>(i18next.t('unknown-ns:unknown-key', 'default value'));
   });
 
   it('should work with plurals', () => {

--- a/test/typescript/custom-types-default-ns-as-array/t.test.ts
+++ b/test/typescript/custom-types-default-ns-as-array/t.test.ts
@@ -93,12 +93,12 @@ describe('t', () => {
       assertType<string[]>(result);
     });
 
-    it('should not throw an error when `defaultValue` is provided', () => {
+    it('should not throw an error when `defaultValue` is provided and value should be equal to DefaultValue', () => {
       expectTypeOf(
         t('foobar.barfoo', { defaultValue: 'some default value' }),
-      ).toMatchTypeOf<unknown>();
-      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toEqualTypeOf<unknown>();
-      expectTypeOf(t('new.key', 'some default value')).toEqualTypeOf<unknown>();
+      ).toMatchTypeOf<string>();
+      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toMatchTypeOf<string>();
+      expectTypeOf(t('new.key', 'some default value')).toMatchTypeOf<string>();
     });
   });
 

--- a/test/typescript/custom-types-json-v3/i18nextT.test.ts
+++ b/test/typescript/custom-types-json-v3/i18nextT.test.ts
@@ -69,18 +69,17 @@ describe('i18next.t', () => {
   it('should work with default value', () => {
     expectTypeOf(
       i18next.t('custom:bar', { defaultValue: 'some default value' }),
-    ).toMatchTypeOf<unknown>();
-    expectTypeOf(i18next.t('custom:bar', 'some default value')).toMatchTypeOf<unknown>();
+    ).toMatchTypeOf<string>();
+    expectTypeOf(i18next.t('custom:bar', 'some default value')).toMatchTypeOf<string>();
     expectTypeOf(
       i18next.t('bar', { ns: 'custom', defaultValue: 'some default value' }),
-    ).toMatchTypeOf<unknown>();
-    expectTypeOf(i18next.t('bar', { defaultValue: 'some default value' })).toMatchTypeOf<unknown>();
-    expectTypeOf(i18next.t('bar', 'some default value')).toMatchTypeOf<unknown>();
+    ).toMatchTypeOf<string>();
+    expectTypeOf(i18next.t('bar', { defaultValue: 'some default value' })).toMatchTypeOf<string>();
+    expectTypeOf(i18next.t('bar', 'some default value')).toMatchTypeOf<string>();
   });
 
   it('should accept any key if default value is provided', () => {
-    const str: string = i18next.t('unknown-ns:unknown-key', 'default value');
-    assertType<string>(str);
+    assertType<'default value'>(i18next.t('unknown-ns:unknown-key', 'default value'));
   });
 
   it('should work with plurals', () => {

--- a/test/typescript/custom-types-json-v3/t.test.ts
+++ b/test/typescript/custom-types-json-v3/t.test.ts
@@ -88,8 +88,8 @@ describe('t', () => {
       expectTypeOf(
         t('foobar.barfoo', { defaultValue: 'some default value' }),
       ).toMatchTypeOf<unknown>();
-      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toEqualTypeOf<unknown>();
-      expectTypeOf(t('new.key', 'some default value')).toEqualTypeOf<unknown>();
+      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toMatchTypeOf<string>();
+      expectTypeOf(t('new.key', 'some default value')).toMatchTypeOf<string>();
     });
   });
 

--- a/test/typescript/custom-types/i18nextT.test.ts
+++ b/test/typescript/custom-types/i18nextT.test.ts
@@ -70,8 +70,7 @@ describe('i18next.t', () => {
   });
 
   it('should accept any key if default value is provided', () => {
-    const str: string = i18next.t('unknown-ns:unknown-key', 'default value');
-    assertType<string>(str);
+    assertType<'default value'>(i18next.t('unknown-ns:unknown-key', 'default value'));
   });
 
   it('should fallback for null translations with unset returnNull in config', () => {

--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -84,12 +84,12 @@ describe('t', () => {
       assertType<string[]>(result);
     });
 
-    it('should not throw an error when `defaultValue` is provided', () => {
+    it('should not throw an error when `defaultValue` is provided and value should be equal to DefaultValue', () => {
       expectTypeOf(
         t('foobar.barfoo', { defaultValue: 'some default value' }),
-      ).toMatchTypeOf<unknown>();
-      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toEqualTypeOf<unknown>();
-      expectTypeOf(t('new.key', 'some default value')).toEqualTypeOf<unknown>();
+      ).toMatchTypeOf<string>();
+      expectTypeOf(t('new.key', { defaultValue: 'some default value' })).toMatchTypeOf<string>();
+      expectTypeOf(t('new.key', 'some default value')).toMatchTypeOf<string>();
     });
   });
 

--- a/test/typescript/misc/t.test.ts
+++ b/test/typescript/misc/t.test.ts
@@ -188,12 +188,12 @@ describe('t', () => {
     });
 
     it('`returnObjects`', () => {
-      expectTypeOf(t('tree', { returnObjects: true, something: 'gold' })).toEqualTypeOf<
+      expectTypeOf(t('tree', { returnObjects: true, something: 'gold' })).toMatchTypeOf<
         object | Array<string | object>
       >();
       // -> { res: 'added gold' }
 
-      expectTypeOf(t('array', { returnObjects: true })).toEqualTypeOf<
+      expectTypeOf(t('array', { returnObjects: true })).toMatchTypeOf<
         object | Array<string | object>
       >();
       // -> ['a', 'b', 'c']
@@ -214,7 +214,7 @@ describe('t', () => {
     it('`returnObjects` + `returnDetails`', () => {
       expectTypeOf(t('test', { returnObjects: true, returnDetails: true }))
         .toHaveProperty('res')
-        .toEqualTypeOf<object | Array<string | object>>();
+        .toMatchTypeOf<object | Array<string | object>>();
     });
 
     it('should provide information when `returnDetails` is `true`', () => {

--- a/typescript/helpers.d.ts
+++ b/typescript/helpers.d.ts
@@ -58,3 +58,11 @@ type $StringKeyPathToRecordUnion<
 export type $StringKeyPathToRecord<TPath extends string, TValue> = $UnionToIntersection<
   $StringKeyPathToRecordUnion<TPath, TValue>
 >;
+
+/**
+ * We could use NoInfer typescript build-in utility,
+ * however this project still supports ts < 5.4.
+ *
+ * @see https://github.com/millsp/ts-toolbelt/blob/master/sources/Function/NoInfer.ts
+ */
+export type $NoInfer<A> = [A][A extends any ? 0 : never];

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -4,6 +4,7 @@ import type {
   $Dictionary,
   $SpecialObject,
   $StringKeyPathToRecord,
+  $NoInfer,
 } from './helpers.js';
 import type {
   TypeOptions,
@@ -260,6 +261,12 @@ export type TFunctionDetailedResult<T = string, TOpt extends TOptions = {}> = {
   usedParams: InterpolationMap<T> & { count?: TOpt['count'] };
 };
 
+type TFunctionProcessReturnValue<Ret, DefaultValue> = Ret extends string | $SpecialObject | null
+  ? Ret
+  : [DefaultValue] extends [never]
+  ? Ret
+  : DefaultValue;
+
 type TFunctionReturnOptionalDetails<Ret, TOpt extends TOptions> = TOpt['returnDetails'] extends true
   ? TFunctionDetailedResult<Ret, TOpt>
   : Ret;
@@ -278,12 +285,13 @@ export interface TFunction<Ns extends Namespace = DefaultNamespace, KPrefix = un
     const TOpt extends TOptions,
     Ret extends TFunctionReturn<Ns, AppendKeyPrefix<Key, KPrefix>, TOpt>,
     const ActualOptions extends TOpt & InterpolationMap<Ret> = TOpt & InterpolationMap<Ret>,
+    DefaultValue extends string = never,
   >(
     ...args:
       | [key: Key | Key[], options?: ActualOptions]
-      | [key: string | string[], options: TOpt & $Dictionary & { defaultValue: string }]
-      | [key: string | string[], defaultValue: string, options?: TOpt & $Dictionary]
-  ): TFunctionReturnOptionalDetails<Ret, TOpt>;
+      | [key: string | string[], options: TOpt & $Dictionary & { defaultValue: DefaultValue }]
+      | [key: string | string[], defaultValue: DefaultValue, options?: TOpt & $Dictionary]
+  ): TFunctionReturnOptionalDetails<TFunctionProcessReturnValue<$NoInfer<Ret>, DefaultValue>, TOpt>;
 }
 
 export type KeyPrefix<Ns extends Namespace> = ResourceKeys<true>[$FirstNamespace<Ns>] | undefined;


### PR DESCRIPTION
Close #2232

Now `TFunction` do not infer return type. In addition if defaultValue is provided and the key is not mapped in `Resources` the return type of the `TFunction` will be inferred by `DefaultValue`.


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
