### PR TITLE
fix(types): make context related keys detection stricter

### DIFF
--- a/test/typescript/custom-types/t.test.ts
+++ b/test/typescript/custom-types/t.test.ts
@@ -175,9 +175,16 @@ describe('t', () => {
         MUFFIN = 'muffin',
       }
 
-      const ctx = Dessert.CAKE;
+      expectTypeOf(t('dessert', { context: Dessert.CAKE })).toMatchTypeOf<string>();
 
+      const ctx: Dessert = Dessert.CAKE;
       expectTypeOf(t('dessert', { context: ctx })).toMatchTypeOf<string>();
+    });
+
+    it('should not provide partial match as option when keys include context separator', () => {
+      // https://github.com/i18next/i18next/issues/2242
+      // @ts-expect-error
+      t('beverageater');
     });
 
     it('should trow error with string union with missing context value', () => {

--- a/test/typescript/many-keys/PERF_README.md
+++ b/test/typescript/many-keys/PERF_README.md
@@ -13,14 +13,13 @@ cd test/typescript/many-keys
 Then run tsc
 
 ```bash
-time tsc --noEmit
+time npx tsc --noEmit
 ```
 
 Alternatively you can also debug using [ts trace](https://github.com/microsoft/typescript-analyze-trace)
 
 ```bash
-tsc -p tsconfig.json --generateTrace traceDir && analyze-trace traceDir
+npx tsc -p tsconfig.json --generateTrace traceDir && analyze-trace traceDir
 ```
 
-Or you can debug using `chrome://tracing`. A guide can be found here:
-https://github.com/microsoft/TypeScript/wiki/Performance#performance-tracing
+Or you can debug using `chrome://tracing`. A guide can be on the [Typescript repository wiki](https://github.com/microsoft/TypeScript/wiki/Performance#performance-tracing).

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -712,7 +712,7 @@ export interface TOptionsBase {
   /**
    * Used for contexts (eg. male\female)
    */
-  context?: any;
+  context?: unknown;
   /**
    * Object with vars for interpolation - or put them directly in options
    */

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -127,9 +127,11 @@ type ParseKeysByFallbackNs<Keys extends $Dictionary> = _FallbackNamespace extend
   ? Keys[UnionFallbackNs]
   : Keys[_FallbackNamespace & string];
 
-type FilterKeysByContext<Keys, Context> = Context extends string
-  ? Keys extends `${infer Prefix}${_ContextSeparator}${Context}${infer Suffix}`
-    ? `${Prefix}${Suffix}`
+export type FilterKeysByContext<Keys, Context> = Context extends string
+  ? Keys extends
+      | `${infer Prefix}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
+      | `${infer Prefix}${_ContextSeparator}${Context}`
+    ? Prefix
     : never
   : Keys;
 


### PR DESCRIPTION
Close #2242

----

Now `FilterKeysByContext` is more strict and should not suggest "stripped" keys  like reported in #2242

---

### Limitation

Considering the following namespace:

```ts
export type TestNamespaceContext = {
  dessert_cake: 'a nice cake';
  dessert_muffin_one: 'a nice muffin';
  dessert_muffin_other: '{{count}} nice muffins';

  beverage: 'a classic beverage';
  beverage_beer: 'fresh beer';
  beverage_water: 'cold water';
};
```

`dessert` context related keys have no default and with the current type architecture 
the `dessert` key can't be showed in suggestion. On the contrary all context values can.

E.g.:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/e7952398-ce85-46a6-8774-7466f4b46c32">



#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
