### PR TITLE
perf: use Intl.getCanonicalLocale

### DIFF
--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -1,8 +1,6 @@
 import baseLogger from './logger.js';
 import { getCleanedCode } from './utils.js';
 
-const capitalize = (string) => string.charAt(0).toUpperCase() + string.slice(1);
-
 class LanguageUtil {
   constructor(options) {
     this.options = options;
@@ -33,28 +31,13 @@ class LanguageUtil {
   formatLanguageCode(code) {
     // http://www.iana.org/assignments/language-tags/language-tags.xhtml
     if (typeof code === 'string' && code.indexOf('-') > -1) {
-      const specialCases = ['hans', 'hant', 'latn', 'cyrl', 'cans', 'mong', 'arab'];
-      let p = code.split('-');
+      let formattedCode = Intl.getCanonicalLocales(code)[0];
 
       if (this.options.lowerCaseLng) {
-        p = p.map((part) => part.toLowerCase());
-      } else if (p.length === 2) {
-        p[0] = p[0].toLowerCase();
-        p[1] = p[1].toUpperCase();
-
-        if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
-      } else if (p.length === 3) {
-        p[0] = p[0].toLowerCase();
-
-        // if length 2 guess it's a country
-        if (p[1].length === 2) p[1] = p[1].toUpperCase();
-        if (p[0] !== 'sgn' && p[2].length === 2) p[2] = p[2].toUpperCase();
-
-        if (specialCases.indexOf(p[1].toLowerCase()) > -1) p[1] = capitalize(p[1].toLowerCase());
-        if (specialCases.indexOf(p[2].toLowerCase()) > -1) p[2] = capitalize(p[2].toLowerCase());
+        formattedCode = formattedCode.toLowerCase();
       }
 
-      return p.join('-');
+      return formattedCode;
     }
 
     return this.options.cleanCode || this.options.lowerCaseLng ? code.toLowerCase() : code;

--- a/src/utils.js
+++ b/src/utils.js
@@ -246,7 +246,4 @@ export const deepFind = (obj, path, keySeparator = '.') => {
   return current;
 };
 
-export const getCleanedCode = (code) => {
-  if (code && code.indexOf('_') > 0) return code.replace('_', '-');
-  return code;
-};
+export const getCleanedCode = (code) => code && code.replace('_', '-');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Since this code was created 9 years ago there has been standardisation around this and it's now part of the Intl object.

Replacing this should have no impact on support as it has had full browser support for several years now: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales

This reduces the size by 519 bytes (`49 096 bytes -> 48 577 bytes`) and should be faster as it has a native implementation.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)