### PR TITLE
Introducing i18next Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![cdnjs version](https://img.shields.io/cdnjs/v/i18next.svg?style=flat-square)](https://cdnjs.com/libraries/i18next)
 [![npm version](https://img.shields.io/npm/v/i18next.svg?style=flat-square)](https://www.npmjs.com/package/i18next)
 ![npm](https://img.shields.io/npm/dw/i18next)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20i18next%20Guru-006BFF)](https://gurubase.io/g/i18next)
 
 i18next is a very popular internationalization framework for browser or any other javascript environment (eg. Node.js, Deno).
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [i18next Guru](https://gurubase.io/g/i18next) to Gurubase. i18next Guru uses the data from this repo and data from the [docs](https://www.i18next.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "i18next Guru", which highlights that i18next now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable i18next Guru in Gurubase, just let me know that's totally fine.
