### PR TITLE
types: refine `i18next.on` type assertion after `vitest` update

### DIFF
--- a/test/typescript/misc/exposed.test.ts
+++ b/test/typescript/misc/exposed.test.ts
@@ -49,10 +49,14 @@ describe('exposed', () => {
   });
 
   describe('eventEmitter', () => {
+    /**
+     * After vitest 2.1 update accessing `parameters` of this `i18next.on` reports an error.
+     * Probably it is related to the fact that the function has different overrides.
+     * As a workaround we perform the assertions on the "full" function type
+     */
     expectTypeOf(i18next.on).toMatchTypeOf<
       (event: string, callback: (...args: unknown[]) => void) => void
     >();
-    expectTypeOf(i18next.on).returns.toBeVoid();
 
     expectTypeOf(i18next.emit).parameters.toMatchTypeOf<[string, ...unknown[]]>();
     expectTypeOf(i18next.emit).returns.toBeVoid();


### PR DESCRIPTION
Related to https://github.com/i18next/i18next/pull/2259#issuecomment-2490842688

@adrai  your fix was good 😉. 

Few minor additions:

- Removed redundant assertion 
  (`expectTypeOf(i18next.on).toMatchTypeOf<...>()` already checks the return type)
- Added a comment explaining why this assertion is different from the others 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)