### PR TITLE
fix: incorrect locale detected

### DIFF
--- a/src/LanguageUtils.js
+++ b/src/LanguageUtils.js
@@ -31,7 +31,16 @@ class LanguageUtil {
   formatLanguageCode(code) {
     // http://www.iana.org/assignments/language-tags/language-tags.xhtml
     if (isString(code) && code.indexOf('-') > -1) {
-      let formattedCode = Intl.getCanonicalLocales(code)[0];
+      let formattedCode;
+      try {
+        formattedCode = Intl.getCanonicalLocales(code)[0];
+      } catch (e) {
+        // this can happen if the detected language is not valid
+        // for example: if the path detector is used and the requested path is `/providers`
+        if (!(e instanceof RangeError) || e.message !== 'Incorrect locale information provided') {
+          throw e;
+        }
+      }
       if (formattedCode && this.options.lowerCaseLng) {
         formattedCode = formattedCode.toLowerCase();
       }

--- a/test/runtime/languageUtils.test.js
+++ b/test/runtime/languageUtils.test.js
@@ -319,6 +319,7 @@ describe('LanguageUtils', () => {
       { args: [['c']], expected: 'en' },
       { args: [['e']], expected: 'en' },
       { args: [['user-id']], expected: 'en' },
+      { args: [['en-AU-SA']], expected: 'en' },
       { args: [[]], expected: 'en' },
     ];
 

--- a/test/runtime/languageUtils.test.js
+++ b/test/runtime/languageUtils.test.js
@@ -318,6 +318,7 @@ describe('LanguageUtils', () => {
       { args: [['ru']], expected: 'en' },
       { args: [['c']], expected: 'en' },
       { args: [['e']], expected: 'en' },
+      { args: [['user-id']], expected: 'en' },
       { args: [[]], expected: 'en' },
     ];
 


### PR DESCRIPTION
Some language detectors may return invalid languages which cause `Intl.getCanonicalLocales` to throw. In this case, we need to swallow the error and ignore the detected language.