### PR TITLE
fix(typescript): make `TFunction` augmentable

### DIFF
--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -317,9 +317,12 @@ interface TFunctionNonStrict<Ns extends Namespace = DefaultNamespace, KPrefix = 
   ): TFunctionReturnOptionalDetails<TFunctionProcessReturnValue<$NoInfer<Ret>, DefaultValue>, TOpt>;
 }
 
-export type TFunction<
+type TFunctionSignature<
   Ns extends Namespace = DefaultNamespace,
   KPrefix = undefined,
 > = _StrictKeyChecks extends true ? TFunctionStrict<Ns, KPrefix> : TFunctionNonStrict<Ns, KPrefix>;
+
+export interface TFunction<Ns extends Namespace = DefaultNamespace, KPrefix = undefined>
+  extends TFunctionSignature<Ns, KPrefix> {}
 
 export type KeyPrefix<Ns extends Namespace> = ResourceKeys<true>[$FirstNamespace<Ns>] | undefined;


### PR DESCRIPTION
Change `TFunction` typing back into `interface` so it can be augmentable, wrapping the actual type in `TFunctionSignature`. Would fix #2278 (? need to verify)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)