### PR TITLE
only log loaded translations in debug mode

### DIFF
--- a/src/BackendConnector.js
+++ b/src/BackendConnector.js
@@ -224,8 +224,10 @@ class Connector extends EventEmitter {
 
     this.read(lng, ns, 'read', undefined, undefined, (err, data) => {
       if (err) this.logger.warn(`${prefix}loading namespace ${ns} for language ${lng} failed`, err);
-      if (!err && data)
-        this.logger.log(`${prefix}loaded namespace ${ns} for language ${lng}`, data);
+      if (!err && data) {
+        this.logger.log(`${prefix}loaded namespace ${ns} for language ${lng}`);
+        this.logger.debug(data);
+      }
 
       this.loaded(name, err, data);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ x ] only relevant code is changed (make a diff before you submit the PR)
- [ x ] run tests `npm run test`
  - 3 failing unit tests are related to date formatting
- [ ] tests are included
  - This is a very small change.
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

There's a lot of console output and there's no way to change the log level to only show warnings or errors. This PR would cause i18next to only log all translations when the debug config option is set to true.