### PR TITLE
Make changeLanguage function does no detection

### DIFF
--- a/src/i18next.js
+++ b/src/i18next.js
@@ -345,11 +345,13 @@ class I18n extends EventEmitter {
 
     const done = (err, l) => {
       if (l) {
-        setLngProps(l);
-        this.translator.changeLanguage(l);
-        this.isLanguageChangingTo = undefined;
-        this.emit('languageChanged', l);
-        this.logger.log('languageChanged', l);
+        if (this.isLanguageChangingTo === lng) {
+          setLngProps(l);
+          this.translator.changeLanguage(l);
+          this.isLanguageChangingTo = undefined;
+          this.emit('languageChanged', l);
+          this.logger.log('languageChanged', l);
+        }
       } else {
         this.isLanguageChangingTo = undefined;
       }


### PR DESCRIPTION
Create a new PR to further discuss [This](https://github.com/i18next/i18next/pull/2298#issuecomment-2798492685)

Now, there're only four failed test cases.

So I think the question is why we need to support `undefined` for the `lng` arg in `changeLanguage(lng, callback)`

```
 Test Files  1 failed | 50 passed (51)
      Tests  4 failed | 895 passed | 9 skipped (908)
```

https://github.com/i18next/i18next/blob/59498aede43b28d2c29806da0fb947c8c62795b1/test/runtime/languageDetector.test.js#L20-L26

https://github.com/i18next/i18next/blob/59498aede43b28d2c29806da0fb947c8c62795b1/test/runtime/languageDetector.test.js#L51-L58

https://github.com/i18next/i18next/blob/59498aede43b28d2c29806da0fb947c8c62795b1/test/runtime/languageDetector.test.js#L77-L83

https://github.com/i18next/i18next/blob/59498aede43b28d2c29806da0fb947c8c62795b1/test/runtime/languageDetector.test.js#L109-L117

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)