### PR TITLE
Ensure `nsSeparator` is respected when `appendNamespaceToMissingKey` is `true`

### DIFF
--- a/i18next.js
+++ b/i18next.js
@@ -665,9 +665,15 @@
           }
         }
         res = this.extendTranslation(res, keys, opt, resolved, lastKey);
-        if (usedKey && res === key && this.options.appendNamespaceToMissingKey) res = `${namespace}:${key}`;
+        if (usedKey && res === key && this.options.appendNamespaceToMissingKey) {
+          let nsSeparator = opt.nsSeparator !== undefined ? opt.nsSeparator : this.options.nsSeparator;
+          if (nsSeparator === undefined) nsSeparator = ':';
+          res = `${namespace}${nsSeparator}${key}`;
+        }
         if ((usedKey || usedDefault) && this.options.parseMissingKeyHandler) {
-          res = this.options.parseMissingKeyHandler(this.options.appendNamespaceToMissingKey ? `${namespace}:${key}` : key, usedDefault ? res : undefined, opt);
+          let nsSeparator = opt.nsSeparator !== undefined ? opt.nsSeparator : this.options.nsSeparator;
+          if (nsSeparator === undefined) nsSeparator = ':';
+          res = this.options.parseMissingKeyHandler(this.options.appendNamespaceToMissingKey ? `${namespace}${nsSeparator}${key}` : key, usedDefault ? res : undefined, opt);
         }
       }
       if (returnDetails) {

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -327,13 +327,20 @@ class Translator extends EventEmitter {
       res = this.extendTranslation(res, keys, opt, resolved, lastKey);
 
       // append namespace if still key
-      if (usedKey && res === key && this.options.appendNamespaceToMissingKey)
-        res = `${namespace}:${key}`;
+      if (usedKey && res === key && this.options.appendNamespaceToMissingKey) {
+        let nsSeparator =
+          opt.nsSeparator !== undefined ? opt.nsSeparator : this.options.nsSeparator;
+        if (nsSeparator === undefined) nsSeparator = ':';
+        res = `${namespace}${nsSeparator}${key}`;
+      }
 
       // parseMissingKeyHandler
       if ((usedKey || usedDefault) && this.options.parseMissingKeyHandler) {
+        let nsSeparator =
+          opt.nsSeparator !== undefined ? opt.nsSeparator : this.options.nsSeparator;
+        if (nsSeparator === undefined) nsSeparator = ':';
         res = this.options.parseMissingKeyHandler(
-          this.options.appendNamespaceToMissingKey ? `${namespace}:${key}` : key,
+          this.options.appendNamespaceToMissingKey ? `${namespace}${nsSeparator}${key}` : key,
           usedDefault ? res : undefined,
           opt,
         );


### PR DESCRIPTION
Fixes #2310.

I tried to make the `nsSeparator` checks consistent with the ones in `extractFromKey`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)