### PR TITLE
fix: fix selector api with custom separators (fix for #2341)

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -90,8 +90,7 @@ class Translator extends EventEmitter {
       /* eslint prefer-rest-params: 0 */
       opt = this.options.overloadTranslationOptionHandler(arguments);
     }
-    if (typeof options === 'object') opt = { ...opt };
-    if (!opt) opt = {};
+    if (!opt) opt = { ...this.options };
 
     // non valid keys handling
     if (keys == null /* || keys === '' */) return '';

--- a/test/runtime/translator/translator.translate.selector.test.js
+++ b/test/runtime/translator/translator.translate.selector.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import Translator from '../../../src/Translator.js';
+import ResourceStore from '../../../src/ResourceStore.js';
+import LanguageUtils from '../../../src/LanguageUtils.js';
+import PluralResolver from '../../../src/PluralResolver.js';
+import Interpolator from '../../../src/Interpolator.js';
+
+describe('Translator', () => {
+  describe('translate() with selector and custom separators', () => {
+    /** @type {Translator} */
+    let t;
+
+    beforeAll(() => {
+      const rs = new ResourceStore({
+        en: {
+          root: {
+            foo: {
+              bar: 'foobar'
+            }
+          },
+        },
+      });
+      const lu = new LanguageUtils({ fallbackLng: 'en' });
+      t = new Translator(
+        {
+          resourceStore: rs,
+          languageUtils: lu,
+          pluralResolver: new PluralResolver(lu, { prepend: '_', simplifyPluralSuffix: true }),
+          interpolator: new Interpolator(),
+        },
+        {
+          returnObjects: true,
+          ns: 'root',
+          defaultNS: 'root',
+          nsSeparator: ':::',
+          keySeparator: '::',
+          pluralSeparator: '##',
+          contextSeparator: '##',
+          interpolation: {},
+        },
+      );
+      t.changeLanguage('en');
+    });
+
+    const tests = [
+      { args: ['root:::foo::bar'], expected: 'foobar' },
+      { args: ['foo::bar'], expected: 'foobar' },
+    ];
+
+    tests.forEach((test) => {
+      it(`correctly translates for ${JSON.stringify(test.args)} args`, () => {
+        expect(t.translate.apply(t, test.args)).toEqual(test.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
`typeof options === 'object'` is useless, because it always undefined (code should check this.options instead `options`, also 1. `this.options` can't be non-object 2. even with `undefined` / `null` fix will work fine)

---
#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)