### PR TITLE
exports `keyFromSelector` function for testing purposes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -574,4 +574,7 @@ export const setDefaultNamespace: i18n['setDefaultNamespace'];
 export const hasLoadedNamespace: i18n['hasLoadedNamespace'];
 export const loadNamespaces: i18n['loadNamespaces'];
 export const loadLanguages: i18n['loadLanguages'];
-export function keyFromSelector(selector: ($: Record<string, any>) => any): string;
+
+export declare function keyFromSelector<S = Record<string, any>, T = string>(
+  selector: ($: S) => T,
+): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -574,3 +574,4 @@ export const setDefaultNamespace: i18n['setDefaultNamespace'];
 export const hasLoadedNamespace: i18n['hasLoadedNamespace'];
 export const loadNamespaces: i18n['loadNamespaces'];
 export const loadLanguages: i18n['loadLanguages'];
+export function keyFromSelector(selector: ($: Record<string, any>) => any): string;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import i18next from './i18next.js';
 
-export { default as keysFromSelector } from './selector.js';
+export { default as keyFromSelector } from './selector.js';
 
 export default i18next;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import i18next from './i18next.js';
 
+export { default as keysFromSelector } from './selector.js';
+
 export default i18next;
 
 export const createInstance = i18next.createInstance;


### PR DESCRIPTION
Closes #2345

#### Todo
- [x] Document `keyFromSelector` (PR: https://github.com/i18next/i18next-gitbook/pull/237)
- [x] Add type declaration for `keyFromSelector`
- [ ] Decide: should I attach `keyFromSelector` to the default export (`i18next`) instead?

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)