### PR TITLE
exports `keyFromSelector` from `index.cjs`

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -1,3 +1,5 @@
 import i18next from './i18next.js';
 
+export { default as keyFromSelector } from './selector.js';
+
 export default i18next;


### PR DESCRIPTION
Looks like I forgot to include CommonCJ when I opened #2346 yesterday – my bad!

Are there any other places I should check to make sure it's exported from?

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)