### PR TITLE
fix: TFunctionReturn fallback

### DIFF
--- a/test/typescript/custom-types/getFixedT.test.ts
+++ b/test/typescript/custom-types/getFixedT.test.ts
@@ -51,7 +51,7 @@ describe('getFixedT', () => {
     expectTypeOf(t('bar')).toEqualTypeOf<'bar'>();
 
     expectTypeOf(t('foobar.barfoo', { ns: 'alternate' })).toEqualTypeOf<'barfoo'>();
-    expectTypeOf(t('fallbackKey')).toEqualTypeOf<never>();
+    expectTypeOf(t('fallbackKey')).toBeString();
 
     // @ts-expect-error
     assertType(t('alternate:foobar.barfoo'));

--- a/test/typescript/fallback-types/getFixedT.test.ts
+++ b/test/typescript/fallback-types/getFixedT.test.ts
@@ -17,7 +17,7 @@ describe('t', () => {
   });
 
   it('should accept fallback keys', () => {
-    expectTypeOf(t('fallbackKey')).toEqualTypeOf<never>();
-    expectTypeOf(t('anotherFallbackKey')).toEqualTypeOf<never>();
+    expectTypeOf(t('fallbackKey')).toBeString();
+    expectTypeOf(t('anotherFallbackKey')).toBeString();
   });
 });

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -244,7 +244,20 @@ export type TFunctionReturn<
 > = $IsResourcesDefined extends true
   ? ActualKey extends `${infer Nsp}${_NsSeparator}${infer RestKey}`
     ? ParseTReturn<RestKey, Resources[Nsp & keyof Resources], TOpt>
-    : ParseTReturn<ActualKey, Resources[$FirstNamespace<ActualNS>], TOpt>
+    : $PreservedValue<
+        ParseTReturn<ActualKey, Resources[$FirstNamespace<ActualNS>], TOpt>,
+        ParseTReturn<
+          ActualKey,
+          _FallbackNamespace extends readonly (infer FN)[]
+            ? Resources[FN & keyof Resources]
+            : [_FallbackNamespace] extends [false]
+              ? never
+              : Extract<_FallbackNamespace, keyof Resources> extends infer K
+                ? Resources[K & keyof Resources]
+                : never,
+          TOpt
+        >
+      >
   : DefaultTReturn<TOpt>;
 
 export type TFunctionDetailedResult<T = string, TOpt extends TOptions = {}> = {


### PR DESCRIPTION
Closes #2360 

I had some problems trying to support fallbackNS *arrays*, which made it a bit more complicated than the simple fix I proposed in the issue. I'm not a typescript expert so there might be a simpler way.

I think the tests I changed already cover the fix so I didn't add any extra.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)