### PR TITLE
Improve readability of JSDoc comment

### DIFF
--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -394,8 +394,8 @@ export interface InitOptions<T = object> extends PluginOptions<T> {
   nonExplicitSupportedLngs?: boolean;
 
   /**
-   * Language codes to lookup, given set language is
-   * 'en-US': 'all' --> ['en-US', 'en', 'dev'],
+   * Language codes to lookup, given set language is 'en-US':
+   * 'all' --> ['en-US', 'en', 'dev'],
    * 'currentOnly' --> 'en-US',
    * 'languageOnly' --> 'en'
    * @default 'all'


### PR DESCRIPTION
Clarifies that `en-US` is not part of the first case.

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)