### PR TITLE
fix(types): Selector API - fix Namespace inference for selector `ns` option

### DIFF
--- a/test/typescript/selector-custom-types/t.test.ts
+++ b/test/typescript/selector-custom-types/t.test.ts
@@ -355,4 +355,12 @@ describe('t', () => {
       t(($) => $.keypath_deep, { suffering: { in: { the: 'yes' } } });
     });
   });
+
+  // https://github.com/i18next/i18next/issues/2383
+  it('should error when using a defined namespace that is not present in TFunction NS type parameter', () => {
+    const t: TFunction<['alternate']> = (() => '') as never;
+
+    // @ts-expect-error
+    t(($) => $.foo, { ns: 'custom' });
+  });
 });

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -375,17 +375,24 @@ export type KeyPrefix<Ns extends Namespace> = ResourceKeys<true>[$FirstNamespace
 ///  ↆ selector ↆ  ///
 /// ////////////// ///
 
+type NsArg<Ns extends Namespace> = Ns[number] | readonly Ns[number][];
+
 interface TFunctionSelector<Ns extends Namespace, KPrefix, Source> extends Branded<Ns> {
   <
     Target extends ConstrainTarget<Opts>,
+    const NewNs extends NsArg<Ns> & Namespace,
     const Opts extends SelectorOptions<NewNs>,
-    NewNs extends Namespace,
     NewSrc extends GetSource<NewNs, KPrefix>,
   >(
     selector: SelectorFn<NewSrc, ApplyTarget<Target, Opts>, Opts>,
     options: Opts & InterpolationMap<Target> & { ns: NewNs },
   ): SelectorReturn<Target, Opts>;
-  <Target extends ConstrainTarget<Opts>, const Opts extends SelectorOptions<Ns>>(
+
+  <
+    Target extends ConstrainTarget<Opts>,
+    const NewNs extends NsArg<Ns> = Ns[number],
+    const Opts extends SelectorOptions<NewNs> = SelectorOptions<NewNs>,
+  >(
     selector: SelectorFn<Source, ApplyTarget<Target, Opts>, Opts>,
     options?: Opts & InterpolationMap<Target>,
   ): SelectorReturn<Target, Opts>;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

- closes #2383

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
