### PR TITLE
Avoid crash due to ReferenceError without Intl API

### DIFF
--- a/src/PluralResolver.js
+++ b/src/PluralResolver.js
@@ -47,7 +47,7 @@ class PluralResolver {
     try {
       rule = new Intl.PluralRules(cleanedCode, { type });
     } catch (err) {
-      if (!Intl) {
+      if (typeof Intl === 'undefined') {
         this.logger.error('No Intl support, please use an Intl polyfill!');
         return dummyRule;
       }


### PR DESCRIPTION
Fixes the following error:
ReferenceError: Intl is not defined

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)