### PR TITLE
types(i18n): add missing toJSON() declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -395,6 +395,17 @@ export interface i18n extends CustomInstanceExtensions {
   cloneInstance(options?: CloneOptions, callback?: Callback): i18n;
 
   /**
+   * Returns a JSON representation of the i18next instance for serialization.
+   */
+  toJSON(): {
+    options: InitOptions;
+    store: ResourceStore;
+    language: string;
+    languages: readonly string[];
+    resolvedLanguage?: string;
+  };
+
+  /**
    * Gets fired after initialization.
    */
   on(event: 'initialized', callback: (options: InitOptions) => void): void;

--- a/test/typescript/misc/toJSON.test.ts
+++ b/test/typescript/misc/toJSON.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import i18next, { InitOptions, ResourceStore } from 'i18next';
+
+describe('toJSON', () => {
+  it('should be callable', () => {
+    expectTypeOf(i18next.toJSON).toBeFunction();
+  });
+
+  it('should return an object with the correct shape', () => {
+    const result = i18next.toJSON();
+
+    expectTypeOf(result).toHaveProperty('options').toEqualTypeOf<InitOptions>();
+    expectTypeOf(result).toHaveProperty('store').toEqualTypeOf<ResourceStore>();
+    expectTypeOf(result).toHaveProperty('language').toEqualTypeOf<string>();
+    expectTypeOf(result).toHaveProperty('languages').toEqualTypeOf<readonly string[]>();
+    expectTypeOf(result).toHaveProperty('resolvedLanguage').toEqualTypeOf<string | undefined>();
+  });
+});


### PR DESCRIPTION
## What
Add missing `toJSON()` declaration to the `i18n` interface.

## Why
Runtime already exposes `I18n#toJSON()` but TypeScript types did not, so `i18next.toJSON()` was not type-safe / discoverable.

## How
- Add `toJSON()` signature to `index.d.ts`.
- Add a TypeScript regression test under `test/typescript/misc`.

## Tests
- npm run format
- npm run lint
- npm run test:typescript -- --project misc

## Risk
Type-only change; no runtime behavior changes. Return shape matches runtime `toJSON()` implementation.