### PR TITLE
fix(interpolator): escape nestingOptionsSeparator in nesting option parsing

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -228,7 +228,7 @@ class Interpolator {
       const sep = this.nestingOptionsSeparator;
       if (key.indexOf(sep) < 0) return key;
 
-      const c = key.split(new RegExp(`${sep}[ ]*{`));
+      const c = key.split(new RegExp(`${regexEscape(sep)}[ ]*{`));
 
       let optionsString = `{${c[1]}`;
       key = c[0];

--- a/test/runtime/interpolation.test.js
+++ b/test/runtime/interpolation.test.js
@@ -370,6 +370,24 @@ describe('Interpolator', () => {
     });
   });
 
+  describe('interpolate() - nesting with regex meta char nestingOptionsSeparator', () => {
+    /** @type {Interpolator} */
+    let ip;
+
+    beforeAll(() => {
+      ip = new Interpolator({
+        interpolation: {
+          nestingOptionsSeparator: '+',
+        },
+      });
+    });
+
+    it('correctly parses nesting options when separator is a regex meta character', () => {
+      const result = ip.nest('$t(test+ {"key":"success"})', (key, opts) => `${key} ${opts.key}`);
+      expect(result).to.eql('test success');
+    });
+  });
+
   describe('interpolate() - backwards compatible', () => {
     /** @type {Interpolator} */
     let ip;


### PR DESCRIPTION
## What
Fix nesting option parsing by escaping `nestingOptionsSeparator` before constructing the internal `RegExp` in `Interpolator#nest()`.

## Why
`nestingOptionsSeparator` is user-configurable (default: `,`).  
When it contains regex meta characters (e.g. `+`, `*`, `|`, `(`), the current `RegExp` construction can throw or break the split logic.

## How
- Escape `sep` with `regexEscape(sep)` when building the `RegExp` in `handleHasOptions()`.
- Add a runtime regression test covering a separator with a regex meta character (e.g. `+`).

## Tests
- npm run format
- npm run lint
- npm run test:runtime

## Risk
Internal parsing fix only. Default separator behavior remains unchanged. No public API changes.