### PR TITLE
fix(interpolator): guard null matchedDoubleQuotes in nesting option parsing

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -237,7 +237,7 @@ class Interpolator {
       const matchedDoubleQuotes = optionsString.match(/"/g);
       if (
         ((matchedSingleQuotes?.length ?? 0) % 2 === 0 && !matchedDoubleQuotes) ||
-        matchedDoubleQuotes.length % 2 !== 0
+        (matchedDoubleQuotes?.length ?? 0) % 2 !== 0
       ) {
         optionsString = optionsString.replace(/'/g, '"');
       }

--- a/test/runtime/interpolation.test.js
+++ b/test/runtime/interpolation.test.js
@@ -370,6 +370,20 @@ describe('Interpolator', () => {
     });
   });
 
+  describe('interpolate() - nesting with null matchedDoubleQuotes', () => {
+    /** @type {Interpolator} */
+    let ip;
+
+    beforeAll(() => {
+      ip = new Interpolator({ interpolation: { escapeValue: false } });
+    });
+
+    it('should not crash when optionsString has no double quotes', () => {
+      const result = ip.nest("$t(test, {'key': '{{val}}'})", () => 'ok', { val: "it's" });
+      expect(result).to.eql('ok');
+    });
+  });
+
   describe('interpolate() - nesting with regex meta char nestingOptionsSeparator', () => {
     /** @type {Interpolator} */
     let ip;


### PR DESCRIPTION
## What
Guard `matchedDoubleQuotes` null access in `Interpolator#nest()` option parsing.

## Why
`optionsString.match(/"/g)` can return `null`. In the current logic, `matchedDoubleQuotes.length` may be evaluated when `matchedSingleQuotes` count becomes odd (e.g. single-quoted options + interpolated value contains an apostrophe), causing a `TypeError`.

## How
- Change `matchedDoubleQuotes.length` to `(matchedDoubleQuotes?.length ?? 0)` in the conditional guard.

## Tests
- Add a runtime regression test covering single-quoted options with an interpolated value containing an apostrophe (escape disabled to reproduce reliably).
- npm run format
- npm run lint
- npm run test:runtime

## Risk
Minimal one-line null-guard; no public API changes.