### PR TITLE
fix: getCleanedCode now replaces all underscores

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -252,4 +252,4 @@ export const deepFind = (obj, path, keySeparator = '.') => {
   return current;
 };
 
-export const getCleanedCode = (code) => code?.replace('_', '-');
+export const getCleanedCode = (code) => code?.replace(/_/g, '-');

--- a/test/runtime/utils.test.js
+++ b/test/runtime/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deepExtend, deepFind } from '../../src/utils.js';
+import { deepExtend, deepFind, getCleanedCode } from '../../src/utils.js';
 
 describe('utils', () => {
   describe('#deepExtend', () => {
@@ -59,6 +59,28 @@ describe('utils', () => {
       const obj = { a: [{ c: 1 }] };
       const value = deepFind(obj, 'a.0.c');
       expect(value).toEqual(1);
+    });
+  });
+
+  describe('#getCleanedCode', () => {
+    it('should replace single underscore', () => {
+      expect(getCleanedCode('en_US')).toBe('en-US');
+    });
+
+    it('should replace all underscores in locale codes', () => {
+      expect(getCleanedCode('zh_Hant_TW')).toBe('zh-Hant-TW');
+      expect(getCleanedCode('en_US_POSIX')).toBe('en-US-POSIX');
+      expect(getCleanedCode('sr_Latn_RS')).toBe('sr-Latn-RS');
+    });
+
+    it('should return undefined for nullish input', () => {
+      expect(getCleanedCode(undefined)).toBeUndefined();
+      expect(getCleanedCode(null)).toBeUndefined();
+    });
+
+    it('should return code unchanged if no underscores', () => {
+      expect(getCleanedCode('en-US')).toBe('en-US');
+      expect(getCleanedCode('ko')).toBe('ko');
     });
   });
 });


### PR DESCRIPTION
## What

Fix `getCleanedCode()` to replace all underscores in locale codes, not just the first one.

## Why

`String.prototype.replace(string, string)` only replaces the first match.
Locale codes with multiple underscores (e.g. `zh_Hant_TW`, `en_US_POSIX`, `sr_Latn_RS`) were incorrectly cleaned:

```
'zh_Hant_TW'.replace('_', '-') → 'zh-Hant_TW'  // second _ remains
```

This affects all locale normalization paths — `LanguageUtils`, `PluralResolver`, and `Formatter` — potentially passing malformed locale strings to `Intl.PluralRules`, `Intl.NumberFormat`, etc.

## How

- Change `code?.replace('_', '-')` to `code?.replace(/_/g, '-')` in `src/utils.js:255`.
- Add `getCleanedCode` test cases in `test/runtime/utils.test.js` covering multi-underscore locales, single underscore, no underscore, and nullish input.

## Tests

- npm run format
- npm run lint
- npm test
- Verified failure with original code: `'zh-Hant_TW'` instead of expected `'zh-Hant-TW'`

## Risk

Minimal one-line regex change; no public API changes. Existing single-underscore locales behave identically. Only multi-underscore locales are now correctly normalized.