### PR TITLE
fix(package): typescript peerDependencies version range syntax is not correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/runtime": "^7.29.2"
   },
   "peerDependencies": {
-    "typescript": "^5 | ^6"
+    "typescript": "^5 || ^6"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
<img width="505" height="309" alt="image" src="https://github.com/user-attachments/assets/cd50eb45-5ed3-4abe-8fc4-51307f270e11" />