### PR TITLE
fix(types): add type predicate overload to ExistsFunction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -223,6 +223,7 @@ export interface ExistsFunction<
   TKeys extends string = string,
   TInterpolationMap extends object = $Dictionary,
 > {
+  <K extends TKeys>(key: K, options?: TOptions<TInterpolationMap>): key is K & SelectorKey;
   (key: TKeys | TKeys[], options?: TOptions<TInterpolationMap>): boolean;
 }
 


### PR DESCRIPTION
## Problem

The `ExistsFunction` interface was missing the type predicate overload that `i18n.exists` provides. This caused TypeScript errors when assigning `i18n.exists` to a variable typed as `ExistsFunction`:

```ts
import i18next, { type ExistsFunction } from 'i18next';

let foo: ExistsFunction;
foo = (key, options) => i18next.exists(key, options); // TS error!
```

TypeScript cannot reconcile a type predicate return type (`key is K & SelectorKey`) with a plain `boolean` return type on the target signature.

## Fix

Added a type predicate first overload to `ExistsFunction` matching the pattern already used on `i18n.exists`:

```ts
export interface ExistsFunction<TKeys extends string = string, TInterpolationMap extends object = > {
  <K extends TKeys>(key: K, options?: TOptions<TInterpolationMap>): key is K & SelectorKey;
  (key: TKeys | TKeys[], options?: TOptions<TInterpolationMap>): boolean;
}
```

Fixes #2425