### PR TITLE
fix(types): expose enableSelector on InitOptions

### DIFF
--- a/test/typescript/misc/i18nInstance.test.ts
+++ b/test/typescript/misc/i18nInstance.test.ts
@@ -66,6 +66,21 @@ describe('i18nInstance', () => {
       });
     });
 
+    it('should accept `enableSelector`', () => {
+      expectTypeOf(i18next.init).toBeCallableWith({
+        enableSelector: false,
+      });
+      expectTypeOf(i18next.init).toBeCallableWith({
+        enableSelector: true,
+      });
+      expectTypeOf(i18next.init).toBeCallableWith({
+        enableSelector: 'optimize',
+      });
+      expectTypeOf(i18next.init).toBeCallableWith({
+        enableSelector: 'strict',
+      });
+    });
+
     it('should accept `backend` options', () => {
       expectTypeOf(i18next.init).toBeCallableWith({
         fallbackLng: 'en',

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -642,6 +642,19 @@ export interface InitOptions<T = object> extends PluginOptions<T> {
   nsSeparator?: false | string;
 
   /**
+   * Selector-API mode. Mirrors `CustomTypeOptions['enableSelector']`.
+   *
+   * - `false` (default): selector API disabled.
+   * - `true` / `'optimize'`: selector resolution enabled.
+   * - `'strict'`: require an explicit namespace as the first selector
+   *   path segment in every call. The resolver always rewrites a leading
+   *   namespace-matching segment as a namespace prefix.
+   *
+   * @default false
+   */
+  enableSelector?: false | true | 'optimize' | 'strict';
+
+  /**
    * Char to split plural from key
    * @default '_'
    */


### PR DESCRIPTION
## Problem

`enableSelector` is a runtime option — `i18next.js` reads `opts?.enableSelector === 'strict'` inside `keysFromSelector` and applies the namespace-prefix rewrite accordingly — but it isn't declared on `InitOptions`. As a result, `i18n.init({ enableSelector: 'strict' })` fails to typecheck:

```
Object literal may only specify known properties, and
'enableSelector' does not exist in type 'InitOptions<unknown>'.
```

`CustomTypeOptions['enableSelector']` exists (used for the type-level selector machinery in `t.d.ts`), but that only configures the *compile-time* shape. Users still have to pass `enableSelector` at runtime to actually get strict-mode resolution, and the matching `InitOptions` field is missing.

Today every project enabling the selector API needs a module augmentation:

```ts
declare module "i18next" {
  interface InitOptions {
    enableSelector?: false | true | "optimize" | "strict";
  }
}
```

## Fix

Adds the runtime-side option to `InitOptions`, slotted next to the other selector-resolution knobs (`keySeparator` / `nsSeparator`).

Includes a `test/typescript/misc/i18nInstance.test.ts` case covering each accepted value:

```ts
it('should accept `enableSelector`', () => {
  expectTypeOf(i18next.init).toBeCallableWith({ enableSelector: false });
  expectTypeOf(i18next.init).toBeCallableWith({ enableSelector: true });
  expectTypeOf(i18next.init).toBeCallableWith({ enableSelector: 'optimize' });
  expectTypeOf(i18next.init).toBeCallableWith({ enableSelector: 'strict' });
});
```

```
$ npx vitest --config vitest.workspace.typescript.mts run
 Test Files  56 passed | 1 skipped (56)
      Tests  460 passed | 2 todo (462)
Type Errors  no errors
```