### PR TITLE
feat(types): add ResourceNamespaceMap and enhance CustomTypeOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -584,6 +584,7 @@ export type {
   InitOptions,
   TypeOptions,
   CustomTypeOptions,
+  ResourceNamespaceMap,
   CustomPluginOptions,
   PluginOptions,
   FormatFunction,

--- a/test/typescript/registry-monorepo-legacy-only/i18next.d.ts
+++ b/test/typescript/registry-monorepo-legacy-only/i18next.d.ts
@@ -1,0 +1,12 @@
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'legacy-only';
+    resources: {
+      'legacy-only': {
+        greeting: 'Hello from legacy-only';
+      };
+    };
+  }
+}

--- a/test/typescript/registry-monorepo-legacy-only/t.test.ts
+++ b/test/typescript/registry-monorepo-legacy-only/t.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { TFunction } from 'i18next';
+
+describe('CustomTypeOptions.resources only (no registry)', () => {
+  const t = (() => '') as TFunction<'legacy-only'>;
+
+  it('types keys the way it did before ResourceNamespaceMap', () => {
+    expectTypeOf(t('greeting')).toEqualTypeOf<'Hello from legacy-only'>();
+  });
+});

--- a/test/typescript/registry-monorepo-legacy-only/tsconfig.json
+++ b/test/typescript/registry-monorepo-legacy-only/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/test/typescript/registry-monorepo/package-app-legacy.d.ts
+++ b/test/typescript/registry-monorepo/package-app-legacy.d.ts
@@ -1,0 +1,16 @@
+import 'i18next';
+
+// leaf app namespaces via legacy resources (one resources block for the whole app)
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    resources: {
+      'app-feature': {
+        landing_title: 'Welcome to the app';
+      };
+      overlap: {
+        legacy_only: 'from legacy';
+        shared_literal: 'same value';
+      };
+    };
+  }
+}

--- a/test/typescript/registry-monorepo/package-app-legacy.d.ts
+++ b/test/typescript/registry-monorepo/package-app-legacy.d.ts
@@ -10,6 +10,7 @@ declare module 'i18next' {
       overlap: {
         legacy_only: 'from legacy';
         shared_literal: 'same value';
+        shared_conflict: 'A';
       };
     };
   }

--- a/test/typescript/registry-monorepo/package-common.d.ts
+++ b/test/typescript/registry-monorepo/package-common.d.ts
@@ -1,0 +1,15 @@
+import 'i18next';
+
+// second package, second file — would be TS2717 on CustomTypeOptions.resources
+declare module 'i18next' {
+  interface ResourceNamespaceMap {
+    common: {
+      hello: 'Hello {{name}}';
+      farewell: 'Goodbye';
+    };
+  }
+
+  interface CustomTypeOptions {
+    defaultNS: 'common';
+  }
+}

--- a/test/typescript/registry-monorepo/package-overlap.d.ts
+++ b/test/typescript/registry-monorepo/package-overlap.d.ts
@@ -1,0 +1,11 @@
+import 'i18next';
+
+// overlap ns — registry side; legacy keys are in package-app-legacy.d.ts
+declare module 'i18next' {
+  interface ResourceNamespaceMap {
+    overlap: {
+      registry_only: 'from registry';
+      shared_literal: 'same value';
+    };
+  }
+}

--- a/test/typescript/registry-monorepo/package-overlap.d.ts
+++ b/test/typescript/registry-monorepo/package-overlap.d.ts
@@ -6,6 +6,7 @@ declare module 'i18next' {
     overlap: {
       registry_only: 'from registry';
       shared_literal: 'same value';
+      shared_conflict: 'B';
     };
   }
 }

--- a/test/typescript/registry-monorepo/package-selector.d.ts
+++ b/test/typescript/registry-monorepo/package-selector.d.ts
@@ -1,0 +1,8 @@
+import 'i18next';
+
+// enableSelector is isolated in tsconfig.selector.json so string-key t() tests stay valid.
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    enableSelector: true;
+  }
+}

--- a/test/typescript/registry-monorepo/package-ui.d.ts
+++ b/test/typescript/registry-monorepo/package-ui.d.ts
@@ -1,0 +1,13 @@
+import 'i18next';
+
+// shared UI package — own namespace only
+declare module 'i18next' {
+  interface ResourceNamespaceMap {
+    '@repo/ui': {
+      button_label: 'Click';
+      panel: {
+        title: 'Settings';
+      };
+    };
+  }
+}

--- a/test/typescript/registry-monorepo/t-selector.test.ts
+++ b/test/typescript/registry-monorepo/t-selector.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { TFunction } from 'i18next';
+
+declare const t: TFunction<'@repo/ui'>;
+
+describe('ResourceNamespaceMap registry selector (issue #2409)', () => {
+  it('resolves keys via selector on registry namespace', () => {
+    expectTypeOf(t(($) => $.button_label)).toEqualTypeOf<'Click'>();
+    expectTypeOf(t(($) => $.panel.title)).toEqualTypeOf<'Settings'>();
+  });
+});

--- a/test/typescript/registry-monorepo/t.test.ts
+++ b/test/typescript/registry-monorepo/t.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, assertType, expectTypeOf } from 'vitest';
+import type {
+  TFunction,
+  ResourceNamespaceMap,
+  CustomTypeOptions,
+  FlatNamespace,
+  TypeOptions,
+} from 'i18next';
+
+describe('ResourceNamespaceMap registry (issue #2409)', () => {
+  describe('package-ui (@repo/ui)', () => {
+    const t = (() => '') as TFunction<'@repo/ui'>;
+
+    it('types keys from the registry', () => {
+      expectTypeOf(t('button_label')).toEqualTypeOf<'Click'>();
+      expectTypeOf(t('panel.title')).toEqualTypeOf<'Settings'>();
+    });
+
+    it('rejects unknown keys', () => {
+      // @ts-expect-error not in '@repo/ui' namespace
+      assertType(t('not_a_key'));
+    });
+  });
+
+  describe('package-common (second registry file)', () => {
+    const t = (() => '') as TFunction<'common'>;
+
+    it('merges with package-ui in the same program', () => {
+      expectTypeOf(t('hello', { name: 'world' })).toEqualTypeOf<'Hello {{name}}'>();
+      expectTypeOf(t('farewell')).toEqualTypeOf<'Goodbye'>();
+    });
+  });
+
+  describe('package-app-legacy (CustomTypeOptions.resources)', () => {
+    const t = (() => '') as TFunction<'app-feature'>;
+
+    it('still works next to registry namespaces', () => {
+      expectTypeOf(t('landing_title')).toEqualTypeOf<'Welcome to the app'>();
+    });
+
+    it('rejects keys from other namespaces', () => {
+      // @ts-expect-error 'button_label' belongs to '@repo/ui'
+      assertType(t('button_label'));
+    });
+  });
+
+  describe('overlap namespace (registry + legacy on one ns)', () => {
+    const t = (() => '') as TFunction<'overlap'>;
+
+    it('picks up registry-only keys', () => {
+      expectTypeOf(t('registry_only')).toEqualTypeOf<'from registry'>();
+    });
+
+    it('picks up legacy-only keys', () => {
+      expectTypeOf(t('legacy_only')).toEqualTypeOf<'from legacy'>();
+    });
+
+    it('keeps a key when both sides agree on the literal', () => {
+      expectTypeOf(t('shared_literal')).toEqualTypeOf<'same value'>();
+    });
+
+    it('merges both halves into TypeOptions.resources.overlap', () => {
+      type OverlapNs = TypeOptions['resources']['overlap'];
+      type ExpectedKeys = 'registry_only' | 'legacy_only' | 'shared_literal';
+      assertType<keyof OverlapNs>('' as ExpectedKeys);
+      assertType<ExpectedKeys>('' as keyof OverlapNs);
+      expectTypeOf<OverlapNs['shared_literal']>().toEqualTypeOf<'same value'>();
+    });
+
+    it('turns clashing literals on the same key into never', () => {
+      type ConflictLegacy = { shared_conflict: 'legacy version' };
+      type ConflictRegistry = { shared_conflict: 'registry version' };
+      type ConflictMerged = ConflictLegacy & ConflictRegistry;
+      expectTypeOf<ConflictMerged['shared_conflict']>().toEqualTypeOf<never>();
+    });
+  });
+
+  describe('FlatNamespace', () => {
+    it('lists every namespace from registry and legacy', () => {
+      type Expected = '@repo/ui' | 'common' | 'app-feature' | 'overlap';
+      assertType<FlatNamespace>('' as Expected);
+      assertType<Expected>('' as FlatNamespace);
+    });
+  });
+
+  describe('default namespace via CustomTypeOptions still applies', () => {
+    const t = (() => '') as TFunction;
+
+    it('uses the default namespace declared in package-common.d.ts', () => {
+      expectTypeOf(t('hello', { name: 'world' })).toEqualTypeOf<'Hello {{name}}'>();
+      expectTypeOf(t('farewell')).toEqualTypeOf<'Goodbye'>();
+    });
+  });
+
+  describe('exports', () => {
+    it('ResourceNamespaceMap', () => {
+      const registry: ResourceNamespaceMap = {} as ResourceNamespaceMap;
+      assertType<ResourceNamespaceMap>(registry);
+    });
+
+    it('CustomTypeOptions', () => {
+      const opts: CustomTypeOptions = {} as CustomTypeOptions;
+      assertType<CustomTypeOptions>(opts);
+    });
+  });
+});

--- a/test/typescript/registry-monorepo/t.test.ts
+++ b/test/typescript/registry-monorepo/t.test.ts
@@ -67,11 +67,13 @@ describe('ResourceNamespaceMap registry (issue #2409)', () => {
       expectTypeOf<OverlapNs['shared_literal']>().toEqualTypeOf<'same value'>();
     });
 
-    it('turns clashing literals on the same key into never', () => {
-      type ConflictLegacy = { shared_conflict: 'legacy version' };
-      type ConflictRegistry = { shared_conflict: 'registry version' };
-      type ConflictMerged = ConflictLegacy & ConflictRegistry;
-      expectTypeOf<ConflictMerged['shared_conflict']>().toEqualTypeOf<never>();
+    it('drops same-key/different-literal conflicts from the merged namespace', () => {
+      // `shared_conflict` is 'A' in legacy and 'B' in registry. Without
+      // filtering, the entire `overlap` namespace would collapse to `never`
+      // (TS reduces `{ x:'A' } & { x:'B' }` to `never`) and poison `t()`
+      // overload resolution.
+      // @ts-expect-error 'shared_conflict' is dropped because legacy says 'A', registry says 'B'
+      assertType(t('shared_conflict'));
     });
   });
 

--- a/test/typescript/registry-monorepo/tsconfig.json
+++ b/test/typescript/registry-monorepo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/test/typescript/registry-monorepo/tsconfig.json
+++ b/test/typescript/registry-monorepo/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["./**/*"]
+  "include": ["./**/*"],
+  "exclude": ["./package-selector.d.ts", "./t-selector.test.ts"]
 }

--- a/test/typescript/registry-monorepo/tsconfig.selector.json
+++ b/test/typescript/registry-monorepo/tsconfig.selector.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./package-*.d.ts", "./t-selector.test.ts"]
+}

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -28,160 +28,198 @@ import type { $MergeBy, $PreservedValue, $Dictionary } from './helpers.js';
 export interface CustomTypeOptions {}
 
 /**
+ * Per-package namespace types for monorepos. Augment this in each package's
+ * `i18next.d.ts` instead of `CustomTypeOptions.resources` when several packages
+ * need their own namespaces — otherwise TypeScript reports TS2717 on merge.
+ *
+ * Works alongside the legacy `CustomTypeOptions.resources` field; both end up
+ * in `TypeOptions['resources']`.
+ *
+ * @see https://github.com/i18next/i18next/issues/2409
+ *
+ * @example
+ * ```ts
+ * // packages/ui/i18next.d.ts
+ * declare module 'i18next' {
+ *   interface ResourceNamespaceMap {
+ *     '@repo/ui': typeof uiTranslations;
+ *   }
+ * }
+ * ```
+ */
+export interface ResourceNamespaceMap {}
+
+/**
  * This interface can be augmented by users to add types to `i18next` default PluginOptions.
  */
 export interface CustomPluginOptions {}
 
+type _LegacyResources = CustomTypeOptions extends { resources: infer R } ? R : object;
+
+// NOTE: empty legacy + empty registry must stay `object` so unconfigured projects
+// still get `$IsResourcesDefined === false`.
+type _MergedResources = [keyof _LegacyResources] extends [never]
+  ? [keyof ResourceNamespaceMap] extends [never]
+    ? object
+    : ResourceNamespaceMap
+  : [keyof ResourceNamespaceMap] extends [never]
+    ? _LegacyResources
+    : _LegacyResources & ResourceNamespaceMap;
+
 export type TypeOptions = $MergeBy<
-  {
-    /** @see {InitOptions.returnNull} */
-    returnNull: false;
+  $MergeBy<
+    {
+      /** @see {InitOptions.returnNull} */
+      returnNull: false;
 
-    /** @see {InitOptions.returnEmptyString} */
-    returnEmptyString: true;
+      /** @see {InitOptions.returnEmptyString} */
+      returnEmptyString: true;
 
-    /** @see {InitOptions.returnObjects} */
-    returnObjects: false;
+      /** @see {InitOptions.returnObjects} */
+      returnObjects: false;
 
-    /** @see {InitOptions.keySeparator} */
-    keySeparator: '.';
+      /** @see {InitOptions.keySeparator} */
+      keySeparator: '.';
 
-    /** @see {InitOptions.nsSeparator} */
-    nsSeparator: ':';
+      /** @see {InitOptions.nsSeparator} */
+      nsSeparator: ':';
 
-    /** @see {InitOptions.pluralSeparator} */
-    pluralSeparator: '_';
+      /** @see {InitOptions.pluralSeparator} */
+      pluralSeparator: '_';
 
-    /** @see {InitOptions.contextSeparator} */
-    contextSeparator: '_';
+      /** @see {InitOptions.contextSeparator} */
+      contextSeparator: '_';
 
-    /** @see {InitOptions.defaultNS} */
-    defaultNS: 'translation';
+      /** @see {InitOptions.defaultNS} */
+      defaultNS: 'translation';
 
-    /** @see {InitOptions.fallbackNS} */
-    fallbackNS: false;
+      /** @see {InitOptions.fallbackNS} */
+      fallbackNS: false;
 
-    /** @see {InitOptions.compatibilityJSON} */
-    compatibilityJSON: 'v4';
+      /** @see {InitOptions.compatibilityJSON} */
+      compatibilityJSON: 'v4';
 
-    /** @see {InitOptions.resources} */
-    resources: object;
+      /** @see {InitOptions.resources} */
+      resources: object;
 
-    /**
-     * Flag that allows HTML elements to receive objects. This is only useful for React applications
-     * where you pass objects to HTML elements so they can be replaced to their respective interpolation
-     * values (mostly with Trans component)
-     */
-    allowObjectInHTMLChildren: false;
+      /**
+       * Flag that allows HTML elements to receive objects. This is only useful for React applications
+       * where you pass objects to HTML elements so they can be replaced to their respective interpolation
+       * values (mostly with Trans component)
+       */
+      allowObjectInHTMLChildren: false;
 
-    /**
-     * Flag that enables strict key checking even if a `defaultValue` has been provided.
-     * This ensures all calls of `t` function don't accidentally use implicitly missing keys.
-     */
-    strictKeyChecks: false;
+      /**
+       * Flag that enables strict key checking even if a `defaultValue` has been provided.
+       * This ensures all calls of `t` function don't accidentally use implicitly missing keys.
+       */
+      strictKeyChecks: false;
 
-    /**
-     * Prefix for interpolation
-     */
-    interpolationPrefix: '{{';
+      /**
+       * Prefix for interpolation
+       */
+      interpolationPrefix: '{{';
 
-    /**
-     * Suffix for interpolation
-     */
-    interpolationSuffix: '}}';
+      /**
+       * Suffix for interpolation
+       */
+      interpolationSuffix: '}}';
 
-    /** @see {InterpolationOptions.unescapePrefix} */
-    unescapePrefix: '-';
+      /** @see {InterpolationOptions.unescapePrefix} */
+      unescapePrefix: '-';
 
-    /** @see {InterpolationOptions.unescapeSuffix} */
-    unescapeSuffix: '';
+      /** @see {InterpolationOptions.unescapeSuffix} */
+      unescapeSuffix: '';
 
-    /**
-     * Whether to extract interpolation variables from translation strings at
-     * the type level. When `true` (default), the type system parses each
-     * resource value for `{{variable}}` patterns and types the `t()` options
-     * accordingly.
-     *
-     * Set to `false` when your translation strings use a different
-     * interpolation syntax that the i18next type extractor cannot understand
-     * — e.g. ICU MessageFormat plurals like `{count, plural, one {{count} row}
-     * other {{count} rows}}` would otherwise produce phantom variable names
-     * because the default extractor naively matches the outermost `{{` …
-     * `}}`. This flag is type-only; runtime interpolation is governed by
-     * `InterpolationOptions` and is unaffected.
-     *
-     * Required by `i18next-icu` users — see that package's docs for the
-     * recommended `CustomTypeOptions` augmentation.
-     *
-     * @default true
-     */
-    parseInterpolation: true;
+      /**
+       * Whether to extract interpolation variables from translation strings at
+       * the type level. When `true` (default), the type system parses each
+       * resource value for `{{variable}}` patterns and types the `t()` options
+       * accordingly.
+       *
+       * Set to `false` when your translation strings use a different
+       * interpolation syntax that the i18next type extractor cannot understand
+       * — e.g. ICU MessageFormat plurals like `{count, plural, one {{count} row}
+       * other {{count} rows}}` would otherwise produce phantom variable names
+       * because the default extractor naively matches the outermost `{{` …
+       * `}}`. This flag is type-only; runtime interpolation is governed by
+       * `InterpolationOptions` and is unaffected.
+       *
+       * Required by `i18next-icu` users — see that package's docs for the
+       * recommended `CustomTypeOptions` augmentation.
+       *
+       * @default true
+       */
+      parseInterpolation: true;
 
-    /**
-     * Use a proxy-based selector to select a translation.
-     *
-     * Enables features like go-to definition, and better DX/faster autocompletion
-     * for TypeScript developers.
-     *
-     * If you're working with an especially large set of translations and aren't
-     * using context, you set `enableSelector` to `"optimize"` and i18next won't do
-     * any type-level processing of your translations at all.
-     *
-     * With `enableSelector` set to `"optimize"`, i18next is capable of supporting
-     * arbitrarily large/deep translation sets without causing any IDE slowdown
-     * whatsoever.
-     *
-     * Set `enableSelector` to `"strict"` to require an explicit namespace as the
-     * first selector path segment in every call. The selector proxy stops
-     * exposing the primary namespace's keys flat on `$` — even
-     * `useTranslation('only')` must use `$.only.foo`, never `$.foo`. At runtime,
-     * a leading segment matching the scope's namespace list (primary included)
-     * is always rewritten as a namespace prefix, fully decoupling selector
-     * shape from resolution scope. Use this when you want a single mental model
-     * for selector paths regardless of how many namespaces a hook was created
-     * with, and to remove the silent miss that flat-primary paths can otherwise
-     * cause in multi-ns hooks (see [#2429](https://github.com/i18next/i18next/issues/2429)).
-     *
-     * `"strict"` mode is incompatible with the `"optimize"` shortcut. If you
-     * have keys whose names match sibling namespaces (the
-     * [#2405](https://github.com/i18next/i18next/issues/2405) pattern), do not
-     * enable strict mode — the leading-segment rewrite would route those keys
-     * into the wrong namespace.
-     *
-     * @default false
-     */
-    enableSelector: false;
+      /**
+       * Use a proxy-based selector to select a translation.
+       *
+       * Enables features like go-to definition, and better DX/faster autocompletion
+       * for TypeScript developers.
+       *
+       * If you're working with an especially large set of translations and aren't
+       * using context, you set `enableSelector` to `"optimize"` and i18next won't do
+       * any type-level processing of your translations at all.
+       *
+       * With `enableSelector` set to `"optimize"`, i18next is capable of supporting
+       * arbitrarily large/deep translation sets without causing any IDE slowdown
+       * whatsoever.
+       *
+       * Set `enableSelector` to `"strict"` to require an explicit namespace as the
+       * first selector path segment in every call. The selector proxy stops
+       * exposing the primary namespace's keys flat on `$` — even
+       * `useTranslation('only')` must use `$.only.foo`, never `$.foo`. At runtime,
+       * a leading segment matching the scope's namespace list (primary included)
+       * is always rewritten as a namespace prefix, fully decoupling selector
+       * shape from resolution scope. Use this when you want a single mental model
+       * for selector paths regardless of how many namespaces a hook was created
+       * with, and to remove the silent miss that flat-primary paths can otherwise
+       * cause in multi-ns hooks (see [#2429](https://github.com/i18next/i18next/issues/2429)).
+       *
+       * `"strict"` mode is incompatible with the `"optimize"` shortcut. If you
+       * have keys whose names match sibling namespaces (the
+       * [#2405](https://github.com/i18next/i18next/issues/2405) pattern), do not
+       * enable strict mode — the leading-segment rewrite would route those keys
+       * into the wrong namespace.
+       *
+       * @default false
+       */
+      enableSelector: false;
 
-    /**
-     * Maps interpolation format specifiers to their expected value types.
-     *
-     * By default, i18next infers types from built-in formatter names:
-     * - `number`, `currency` → `number`
-     * - `datetime` → `Date`
-     * - `relativetime` → `number`
-     * - `list` → `readonly string[]`
-     * - No format specifier → `string | number` (since i18next stringifies values at runtime)
-     *
-     * Use this option to add mappings for custom formatters or to override
-     * the built-in defaults.
-     *
-     * @default {} (empty — built-in defaults apply)
-     *
-     * @example
-     * ```ts
-     * interface CustomTypeOptions {
-     *   interpolationFormatTypeMap: {
-     *     // custom formatter
-     *     uppercase: string;
-     *     // override built-in
-     *     currency: string;
-     *   };
-     * }
-     * ```
-     */
-    interpolationFormatTypeMap: {};
-  },
-  CustomTypeOptions
+      /**
+       * Maps interpolation format specifiers to their expected value types.
+       *
+       * By default, i18next infers types from built-in formatter names:
+       * - `number`, `currency` → `number`
+       * - `datetime` → `Date`
+       * - `relativetime` → `number`
+       * - `list` → `readonly string[]`
+       * - No format specifier → `string | number` (since i18next stringifies values at runtime)
+       *
+       * Use this option to add mappings for custom formatters or to override
+       * the built-in defaults.
+       *
+       * @default {} (empty — built-in defaults apply)
+       *
+       * @example
+       * ```ts
+       * interface CustomTypeOptions {
+       *   interpolationFormatTypeMap: {
+       *     // custom formatter
+       *     uppercase: string;
+       *     // override built-in
+       *     currency: string;
+       *   };
+       * }
+       * ```
+       */
+      interpolationFormatTypeMap: {};
+    },
+    CustomTypeOptions
+  >,
+  // HACK: apply merged resources after CustomTypeOptions so registry + legacy both count.
+  { resources: _MergedResources }
 >;
 
 export type PluginOptions<T> = $MergeBy<

--- a/typescript/options.d.ts
+++ b/typescript/options.d.ts
@@ -35,6 +35,10 @@ export interface CustomTypeOptions {}
  * Works alongside the legacy `CustomTypeOptions.resources` field; both end up
  * in `TypeOptions['resources']`.
  *
+ * Scalar type options like `defaultNS`, `returnNull`, `enableSelector`, etc.,
+ * still belong on `CustomTypeOptions` — this interface is for namespace
+ * resource types only.
+ *
  * @see https://github.com/i18next/i18next/issues/2409
  *
  * @example
@@ -56,6 +60,46 @@ export interface CustomPluginOptions {}
 
 type _LegacyResources = CustomTypeOptions extends { resources: infer R } ? R : object;
 
+// Per-property merge of two object types. Unlike `L & R`, which TypeScript
+// collapses to `never` whenever ANY property has incompatible literals (so a
+// single same-key/different-literal conflict wipes out the whole namespace),
+// this iterates keys and intersects them individually — the conflicting key
+// becomes `never`, the rest survive.
+type _PerPropMerge<L, R> = {
+  [K in keyof L | keyof R]: K extends keyof L
+    ? K extends keyof R
+      ? L[K] & R[K]
+      : L[K]
+    : K extends keyof R
+      ? R[K]
+      : never;
+};
+
+// Drop properties whose value resolved to `never`. Without this, the
+// conflict key would leak into `keyof Resources[ns]`, then poison
+// `KeysBuilder` recursion (it tries to walk a `never` value) and break
+// `t()` overload resolution for the entire namespace.
+// NOTE: must use the `Pick<T, NonNeverKeys>` form. A `[K in keyof T as ...]`
+// remap does NOT eagerly evaluate `T[K]` for intersection types, so conflict
+// keys would survive the filter.
+type _NonNeverKeys<T> = {
+  [K in keyof T]: [T[K]] extends [never] ? never : K;
+}[keyof T];
+type _DropConflictKeys<T> = Pick<T, _NonNeverKeys<T>>;
+
+// When the same namespace exists on both sides, deep-merge per property and
+// strip same-key/different-literal conflicts. Otherwise pick from whichever
+// side has it.
+type _MergeNamespaces<L, R> = {
+  [K in keyof L | keyof R]: K extends keyof L
+    ? K extends keyof R
+      ? _DropConflictKeys<_PerPropMerge<L[K], R[K]>>
+      : L[K]
+    : K extends keyof R
+      ? R[K]
+      : never;
+};
+
 // NOTE: empty legacy + empty registry must stay `object` so unconfigured projects
 // still get `$IsResourcesDefined === false`.
 type _MergedResources = [keyof _LegacyResources] extends [never]
@@ -64,7 +108,7 @@ type _MergedResources = [keyof _LegacyResources] extends [never]
     : ResourceNamespaceMap
   : [keyof ResourceNamespaceMap] extends [never]
     ? _LegacyResources
-    : _LegacyResources & ResourceNamespaceMap;
+    : _MergeNamespaces<_LegacyResources, ResourceNamespaceMap>;
 
 export type TypeOptions = $MergeBy<
   $MergeBy<
@@ -218,7 +262,10 @@ export type TypeOptions = $MergeBy<
     },
     CustomTypeOptions
   >,
-  // HACK: apply merged resources after CustomTypeOptions so registry + legacy both count.
+  // HACK: apply merged resources *after* CustomTypeOptions so registry contributions
+  // survive when CustomTypeOptions.resources is also defined. Without this
+  // second step, the inner $MergeBy would replace the default `resources: object`
+  // with CustomTypeOptions['resources'] alone, dropping the registry namespaces.
   { resources: _MergedResources }
 >;
 

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -77,19 +77,23 @@ interface Branded<Ns extends Namespace> {
 /** ****************************************************
  * Build all keys and key prefixes based on Resources *
  ***************************************************** */
-type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
-  ? Res[Key] extends $Dictionary | readonly unknown[]
-    ?
-        | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
-        | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-    : never
-  : never;
+type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = [Res] extends [never]
+  ? never
+  : Key extends keyof Res
+    ? Res[Key] extends $Dictionary | readonly unknown[]
+      ?
+          | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
+          | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
+      : never
+    : never;
 
-type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
-  ? Res[Key] extends $Dictionary | readonly unknown[]
-    ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-    : Key
-  : never;
+type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = [Res] extends [never]
+  ? never
+  : Key extends keyof Res
+    ? Res[Key] extends $Dictionary | readonly unknown[]
+      ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
+      : Key
+    : never;
 
 type KeysBuilder<Res, WithReturnObjects> = $IsResourcesDefined extends true
   ? WithReturnObjects extends true


### PR DESCRIPTION
Add `ResourceNamespaceMap` to let monorepo packages declare their own i18n namespaces without TS2717. It merges with legacy `CustomTypeOptions.resources` to keep existing augmentations working (closes #2409).

- **New Features**
  - Introduced and exported `ResourceNamespaceMap` for per‑package namespace types in separate `i18next.d.ts` files.
  - `TypeOptions['resources']` now builds from legacy resources and `ResourceNamespaceMap`, allowing both patterns to coexist.
  - Added TypeScript tests for monorepo setups, overlapping namespaces, default NS behavior, and backward compatibility.