### PR TITLE
fix(types): keyPrefix no longer pollutes t() return type with sibling keys (#2434 regression)

### DIFF
--- a/test/typescript/keyprefix-return-type/i18next.d.ts
+++ b/test/typescript/keyprefix-return-type/i18next.d.ts
@@ -1,0 +1,26 @@
+import 'i18next';
+
+// #2434 regression scenario: two sibling keys both expose `title` with
+// different shapes (string vs object). A `t` scoped to one sibling via
+// `keyPrefix` must resolve `title` to only that sibling's value.
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'app';
+    resources: {
+      app: {
+        settings: {
+          profile: {
+            title: 'Profile';
+            description: 'Manage your profile';
+          };
+          notifications: {
+            title: {
+              on: 'On';
+              off: 'Off';
+            };
+          };
+        };
+      };
+    };
+  }
+}

--- a/test/typescript/keyprefix-return-type/t.test.ts
+++ b/test/typescript/keyprefix-return-type/t.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { TFunction, KeyPrefix, Namespace } from 'i18next';
+
+describe('keyPrefix return type (#2434 regression)', () => {
+  it('resolves a leaf key to its exact value, not a union with sibling keys', () => {
+    // Mirrors how `react-i18next`'s `useTranslation(ns, { keyPrefix })` composes
+    // i18next's public types: `KPrefix` is constrained to `KeyPrefix<Ns>` and
+    // inferred from an options-object property. This is the surface that
+    // regressed in 26.3.0 (#2434); `getFixedT` takes `keyPrefix` positionally
+    // and is unaffected, hence the local helper.
+    const useTranslation = <Ns extends Namespace, KPrefix extends KeyPrefix<Ns> = undefined>(
+      _: Ns,
+      __: {
+        keyPrefix?: KPrefix;
+      },
+      // @ts-expect-error we only care about typing here, not about actual returns
+    ): { t: TFunction<Ns, KPrefix> } => undefined;
+
+    const { t } = useTranslation('app', { keyPrefix: 'settings.profile' });
+
+    // Before the fix this was inferred as `'Profile' | { on: 'On'; off: 'Off' }`,
+    // unioning the sibling `settings.notifications.title` object.
+    expectTypeOf(t('title')).toEqualTypeOf<'Profile'>();
+    expectTypeOf(t('description')).toEqualTypeOf<'Manage your profile'>();
+  });
+});

--- a/test/typescript/keyprefix-return-type/tsconfig.json
+++ b/test/typescript/keyprefix-return-type/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "exclude": []
+}

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -77,23 +77,23 @@ interface Branded<Ns extends Namespace> {
 /** ****************************************************
  * Build all keys and key prefixes based on Resources *
  ***************************************************** */
-type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = [Res] extends [never]
-  ? never
-  : Key extends keyof Res
-    ? Res[Key] extends $Dictionary | readonly unknown[]
-      ?
-          | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
-          | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
-      : never
-    : never;
+// Do NOT add a `[Res] extends [never]` guard here: it defers these into
+// conditional types, so `KeyPrefix<Ns>` no longer resolves to a literal union
+// and `keyPrefix` inference widens to the whole namespace, polluting `t()`
+// return types with sibling keys (#2434 regression). Guard `never` in the merge.
+type KeysBuilderWithReturnObjects<Res, Key = keyof Res> = Key extends keyof Res
+  ? Res[Key] extends $Dictionary | readonly unknown[]
+    ?
+        | JoinKeys<Key, WithOrWithoutPlural<keyof $OmitArrayKeys<Res[Key]>>>
+        | JoinKeys<Key, KeysBuilderWithReturnObjects<Res[Key]>>
+    : never
+  : never;
 
-type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = [Res] extends [never]
-  ? never
-  : Key extends keyof Res
-    ? Res[Key] extends $Dictionary | readonly unknown[]
-      ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
-      : Key
-    : never;
+type KeysBuilderWithoutReturnObjects<Res, Key = keyof $OmitArrayKeys<Res>> = Key extends keyof Res
+  ? Res[Key] extends $Dictionary | readonly unknown[]
+    ? JoinKeys<Key, KeysBuilderWithoutReturnObjects<Res[Key]>>
+    : Key
+  : never;
 
 type KeysBuilder<Res, WithReturnObjects> = $IsResourcesDefined extends true
   ? WithReturnObjects extends true


### PR DESCRIPTION
# fix(types): keyPrefix no longer pollutes t() return type with sibling keys (#2434 regression)

## Summary

26.3.0 (#2434) regressed `t()` return types for any project that scopes a `t`
function with a `keyPrefix` constrained to `KeyPrefix<Ns>` — most notably every
`react-i18next` `useTranslation(ns, { keyPrefix })` caller. A leaf lookup now
resolves to a union with **unrelated sibling keys' values**, and large/deep
resource trees additionally hit `TS2589` ("Type instantiation is excessively
deep").

```ts
// resources: app.settings.{
//   profile:       { title: 'Profile' },                  // string
//   notifications: { title: { on: 'On'; off: 'Off' } },   // object (a sibling)
// }
const { t } = useTranslation('app', { keyPrefix: 'settings.profile' });

t('title');
// 26.2.0:  'Profile'                              ✅
// 26.3.0:  'Profile' | { on: 'On'; off: 'Off' }   ❌  (sibling's title leaks in)
```

Reproduces under both `tsc` and `tsgo`. It does **not** surface through
`getFixedT` (which takes `keyPrefix` as a positional argument) or through a raw
`TFunction<Ns, 'literal'>` type argument — only when `KPrefix` is *inferred*
against the `KeyPrefix<Ns>` constraint from an options-object property, which is
exactly the `react-i18next` `useTranslation` shape.

## Root cause

#2434 added `[Res] extends [never] ? never : …` guards to
`KeysBuilderWithReturnObjects` and `KeysBuilderWithoutReturnObjects` in
`typescript/t.d.ts`.

Those guards turn the builders into **deferred conditional types**. Because
`KeyPrefix<Ns> = ResourceKeys<true>[$FirstNamespace<Ns>]` flows through these
builders, `KeyPrefix<Ns>` stops resolving to an eager union of string-literal
key paths. When `KPrefix extends KeyPrefix<Ns>` is then inferred from a literal
`keyPrefix`, TypeScript can no longer match the literal against the deferred
constraint and falls back to the **entire `KeyPrefix<Ns>` constraint**.
`AppendKeyPrefix<'title', <whole union>>` then expands to every
`<prefix>.title`, so `t('title')` unions all sibling `title` values (and the
over-expansion blows the instantiation-depth budget on big trees).

## Fix

Restore the two builders to their 26.2.0 (eager) form.

I checked whether the guards could be kept in a non-deferring shape and they
can't: the same `[Res] extends [never]` deferral re-breaks `KeyPrefix<Ns>`
whether it sits in `KeysBuilder` or directly on the concrete child `Res[Key]`.
And `never` can't be detected without the `[T] extends [never]` trick, since
`never extends X` is always `true`.

The guards also turn out to be inert for the case they targeted:

- **Top-level conflicts** (the only scenario covered by tests, e.g.
  `shared_conflict`) are already resolved by `_DropConflictKeys` in
  `options.d.ts` *before* the builders run — a merged namespace is never `never`
  (worst case `{}`).
- **Nested conflicts** (a deep `'A' & 'B'` → `never` leaf) behave **identically**
  with and without the guard: same `KeyPrefix<Ns>`, no garbage keys, the
  conflicted sub-tree is equally poisoned either way. The guard doesn't rescue
  it.

So removing the guards changes no working scenario. If belt-and-suspenders
`never`-safety is ever wanted, it belongs in the merge layer (`options.d.ts`),
not on the `ResourceKeys` path — a comment in `t.d.ts` records this so the guard
isn't reintroduced.

## Testing

- New type-test scenario `test/typescript/keyprefix-return-type/` reproducing the
  sibling-pollution case via a minimal `useTranslation`-shaped helper. Red on the
  guarded code, green with the fix.
- Full `npm run test:typescript` suite passes (incl. `registry-monorepo` /
  `registry-monorepo-legacy-only`).

Fixes the regression introduced in #2434.
