### PR TITLE
fix: reassemble comma-in-parens formatters at any chain position

### DIFF
--- a/src/Formatter.js
+++ b/src/Formatter.js
@@ -117,15 +117,14 @@ class Formatter {
   format(value, format, lng, options = {}) {
     if (!format) return value;
     if (value == null) return value;
-    const formats = format.split(this.formatSeparator);
-    if (
-      formats.length > 1 &&
-      formats[0].indexOf('(') > 1 &&
-      !formats[0].includes(')') &&
-      formats.find((f) => f.includes(')'))
-    ) {
-      const lastIndex = formats.findIndex((f) => f.includes(')'));
-      formats[0] = [formats[0], ...formats.splice(1, lastIndex)].join(this.formatSeparator);
+    const rawFormats = format.split(this.formatSeparator);
+    const formats = [];
+    for (let i = 0; i < rawFormats.length; i++) {
+      let f = rawFormats[i];
+      while (f.indexOf('(') > -1 && !f.includes(')') && i + 1 < rawFormats.length) {
+        f = `${f}${this.formatSeparator}${rawFormats[++i]}`;
+      }
+      formats.push(f);
     }
 
     const result = formats.reduce((mem, f) => {

--- a/test/runtime/i18next.translation.formatting.test.js
+++ b/test/runtime/i18next.translation.formatting.test.js
@@ -53,6 +53,8 @@ describe('i18next.translation.formatting', () => {
                     'Before {{date, customDateCached(format: EEEE d MMMM yyyy HH:mm; otherParam: 0)}}',
                   customFormatWithSeparator: "Hello {{myVar, join(separator: ' | ')}}",
                   customFormatWithSeparatorComma: "Hello {{myVar, join(separator: ', ')}}",
+                  customFormatWithSeparatorCommaNotFirst:
+                    "Hello {{myVar, upper, join(separator: ', ')}}",
                   boy: 'Boy',
                   boy_other: 'Boys',
                   girl: 'Girl',
@@ -101,6 +103,9 @@ describe('i18next.translation.formatting', () => {
             );
             instance.services.formatter.add('join', (value, lng, options) =>
               value.join(options.separator),
+            );
+            instance.services.formatter.add('upper', (value) =>
+              value.map((item) => item.toUpperCase()),
             );
             resolve();
           },
@@ -289,6 +294,10 @@ describe('i18next.translation.formatting', () => {
       {
         args: ['customFormatWithSeparatorComma', { myVar: ['here', 'there'] }],
         expected: 'Hello here, there',
+      },
+      {
+        args: ['customFormatWithSeparatorCommaNotFirst', { myVar: ['a', 'b'] }],
+        expected: 'Hello A, B',
       },
     ]);
 


### PR DESCRIPTION
## Problem

Chained formatters support parenthesised options that may contain the format separator, for example `join(separator: ', ')`. When such a formatter is split on the separator, the option fragments have to be rejoined before parsing.

Today that reassembly only runs for `formats[0]`. A formatter whose parenthesised options contain the separator therefore works **only when it is first** in the chain:

```js
// works
{{v, join(separator: ', '), uppercase}}

// broken: corrupt output
{{v, uppercase, join(separator: ', ')}}
```

In the broken case the `join(separator: ', ')` fragment is split into `join(separator: ' '` and `')'`, never rejoined, and the value comes out corrupted (e.g. `ANaNB`).

## Fix

Replace the `formats[0]`-only repair with a single position-independent pass: walk the split fragments and, whenever a fragment opens a paren that is not yet closed, keep appending following fragments (re-inserting the separator) until the paren closes. This reassembles comma-in-parens options at **any** position in the chain. The downstream `formats.reduce(...)` is unchanged.

## Tests

Added a regression test in `test/runtime/i18next.translation.formatting.test.js` exercising a chain where the comma-in-parens formatter is not first (`{{myVar, upper, join(separator: ', ')}}` with `['a','b']` -> `A, B`).

- Before the fix, the new test fails (`Hello ANaNB`).
- After the fix it passes, and the full runtime suite stays green.