### PR TITLE
fix(types): preserve selector returnObjects shape with context (#2398)

### DIFF
--- a/test/typescript/selector-issue-2398/t.test.ts
+++ b/test/typescript/selector-issue-2398/t.test.ts
@@ -1,49 +1,36 @@
-import { describe, it } from 'vitest';
+import { describe, it, expectTypeOf } from 'vitest';
 import type { TFunction } from 'i18next';
 
-// Reproduces https://github.com/i18next/i18next/issues/2398 (Problem 1)
+// Reproduces https://github.com/i18next/i18next/issues/2398
 //
 // When a JSON array has objects with different key sets (one with a context
 // variant like `transKey1_withContext`, one without), TypeScript merges all
-// keys into a single element type. The selector overload with `context` then
-// loses `transKey1` from the inferred return type, producing:
-//   ({ transKey2: string } | { transKey1: string; transKey2: string })[]
-// instead of:
-//   { transKey1: string; transKey2: string }[]
-//
-// Root cause: FilterKeys works correctly when tested directly. The issue is
-// in the context-specific selector overload (TFunctionSelector) where
-// `Target` is inferred via `SelectorFn<Source, ApplyTarget<Target, Opts>, Opts>`.
-// With `returnObjects: true`, `ApplyTarget` resolves to `unknown`, so TypeScript
-// cannot infer a specific `Target` from the callback. The non-context overloads
-// solve this with `const Fn` + `ReturnType<Fn>`, but that approach breaks
-// namespace-ordering checks when applied to the context overload (because `Fn`'s
-// parameter depends on `Opts['context']`, creating an inference dependency).
+// keys into a single element type. The selector overload with `context` must
+// still preserve `transKey1` and `transKey2` on every element after filtering.
 
 describe('issue #2398 - returnObjects + context + array with selector', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const t = (() => []) as unknown as TFunction;
 
-  it.todo('should return full object shape for all array elements, not a union of partial types');
-  // When fixed, replace the .todo above with:
-  // it('should return full object shape for all array elements', () => {
-  //   const result = t(($) => $.transWithArray, {
-  //     returnObjects: true,
-  //     context: 'withContext',
-  //   });
-  //   expectTypeOf(result[0]).toHaveProperty('transKey1');
-  //   expectTypeOf(result[0]).toHaveProperty('transKey2');
-  // });
+  it('should return full object shape for all array elements, not a union of partial types', () => {
+    const result = t(($) => $.transWithArray, {
+      returnObjects: true,
+      context: 'withContext',
+    });
+    expectTypeOf(result[0]).toHaveProperty('transKey1');
+    expectTypeOf(result[0]).toHaveProperty('transKey2');
+    expectTypeOf(result[0].transKey1).toEqualTypeOf<string>();
+    expectTypeOf(result[0].transKey2).toEqualTypeOf<string>();
+  });
 
-  it.todo('should also work when context and plurals are combined on array elements');
-  // When fixed, replace the .todo above with:
-  // it('should work with context + plurals combined on array elements', () => {
-  //   const result = t(($) => $.transWithArrayAndPlurals, {
-  //     returnObjects: true,
-  //     context: 'withContext',
-  //     count: 5,
-  //   });
-  //   expectTypeOf(result[0]).toHaveProperty('transKey1');
-  //   expectTypeOf(result[0]).toHaveProperty('transKey2');
-  // });
+  it('should also work when context and plurals are combined on array elements', () => {
+    const result = t(($) => $.transWithArrayAndPlurals, {
+      returnObjects: true,
+      context: 'withContext',
+      count: 5,
+    });
+    expectTypeOf(result[0]).toHaveProperty('transKey1');
+    expectTypeOf(result[0]).toHaveProperty('transKey2');
+    expectTypeOf(result[0].transKey1).toEqualTypeOf<string>();
+    expectTypeOf(result[0].transKey2).toEqualTypeOf<string>();
+  });
 });

--- a/typescript/t.d.ts
+++ b/typescript/t.d.ts
@@ -605,6 +605,24 @@ interface TFunctionSelector<Ns extends Namespace, KPrefix, Source> extends Brand
       >,
   ): SelectorReturn<Fns[number] extends (...args: any[]) => infer R ? R : never, Opts>;
 
+  // ── Single selector with context + returnObjects ────────────────────────────
+  // More specific than the general context overload below. Captures `Context` as
+  // a const generic and uses `const Fn` + `ReturnType<Fn>` so FilterKeys sees the
+  // concrete context and the callback's object/array shape is preserved (#2398).
+  // Without this, `ConstrainTarget` / `ApplyTarget` collapse to `unknown` when
+  // `returnObjects: true`.
+  <
+    const Context extends string,
+    const Fn extends (src: Select<Source, Context>) => any,
+    const Opts extends SelectorOptions<Ns[number]> & {
+      context: Context;
+      returnObjects: true;
+    } = SelectorOptions<Ns[number]> & { context: Context; returnObjects: true },
+  >(
+    selector: Fn,
+    options: Opts & InterpolationMap<DeepUnwrapPlural<ReturnType<Fn>>>,
+  ): SelectorReturn<ReturnType<Fn>, Opts>;
+
   // ── Single selector with context — bypasses count enforcement ────────────────
   // When `context` is present in options, `Target` is derived from the
   // context-filtered source (third mapped type of FilterKeys), which does NOT
@@ -728,12 +746,20 @@ type Select<T, Context> = $IsResourcesDefined extends false
     ? T
     : FilterKeys<T, Context>;
 
+/**
+ * Context-variant keys that are actually present (not JSON-union phantoms typed
+ * as optional `undefined`, e.g. `transKey1_withContext?: undefined`).
+ */
+type _DefinedContextKeys<T, Pattern extends string> = {
+  [P in keyof T as P extends Pattern ? ([T[P]] extends [undefined] ? never : P) : never]: true;
+};
+
 type _HasContextVariant<T, K extends string, Context> = [
-  keyof T &
-    (
-      | `${K}${_ContextSeparator}${Context & string}`
-      | `${K}${_ContextSeparator}${Context & string}${_PluralSeparator}${PluralSuffix}`
-    ),
+  keyof _DefinedContextKeys<
+    T,
+    | `${K}${_ContextSeparator}${Context & string}`
+    | `${K}${_ContextSeparator}${Context & string}${_PluralSeparator}${PluralSuffix}`
+  >,
 ] extends [never]
   ? false
   : true;
@@ -741,7 +767,7 @@ type _HasContextVariant<T, K extends string, Context> = [
 /** Checks whether key K has **any** context variant in T (excluding pure plural suffixes). */
 type _IsContextualKey<T, K extends string> = [
   Exclude<
-    keyof T & `${K}${_ContextSeparator}${string}`,
+    keyof _DefinedContextKeys<T, `${K}${_ContextSeparator}${string}`>,
     | `${K}${_PluralSeparator}${PluralSuffix}`
     | `${K}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`
   >,
@@ -749,61 +775,72 @@ type _IsContextualKey<T, K extends string> = [
   ? false
   : true;
 
-type FilterKeys<T, Context> = never | T extends readonly any[]
+/**
+ * Distributes {@link FilterKeysObject} over unions so heterogeneous JSON array
+ * element types (each object literal in the array) are filtered independently,
+ * then re-unified. Without distribution, `keyof (A | B)` is only the common keys
+ * and context variants that exist on a single element are invisible, which
+ * produced partial element unions for `returnObjects` + `context` (#2398).
+ */
+type FilterKeys<T, Context> = [T] extends [readonly any[]]
   ? { [I in keyof T]: FilterKeys<T[I], Context> }
-  : $Prune<
-      {
-        // Mapped type 1: object-valued keys (recurse) + plain leaf keys (non-plural, non-context)
-        [K in keyof T as T[K] extends object
-          ? K
-          : [Context] extends [string]
-            ? K extends
-                | `${string}${_ContextSeparator}${Context}`
-                | `${string}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
-              ? never // context keys handled by mapped type 3
-              : K extends `${string}${_PluralSeparator}${PluralSuffix}`
-                ? never // plural keys handled by mapped type 2
-                : K extends string
-                  ? _HasContextVariant<T, K, Context> extends true
-                    ? never // context variant exists, drop base key (type 3 handles it)
-                    : _IsContextualKey<T, K> extends true
-                      ? never // key has context variants but not for this context
-                      : K // no context variants at all, keep base key
-                  : K
-            : K extends `${string}${_PluralSeparator}${PluralSuffix}`
-              ? never
-              : K]: T[K] extends object ? FilterKeys<T[K], Context> : T[K];
-      } & {
-        // Mapped type 2: plural collapsing (active regardless of context)
-        [K in keyof T as T[K] extends object
+  : T extends any
+    ? FilterKeysObject<T, Context>
+    : never;
+
+type FilterKeysObject<T, Context> = $Prune<
+  {
+    // Mapped type 1: object-valued keys (recurse) + plain leaf keys (non-plural, non-context)
+    [K in keyof T as T[K] extends object
+      ? K
+      : [Context] extends [string]
+        ? K extends
+            | `${string}${_ContextSeparator}${Context}`
+            | `${string}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
+          ? never // context keys handled by mapped type 3
+          : K extends `${string}${_PluralSeparator}${PluralSuffix}`
+            ? never // plural keys handled by mapped type 2
+            : K extends string
+              ? _HasContextVariant<T, K, Context> extends true
+                ? never // context variant exists, drop base key (type 3 handles it)
+                : _IsContextualKey<T, K> extends true
+                  ? never // key has context variants but not for this context
+                  : K // no context variants at all, keep base key
+              : K
+        : K extends `${string}${_PluralSeparator}${PluralSuffix}`
           ? never
-          : [Context] extends [string]
-            ? K extends
-                | `${string}${_ContextSeparator}${Context}`
-                | `${string}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
-              ? never // context keys handled by mapped type 3
-              : K extends
-                    | `${infer Prefix}${_PluralSeparator}${PluralSuffix}`
-                    | `${infer Prefix}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`
-                ? Prefix
-                : never
-            : K extends
-                  | `${infer Prefix}${_PluralSeparator}${PluralSuffix}`
-                  | `${infer Prefix}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`
-              ? Prefix
-              : never]: T[K] extends object
-          ? FilterKeys<T[K], Context>
-          : PluralValue<T[K] & string>;
-      } & {
-        // Mapped type 3: context key collapsing
-        [K in keyof T as T[K] extends object
-          ? never
-          : [Context] extends [string]
-            ? K extends
-                | `${infer Prefix}${_ContextSeparator}${Context}`
-                | `${infer Prefix}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
-              ? Prefix
-              : never
-            : never]: T[K] extends object ? FilterKeys<T[K], Context> : T[K];
-      }
-    >;
+          : K]: T[K] extends object ? FilterKeys<T[K], Context> : T[K];
+  } & {
+    // Mapped type 2: plural collapsing (active regardless of context)
+    [K in keyof T as T[K] extends object
+      ? never
+      : [Context] extends [string]
+        ? K extends
+            | `${string}${_ContextSeparator}${Context}`
+            | `${string}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
+          ? never // context keys handled by mapped type 3
+          : K extends
+                | `${infer Prefix}${_PluralSeparator}${PluralSuffix}`
+                | `${infer Prefix}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`
+            ? Prefix
+            : never
+        : K extends
+              | `${infer Prefix}${_PluralSeparator}${PluralSuffix}`
+              | `${infer Prefix}${_PluralSeparator}ordinal${_PluralSeparator}${PluralSuffix}`
+          ? Prefix
+          : never]: T[K] extends object ? FilterKeys<T[K], Context> : PluralValue<T[K] & string>;
+  } & {
+    // Mapped type 3: context key collapsing (skip JSON-union phantoms typed as `undefined`)
+    [K in keyof T as T[K] extends object
+      ? never
+      : [T[K]] extends [undefined]
+        ? never
+        : [Context] extends [string]
+          ? K extends
+              | `${infer Prefix}${_ContextSeparator}${Context}`
+              | `${infer Prefix}${_ContextSeparator}${Context}${_PluralSeparator}${PluralSuffix}`
+            ? Prefix
+            : never
+          : never]: T[K] extends object ? FilterKeys<T[K], Context> : T[K];
+  }
+>;


### PR DESCRIPTION
## Summary

Fixes the remaining TypeScript selector regression from [#2398](https://github.com/i18next/i18next/issues/2398): `t(selector, { returnObjects: true, context })` on heterogeneous JSON arrays was inferring a union of partial element types (or `unknown`) instead of preserving full object shapes such as `{ transKey1: string; transKey2: string }[]`.

Problem 2 from the issue (valid context keys erroring) was already addressed on master; this PR targets the leftover Problem 1 case and the context + plurals array regression test.

## Changes

- **`FilterKeys`**: distribute over object unions so each JSON array element is filtered independently (avoids `keyof (A | B)` only seeing common keys).
- **`_DefinedContextKeys` / `_HasContextVariant` / `_IsContextualKey`**: ignore phantom optional `undefined` context keys that TypeScript adds when merging heterogeneous array element types (e.g. `transKey1_withContext?: undefined` on elements that do not define that key).
- **`TFunctionSelector`**: add a more specific overload for `context` + `returnObjects: true` using `const Context` + `const Fn` + `ReturnType<Fn>`, matching the non-context selector pattern so `Target` is not collapsed via `ConstrainTarget` / `ApplyTarget` → `unknown`.
- **Tests**: promote `test/typescript/selector-issue-2398/` from `.todo` to real `expectTypeOf` assertions (including context + plurals on array elements).

## Test plan

- [x] Local commit includes regression tests in `test/typescript/selector-issue-2398/t.test.ts`
- [ ] `npx vitest --config vitest.workspace.typescript.mts run test/typescript/selector-issue-2398`
- [ ] `npx vitest --config vitest.workspace.typescript.mts run` (full TypeScript workspace)
- [ ] Spot-check existing selector context cases in `test/typescript/selector/` still pass

Fixes #2398