### PR TITLE
fix: parse $t() nesting options block that spans multiple lines

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -298,7 +298,7 @@ class Interpolator {
        *
        * Since v25.3.0 also this is possible: https://github.com/i18next/i18next/pull/2325
        */
-      const keyEndIndex = /{.*}/.test(match[1])
+      const keyEndIndex = /{.*}/s.test(match[1])
         ? match[1].lastIndexOf('}') + 1
         : match[1].indexOf(this.formatSeparator);
       if (keyEndIndex !== -1) {

--- a/test/runtime/i18next.interpolation.nesting.test.js
+++ b/test/runtime/i18next.interpolation.nesting.test.js
@@ -34,6 +34,7 @@ describe('i18next.interpolation.nesting', () => {
             test_baz: 'baz',
             foo: '$t(bar, {"firstName": "{{firstName}}", "lastName": "{{lastName}}" })',
             fooSingle: `$t(bar, {'firstName': '{{firstName}}', 'lastName': '{{lastName}}' })`,
+            fooMultiline: '$t(bar, {\n  "firstName": "Marc",\n  "lastName": "Weber"\n})',
             bar: '{{firstName}} {{lastName}}',
 
             item_one: 'item',
@@ -125,6 +126,10 @@ describe('i18next.interpolation.nesting', () => {
           { firstName: `Cool`, lastName: `Dood`, interpolation: { escapeValue: false } },
         ],
         expected: `Cool Dood`,
+      },
+      {
+        args: ['fooMultiline'],
+        expected: `Marc Weber`,
       },
       {
         args: [


### PR DESCRIPTION
`nest()` decides where the nested key ends and the trailing formatters begin by checking `match[1]` for an options object with `/{.*}/`. That regex dot does not cross line breaks, so a `$t(key, { ... })` options block containing a newline is treated as if it had no options. The block is then mis-split as formatters and the key is truncated, so the nested lookup runs without its options and the variables inside it never resolve.

The nesting regex already allows newlines inside `$t(...)`, so single-line and multiline options should behave the same. This adds the dotAll flag. The new test covers a multiline options block; existing single-line cases stay green.
