### PR TITLE
fix: stop mutating the passed replace object when returning details

### DIFF
--- a/src/Translator.js
+++ b/src/Translator.js
@@ -607,7 +607,7 @@ class Translator extends EventEmitter {
     const useOptionsReplaceForData = options.replace && !isString(options.replace);
     let data = useOptionsReplaceForData ? options.replace : options;
     if (useOptionsReplaceForData && typeof options.count !== 'undefined') {
-      data.count = options.count;
+      data = { ...data, count: options.count };
     }
 
     if (this.options.interpolation.defaultVariables) {

--- a/test/runtime/translator/translator.translate.test.js
+++ b/test/runtime/translator/translator.translate.test.js
@@ -255,6 +255,12 @@ describe('Translator', () => {
           expect(t.translate.apply(t, test.args)).toEqual(test.expected);
         });
       });
+
+      it('does not mutate the passed replace object when count is set', () => {
+        const replace = { testParam: 'test-param' };
+        t.translate('translation:test', { returnDetails: true, replace, count: 1 });
+        expect(replace).toEqual({ testParam: 'test-param' });
+      });
     });
   });
 });


### PR DESCRIPTION
`getUsedParamsDetails` builds the returned `usedParams` from `options.replace` when a `replace` map is used, and adds `count` so consumers see it. It did so by writing `count` straight onto `options.replace`, mutating the caller's object. A caller that reuses one `replace` object across `t()` calls then carries a stale `count` into later interpolations.

This builds the params from a copy so the returned details still include `count` without touching the input. Adds a test asserting the passed `replace` object is not mutated.
