### PR TITLE
fix: skip interpolation of placeholders inside escaped values

### DIFF
--- a/src/Interpolator.js
+++ b/src/Interpolator.js
@@ -189,12 +189,12 @@ class Interpolator {
       {
         // unescape if has unescapePrefix/Suffix
         regex: this.regexpUnescape,
-        safeValue: (val) => regexSafe(val),
+        safeValue: (val) => val,
       },
       {
         // regular escape on demand
         regex: this.regexp,
-        safeValue: (val) => (this.escapeValue ? regexSafe(this.escape(val)) : regexSafe(val)),
+        safeValue: (val) => (this.escapeValue ? this.escape(val) : val),
       },
     ];
     todos.forEach((todo) => {
@@ -219,9 +219,9 @@ class Interpolator {
           value = makeString(value);
         }
         const safeValue = todo.safeValue(value);
-        str = str.replace(match[0], safeValue);
+        str = str.replace(match[0], regexSafe(safeValue));
         if (skipOnVariables) {
-          todo.regex.lastIndex += value.length;
+          todo.regex.lastIndex += safeValue.length;
           todo.regex.lastIndex -= match[0].length;
         } else {
           todo.regex.lastIndex = 0;

--- a/test/runtime/i18next.interpolation.skipOnVariables.test.js
+++ b/test/runtime/i18next.interpolation.skipOnVariables.test.js
@@ -76,6 +76,10 @@ describe('i18next.interpolation.nesting', () => {
         args: ['cur', { CURRENCY: '$', AMOUNT: 23 }],
         expected: 'Save $23',
       },
+      {
+        args: ['key', { a: '&&&{{b}}', b: 'leaked' }],
+        expected: 'value &amp;&amp;&amp;{{b}}',
+      },
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
With `skipOnVariables` on (the default), after each replacement the loop advances `lastIndex` past the inserted value so a `{{...}}` carried inside that value is left alone. It advanced by the raw value length. When `escapeValue` is on (also the default) and the value contains escapable characters, the written text is longer than the raw value, so `lastIndex` lands inside the inserted text and a following `{{placeholder}}` gets interpolated, leaking another in-scope variable that should have stayed literal.

This advances by the escaped length that is actually written, and applies the regex-safe `$` transform only to the replacement argument so the `$`-doubling does not distort the length. The new test asserts a placeholder carried in a value with leading `&` characters stays literal; existing `$`, whitespace, and nesting cases stay green.
